### PR TITLE
Update X509Certificate2.xml

### DIFF
--- a/xml/System.Security.Cryptography.X509Certificates/X509Certificate2.xml
+++ b/xml/System.Security.Cryptography.X509Certificates/X509Certificate2.xml
@@ -1849,7 +1849,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the serial number of a certificate.</summary>
-        <value>The serial number of the certificate.</value>
+        <value>The serial number of the certificate as a big-endian hexadecimal string.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
Developers need clear information on the resulting format of the data when retrieving a x509 certificates based serial number.

## Summary

Describe your changes here.

Fixes dotnet/docs#Issue_Number (if available)
