### PR TITLE
Correct typo, CTL -> CTRL

### DIFF
--- a/samples/snippets/cpp/VS_Snippets_Winforms/System.Windows.Forms.Control.DoDragDrop/CPP/form1.cpp
+++ b/samples/snippets/cpp/VS_Snippets_Winforms/System.Windows.Forms.Control.DoDragDrop/CPP/form1.cpp
@@ -195,7 +195,7 @@ namespace Snip_DragNDrop
          // Set the effect based upon the KeyState.
          if ( (e->KeyState & (8 + 32)) == (8 + 32) && ((e->AllowedEffect & DragDropEffects::Link) == DragDropEffects::Link) )
          {
-            // KeyState 8 + 32 = CTL + ALT
+            // KeyState 8 + 32 = CTRL + ALT
             // Link drag-and-drop effect.
             e->Effect = DragDropEffects::Link;
          }
@@ -214,7 +214,7 @@ namespace Snip_DragNDrop
          else
          if ( (e->KeyState & 8) == 8 && ((e->AllowedEffect & DragDropEffects::Copy) == DragDropEffects::Copy) )
          {
-            // CTL KeyState for copy.
+            // CTRL KeyState for copy.
             e->Effect = DragDropEffects::Copy;
          }
          else

--- a/samples/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.Control.DoDragDrop/CS/form1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.Control.DoDragDrop/CS/form1.cs
@@ -199,7 +199,7 @@ namespace Snip_DragNDrop
             if ((e.KeyState & (8 + 32)) == (8 + 32) &&
                 (e.AllowedEffect & DragDropEffects.Link) == DragDropEffects.Link)
             {
-                // KeyState 8 + 32 = CTL + ALT
+                // KeyState 8 + 32 = CTRL + ALT
 
                 // Link drag-and-drop effect.
                 e.Effect = DragDropEffects.Link;
@@ -219,7 +219,7 @@ namespace Snip_DragNDrop
             else if ((e.KeyState & 8) == 8 &&
                 (e.AllowedEffect & DragDropEffects.Copy) == DragDropEffects.Copy)
             {
-                // CTL KeyState for copy.
+                // CTRL KeyState for copy.
                 e.Effect = DragDropEffects.Copy;
             }
             else if ((e.AllowedEffect & DragDropEffects.Move) == DragDropEffects.Move)

--- a/samples/snippets/visualbasic/VS_Snippets_Winforms/System.Windows.Forms.Control.DoDragDrop/VB/form1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Winforms/System.Windows.Forms.Control.DoDragDrop/VB/form1.vb
@@ -181,7 +181,7 @@ Public NotInheritable Class Form1
         ' Set the effect based upon the KeyState.
         If ((e.KeyState And (8 + 32)) = (8 + 32) And
             (e.AllowedEffect And DragDropEffects.Link) = DragDropEffects.Link) Then
-            ' KeyState 8 + 32 = CTL + ALT
+            ' KeyState 8 + 32 = CTRL + ALT
 
             ' Link drag-and-drop effect.
             e.Effect = DragDropEffects.Link
@@ -201,7 +201,7 @@ Public NotInheritable Class Form1
         ElseIf ((e.KeyState And 8) = 8 And
             (e.AllowedEffect And DragDropEffects.Copy) = DragDropEffects.Copy) Then
 
-            ' CTL KeyState for copy.
+            ' CTRL KeyState for copy.
             e.Effect = DragDropEffects.Copy
 
         ElseIf ((e.AllowedEffect And DragDropEffects.Move) = DragDropEffects.Move) Then


### PR DESCRIPTION
## Summary

Corrects references to the CTRL key as CTL in System.Windows.Forms.Control.DoDragDrop
I was not able to find any information that would suggest this is correct.


