### PR TITLE
Clarify UseSocketsHttpHandler availability in versions

### DIFF
--- a/xml/System.Net.Http/HttpClientHandler.xml
+++ b/xml/System.Net.Http/HttpClientHandler.xml
@@ -42,7 +42,7 @@ The `HttpClientHandler` class and classes derived from it enable developers to c
 
 Starting in .NET Core 2.1, the implementation of the `HttpClientHandler` class was changed to be based on the cross-platform HTTP protocol stack used by the <xref:System.Net.Http.SocketsHttpHandler?displayProperty=nameWithType> class. Prior to .NET Core 2.1, the `HttpClientHandler` class used older HTTP protocol stacks (<xref:System.Net.Http.WinHttpHandler> on Windows and `CurlHandler`, an internal class implemented on top of Linux's native `libcurl` component, on Linux).
 
-You can configure your app to use the older HTTP protocol stacks on .NET Core 2.1-3.1 in one of the following three ways:
+On .NET Core 2.1 - 3.1 only, you can configure your app to use the older HTTP protocol stacks in one of the following three ways:
 
 - Call the <xref:System.AppContext.SetSwitch%2A?displayProperty=nameWithType> method:
 


### PR DESCRIPTION
Clarify that UseSocketsHttpHandler switch is available only on 2.1-3.1 and not 5.0+

Makes the doc consistent with SocketsHttpHandler remarks - https://docs.microsoft.com/en-us/dotnet/api/system.net.http.socketshttphandler#remarks