### PR TITLE
Convert md links to xml in summary sections (4/5) 

### DIFF
--- a/xml/System.Diagnostics.Eventing.Reader/EventLogPropertySelector.xml
+++ b/xml/System.Diagnostics.Eventing.Reader/EventLogPropertySelector.xml
@@ -19,7 +19,7 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>Contains an array of strings that represent XPath queries for elements in the XML representation of an event, which is based on the [Event Schema](http://go.microsoft.com/fwlink/?LinkID=81771). The queries in this object are used to extract values from the event.</summary>
+    <summary>Contains an array of strings that represent XPath queries for elements in the XML representation of an event, which is based on the <see href="https://docs.microsoft.com/windows/desktop/WES/eventschema-schema">Event Schema</see>. The queries in this object are used to extract values from the event.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.Printing/Collation.xml
+++ b/xml/System.Printing/Collation.xml
@@ -110,7 +110,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/DeviceFontSubstitution.xml
+++ b/xml/System.Printing/DeviceFontSubstitution.xml
@@ -108,7 +108,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/Duplexing.xml
+++ b/xml/System.Printing/Duplexing.xml
@@ -127,7 +127,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/InputBin.xml
+++ b/xml/System.Printing/InputBin.xml
@@ -169,7 +169,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/OutputColor.xml
+++ b/xml/System.Printing/OutputColor.xml
@@ -126,7 +126,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/OutputQuality.xml
+++ b/xml/System.Printing/OutputQuality.xml
@@ -175,7 +175,7 @@
       </ReturnValue>
       <MemberValue>6</MemberValue>
       <Docs>
-        <summary>Photographic quality. For more information, see [Notes on OutputQuality.Photographic](#Photographic) in the Remarks section.</summary>
+        <summary>Photographic quality. For more information, see <see href="https://docs.microsoft.com/dotnet/api/system.printing.outputquality?view=netframework-4.7.2#Photographic">Notes on OutputQuality.Photographic</see> in the Remarks section.</summary>
       </Docs>
     </Member>
     <Member MemberName="Text">
@@ -217,7 +217,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/PageMediaType.xml
+++ b/xml/System.Printing/PageMediaType.xml
@@ -673,7 +673,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/PageOrder.xml
+++ b/xml/System.Printing/PageOrder.xml
@@ -106,7 +106,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/PageOrientation.xml
+++ b/xml/System.Printing/PageOrientation.xml
@@ -147,7 +147,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/PageQualitativeResolution.xml
+++ b/xml/System.Printing/PageQualitativeResolution.xml
@@ -151,7 +151,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/PagesPerSheetDirection.xml
+++ b/xml/System.Printing/PagesPerSheetDirection.xml
@@ -232,7 +232,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/PhotoPrintingIntent.xml
+++ b/xml/System.Printing/PhotoPrintingIntent.xml
@@ -137,7 +137,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/PrintQueue.xml
+++ b/xml/System.Printing/PrintQueue.xml
@@ -658,7 +658,7 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the version of the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>Gets the version of the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
         <value>The version of the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397) in use.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  

--- a/xml/System.Printing/Stapling.xml
+++ b/xml/System.Printing/Stapling.xml
@@ -274,7 +274,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Printing/TrueTypeFontMode.xml
+++ b/xml/System.Printing/TrueTypeFontMode.xml
@@ -181,7 +181,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined. in the [Print Schema](http://go.microsoft.com/fwlink/?LinkId=186397).</summary>
+        <summary>The feature (whose options are represented by this enumeration) is set to an option not defined. in the <see href="https://docs.microsoft.com/windows/desktop/printdocs/printschema">Print Schema</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.ServiceModel.Channels/TransportBindingElementImporter.xml
+++ b/xml/System.ServiceModel.Channels/TransportBindingElementImporter.xml
@@ -22,7 +22,7 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>Imports standard transport binding elements from [Web Services Description Language](http://go.microsoft.com/fwlink/?LinkId=96160) (WSDL) documents with attached policy expressions.</summary>
+    <summary>Imports standard transport binding elements from <see href="https://www.w3.org/TR/wsdl/">Web Services Description Language</see> (WSDL) documents with attached policy expressions.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.ServiceModel.Discovery/FindCriteria.xml
+++ b/xml/System.ServiceModel.Discovery/FindCriteria.xml
@@ -335,7 +335,7 @@
         <ReturnType>System.Uri</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Specifies that scopes are matched by using a case-sensitive comparison (http://schemas.xmlsoap.org/ws/2004/10/discovery/strcmp0) as defined by the [WS-Discovery Specification](http://go.microsoft.com/fwlink/?LinkId=122347).</summary>
+        <summary>Specifies that scopes are matched by using a case-sensitive comparison (http://schemas.xmlsoap.org/ws/2004/10/discovery/strcmp0) as defined by the <see href="http://schemas.xmlsoap.org/ws/2004/10/discovery/ws-discovery.pdf">WS-Discovery Specification</see>.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -355,7 +355,7 @@
         <ReturnType>System.Uri</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Specifies that scopes are matched by using the LDAP method (http://schemas.xmlsoap.org/ws/2004/10/discovery/ldap) as defined by the [WS-Discovery Specification](http://go.microsoft.com/fwlink/?LinkId=122347).</summary>
+        <summary>Specifies that scopes are matched by using the LDAP method (http://schemas.xmlsoap.org/ws/2004/10/discovery/ldap) as defined by the <see href="http://schemas.xmlsoap.org/ws/2004/10/discovery/ws-discovery.pdf">WS-Discovery Specification</see>.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -375,7 +375,7 @@
         <ReturnType>System.Uri</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Specifies that scopes are ignored as defined by the [WS-Discovery Specification](http://go.microsoft.com/fwlink/?LinkId=122347).</summary>
+        <summary>Specifies that scopes are ignored as defined by the <see href="http://schemas.xmlsoap.org/ws/2004/10/discovery/ws-discovery.pdf">WS-Discovery Specification</see>.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -395,7 +395,7 @@
         <ReturnType>System.Uri</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Specifies that scopes are matched using the prefix method (http://schemas.xmlsoap.org/ws/2004/10/discovery/rfc2396) as defined by the [WS-Discovery Specification](http://go.microsoft.com/fwlink/?LinkId=122347).</summary>
+        <summary>Specifies that scopes are matched using the prefix method (http://schemas.xmlsoap.org/ws/2004/10/discovery/rfc2396) as defined by the <see href="http://schemas.xmlsoap.org/ws/2004/10/discovery/ws-discovery.pdf">WS-Discovery Specification</see>.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -415,7 +415,7 @@
         <ReturnType>System.Uri</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Specifies that scopes are matched by using the UUID method (http://schemas.xmlsoap.org/ws/2004/10/discovery/uuid) as defined by the [WS-Discovery Specification](http://go.microsoft.com/fwlink/?LinkId=122347).</summary>
+        <summary>Specifies that scopes are matched by using the UUID method (http://schemas.xmlsoap.org/ws/2004/10/discovery/uuid) as defined by the <see href="http://schemas.xmlsoap.org/ws/2004/10/discovery/ws-discovery.pdf">WS-Discovery Specification</see>.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/xml/System.ServiceModel.Dispatcher/XPathMessageContext.xml
+++ b/xml/System.ServiceModel.Dispatcher/XPathMessageContext.xml
@@ -216,8 +216,8 @@
         <param name="prefix">The prefix of the function as it appears in the XPath expression.</param>
         <param name="name">The name of the function.</param>
         <param name="argTypes">An array of argument types for the function being resolved. This allows you to select between methods with the same name (for example, overloaded methods).</param>
-        <summary>Resolves a function reference and returns an [T:System.Xml.Xsl.IXsltContextFunction](ms-help://MS.MSSDK.1033/MS.WinFXSDK.1033/cpref37/html/T_System_Xml_Xsl_IXsltContextFunction.htm) that represents the function.</summary>
-        <returns>An [T:System.Xml.Xsl.IXsltContextFunction](ms-help://MS.MSSDK.1033/MS.WinFXSDK.1033/cpref37/html/T_System_Xml_Xsl_IXsltContextFunction.htm) that represents the function.</returns>
+        <summary>Resolves a function reference and returns an <see cref="T:System.Xml.Xsl.IXsltContextFunction" /> that represents the function.</summary>
+        <returns>An <see cref="T:System.Xml.Xsl.IXsltContextFunction" /> that represents the function.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.ServiceModel/HttpProxyCredentialType.xml
+++ b/xml/System.ServiceModel/HttpProxyCredentialType.xml
@@ -53,7 +53,7 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>Specifies basic authentication. For more information, see [RFC 2617 – HTTP Authentication: Basic and Digest Authentication](http://go.microsoft.com/fwlink/?LinkID=95943).</summary>
+        <summary>Specifies basic authentication. For more information, see <see href="https://www.ietf.org/rfc/rfc2617.txt?number=2617">RFC 2617 – HTTP Authentication: Basic and Digest Authentication</see>.</summary>
       </Docs>
     </Member>
     <Member MemberName="Digest">
@@ -79,7 +79,7 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>Specifies digest authentication. For more information, see [RFC 2617 – HTTP Authentication: Basic and Digest Authentication](http://go.microsoft.com/fwlink/?LinkID=95943).</summary>
+        <summary>Specifies digest authentication. For more information, see <see href="https://www.ietf.org/rfc/rfc2617.txt?number=2617">RFC 2617 – HTTP Authentication: Basic and Digest Authentication</see>.</summary>
       </Docs>
     </Member>
     <Member MemberName="None">

--- a/xml/System.ServiceModel/MsmqEncryptionAlgorithm.xml
+++ b/xml/System.ServiceModel/MsmqEncryptionAlgorithm.xml
@@ -71,7 +71,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>A stream cipher defined by [RSA Security](http://go.microsoft.com/fwlink/?LinkId=95942).</summary>
+        <summary>A stream cipher defined by <see href="https://www.rsa.com/">RSA Security</see>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.ServiceModel/MsmqSecureHashAlgorithm.xml
+++ b/xml/System.ServiceModel/MsmqSecureHashAlgorithm.xml
@@ -47,7 +47,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>The [Message Digest Algorithm 5 (MD5)](http://go.microsoft.com/fwlink/?LinkId=95939).</summary>
+        <summary>The <see href="https://en.wikipedia.org/wiki/MD5">Message Digest Algorithm 5 (MD5)</see>.</summary>
       </Docs>
     </Member>
     <Member MemberName="Sha1">
@@ -69,7 +69,7 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>The [Secure Hash Algorithm (SHA-1)](http://go.microsoft.com/fwlink/?LinkId=95940).</summary>
+        <summary>The <see href="https://en.wikipedia.org/wiki/SHA_hash_functions">Secure Hash Algorithm (SHA-1)</see>.</summary>
       </Docs>
     </Member>
     <Member MemberName="Sha256">
@@ -91,7 +91,7 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>The [SHA-256](http://go.microsoft.com/fwlink/?LinkId=95940) algorithm.</summary>
+        <summary>The <see href="https://en.wikipedia.org/wiki/SHA_hash_functions">SHA-256</see> algorithm.</summary>
       </Docs>
     </Member>
     <Member MemberName="Sha512">
@@ -113,7 +113,7 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary>The [SHA 512](http://go.microsoft.com/fwlink/?LinkId=95940) algorithm.</summary>
+        <summary>The <see href="https://en.wikipedia.org/wiki/SHA_hash_functions">SHA 512</see> algorithm.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Speech.Recognition.SrgsGrammar/SrgsDocument.xml
+++ b/xml/System.Speech.Recognition.SrgsGrammar/SrgsDocument.xml
@@ -20,7 +20,7 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>Defines a design-time object that is used to build strongly-typed runtime grammars that conform to the [Speech Recognition Grammar Specification (SRGS) Version 1.0](http://www.w3.org/TR/speech-grammar/).</summary>
+    <summary>Defines a design-time object that is used to build strongly-typed runtime grammars that conform to the <see href="https://www.w3.org/TR/speech-grammar/">Speech Recognition Grammar Specification (SRGS) Version 1.0</see>.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.Speech.Recognition.SrgsGrammar/SrgsSemanticInterpretationTag.xml
+++ b/xml/System.Speech.Recognition.SrgsGrammar/SrgsSemanticInterpretationTag.xml
@@ -23,7 +23,7 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>Represents a tag that contains [ECMAScript](https://www.ecma-international.org/publications/standards/Ecma-327.htm) that is run when the rule is matched.</summary>
+    <summary>Represents a tag that contains <see href="https://www.ecma-international.org/publications/standards/Ecma-327.htm">ECMAScript</see> that is run when the rule is matched.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[  
   
@@ -250,7 +250,7 @@ version="1.0" xmlns="http://www.w3.org/2001/06/grammar">
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets or sets the [ECMAScript](https://www.ecma-international.org/publications/standards/Ecma-327.htm) for the tag.</summary>
+        <summary>Gets or sets the <see href="https://www.ecma-international.org/publications/standards/Ecma-327.htm">ECMAScript</see> for the tag.</summary>
         <value>A string that contains the semantic interpretation script for the tag.</value>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">An attempt is made to set **Script** to <see langword="null" />.</exception>

--- a/xml/System.Speech.Recognition.SrgsGrammar/SrgsText.xml
+++ b/xml/System.Speech.Recognition.SrgsGrammar/SrgsText.xml
@@ -23,7 +23,7 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>Represents the textual content of grammar elements defined by the World Wide Web Consortium (W3C) [Speech Recognition Grammar Specification (SRGS) Version 1.0](http://www.w3.org/TR/speech-grammar/).</summary>
+    <summary>Represents the textual content of grammar elements defined by the World Wide Web Consortium (W3C) <see href="https://www.w3.org/TR/speech-grammar/">Speech Recognition Grammar Specification (SRGS) Version 1.0</see>.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
More towards dotnet/docs#1931. Markdown links display incorrectly on the API index, they should be xml instead.

I've updated the script I was using for this, so it now also replaces any links which forward (includes various MSDN/fwlinks), and converts to https where possible.