### PR TITLE
fixed the default for IsTextSearchEnabled to true

### DIFF
--- a/xml/System.Windows.Controls/ItemsControl.xml
+++ b/xml/System.Windows.Controls/ItemsControl.xml
@@ -1071,7 +1071,7 @@ ListBox that contains multiple types of objects
       <Docs>
         <summary>Gets or sets a value that indicates whether <see cref="T:System.Windows.Controls.TextSearch" /> is enabled on the <see cref="T:System.Windows.Controls.ItemsControl" /> instance.</summary>
         <value>
-          <see langword="true" /> if <see cref="T:System.Windows.Controls.TextSearch" /> is enabled; otherwise, <see langword="false" />. The default is <see langword="false" />.</value>
+          <see langword="true" /> if <see cref="T:System.Windows.Controls.TextSearch" /> is enabled; otherwise, <see langword="true" />. The default is <see langword="false" />.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
## Summary

Fixing the default for IsTextSearchEnabled to be true

Fixes dotnet/docs#Issue_Number 7905
