### PR TITLE
Document libgdiplus limitation on Linux

### DIFF
--- a/xml/System.Drawing.Imaging/PixelFormat.xml
+++ b/xml/System.Drawing.Imaging/PixelFormat.xml
@@ -32,6 +32,8 @@
  The pixel format defines the number of bits of memory associated with one pixel of data. The format also defines the order of the color components within a single pixel of data.  
   
  PixelFormat48bppRGB, PixelFormat64bppARGB, and PixelFormat64bppPARGB use 16 bits per color component (channel). GDI+ version 1.0 and 1.1 can read 16-bits-per-channel images, but such images are converted to an 8-bits-per-channel format for processing, displaying, and saving. Each 16-bit color channel can hold a value in the range 0 through 2^13.  
+
+ Some PixelFormat are not portable across implementation. In particular PixelFormat16bppGrayScale, PixelFormat16bppARGB1555, PixelFormat48bppRGB, PixelFormat64bppARGB, and PixelFormat64bppPARGB may throw a NotImplemented exception.
   
  Some of the pixel formats contain premultiplied color values. Premultiplied means that the color values have already been multiplied by an alpha value.  
   


### PR DESCRIPTION
Reference code is around line:

* https://github.com/mono/libgdiplus/blob/6.0.4/src/bitmap.c#L848

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

