### PR TITLE
Fix confusing sentence "without assuming architecture dependent alignment of the addresses" (#5342)

### DIFF
--- a/xml/System.Runtime.CompilerServices/Unsafe.xml
+++ b/xml/System.Runtime.CompilerServices/Unsafe.xml
@@ -594,7 +594,7 @@
         <param name="destination">The destination address to copy to.</param>
         <param name="source">The source address to copy from.</param>
         <param name="byteCount">The number of bytes to copy.</param>
-        <summary>Copies bytes from the source address to the destination address without assuming architecture dependent alignment of the addresses.</summary>
+        <summary>Copies bytes from the source address to the destination address. Unlike <xref:System.Runtime.CompilerServices.Unsafe.CopyBlock>, this will succeed even while we use the platform which requires alignment and any of the given location is unaligned.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -626,7 +626,7 @@
         <param name="destination">The destination address to copy to.</param>
         <param name="source">The source address to copy from.</param>
         <param name="byteCount">The number of bytes to copy.</param>
-        <summary>Copies bytes from the source address to the destination address without assuming architecture dependent alignment of the addresses.</summary>
+        <summary>Copies bytes from the source address to the destination address. Unlike <xref:System.Runtime.CompilerServices.Unsafe.CopyBlock>, this will succeed even while we use the platform which requires alignment and any of the given location is unaligned.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -726,7 +726,7 @@
         <param name="startAddress">The address of the start of the memory block to initialize.</param>
         <param name="value">The value to initialize the block to.</param>
         <param name="byteCount">The number of bytes to initialize.</param>
-        <summary>Initializes a block of memory at the given location with a given initial value without assuming architecture dependent alignment of the address.</summary>
+        <summary>Initializes a block of memory at the given location with a given initial value. Unlike <xref:System.Runtime.CompilerServices.Unsafe.InitBlock>, this will succeed even while we use the platform which requires alignment and the given location is unaligned.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -758,7 +758,7 @@
         <param name="startAddress">The address of the start of the memory block to initialize.</param>
         <param name="value">The value to initialize the block to.</param>
         <param name="byteCount">The number of bytes to initialize.</param>
-        <summary>Initializes a block of memory at the given location with a given initial value without assuming architecture dependent alignment of the address.</summary>
+        <summary>Initializes a block of memory at the given location with a given initial value. Unlike <xref:System.Runtime.CompilerServices.Unsafe.InitBlock>, this will succeed even while we use the platform which requires alignment and the given location is unaligned.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -955,7 +955,7 @@
       <Docs>
         <typeparam name="T">The type to read.</typeparam>
         <param name="source">The location to read from.</param>
-        <summary>Reads a value of type <typeparamref name="T" /> from the given location without assuming architecture dependent alignment of the addresses.</summary>
+        <summary>Reads a value of type <typeparamref name="T" /> from the given location. Unlike <xref:System.Runtime.CompilerServices.Unsafe.Read>, this will succeed even while we use the platform which requires alignment and the given location is unaligned for values of type <typeparamref name="T" />.</summary>
         <returns>An object of type <typeparamref name="T" /> read from the given location.</returns>
         <remarks>To be added.</remarks>
       </Docs>
@@ -989,7 +989,7 @@
       <Docs>
         <typeparam name="T">The type to read.</typeparam>
         <param name="source">The location to read from.</param>
-        <summary>Reads a value of type <typeparamref name="T" /> from the given location without assuming architecture dependent alignment of the addresses.</summary>
+        <summary>Reads a value of type <typeparamref name="T" /> from the given location. Unlike <xref:System.Runtime.CompilerServices.Unsafe.Read>, this will succeed even while we use the platform which requires alignment and the given location is unaligned for values of type <typeparamref name="T" />.</summary>
         <returns>An object of type <typeparamref name="T" /> read from the given location.</returns>
         <remarks>To be added.</remarks>
       </Docs>
@@ -1335,7 +1335,7 @@ For more information, see sections III.1.8.1.2.2 ("Controlled-muttability manage
         <typeparam name="T">The type of value to write.</typeparam>
         <param name="destination">The location to write to.</param>
         <param name="value">The value to write.</param>
-        <summary>Writes a value of type <typeparamref name="T" /> to the given location without assuming architecture dependent alignment of the addresses.</summary>
+        <summary>Writes a value of type <typeparamref name="T" /> to the given location. Unlike <xref:System.Runtime.CompilerServices.Unsafe.Write>, this will succeed even while we use the platform which requires alignment and the given location is unaligned for values of type <typeparamref name="T" />.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -1370,7 +1370,7 @@ For more information, see sections III.1.8.1.2.2 ("Controlled-muttability manage
         <typeparam name="T">The type of value to write.</typeparam>
         <param name="destination">The location to write to.</param>
         <param name="value">The value to write.</param>
-        <summary>Writes a value of type <typeparamref name="T" /> to the given location without assuming architecture dependent alignment of the addresses.</summary>
+        <summary>Writes a value of type <typeparamref name="T" /> to the given location. Unlike <xref:System.Runtime.CompilerServices.Unsafe.Write>, this will succeed even while we use the platform which requires alignment and the given location is unaligned for values of type <typeparamref name="T" />.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/xml/System.Runtime.CompilerServices/Unsafe.xml
+++ b/xml/System.Runtime.CompilerServices/Unsafe.xml
@@ -594,7 +594,7 @@
         <param name="destination">The destination address to copy to.</param>
         <param name="source">The source address to copy from.</param>
         <param name="byteCount">The number of bytes to copy.</param>
-        <summary>Copies bytes from the source address to the destination address. Unlike <xref:System.Runtime.CompilerServices.Unsafe.CopyBlock>, this will succeed even while we use the platform which requires alignment and any of the given location is unaligned.</summary>
+        <summary>Copies bytes from the source address to the destination address. Unlike <see cref="Overload:System.Runtime.CompilerServices.Unsafe.CopyBlock" />, this write will succeed on platforms that require alignment even if the source or destination address is unaligned.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
Fixes #5342