### PR TITLE
Networking settings - clarify .NET version availability

### DIFF
--- a/xml/System/AppContext.xml
+++ b/xml/System/AppContext.xml
@@ -363,8 +363,8 @@ In .NET 5.0 and later versions, for bundled assemblies, the value returned is th
 
 |Switch|Values|Description|
 |--|--|--|
-|`System.Net.Http.SocketsHttpHandler.Http2Support`|`true` or `false`|Indicates whether support for the HTTP/2 protocol is enabled (`true`) or disabled (`false`). The default is disabled. The switch must be set before the first use of <xref:System.Net.Http.HttpClient>. Available starting with .NET Core 3.0 Preview 4.|
-|`System.Net.Http.UseSocketsHttpHandler` |`true` or `false`|Determines whether high-level networking APIs such as <xref:System.Net.Http.HttpClient> use <xref:System.Net.Http.SocketsHttpHandler?displayProperty=nameWithType> (`true`) or <xref:System.Net.Http.HttpClientHandler?displayProperty=nameWithType> (`false`).|
+|`System.Net.Http.SocketsHttpHandler.Http2Support`|`true` or `false`|Indicates whether support for the HTTP/2 protocol is enabled (`true`) or disabled (`false`). The default is disabled. The switch must be set before the first use of <xref:System.Net.Http.HttpClient>. Available starting with .NET Core 3.0.|
+|`System.Net.Http.UseSocketsHttpHandler`|`true` or `false`|Determines whether high-level networking APIs such as <xref:System.Net.Http.HttpClient> use <xref:System.Net.Http.SocketsHttpHandler?displayProperty=nameWithType> (`true`) or <xref:System.Net.Http.HttpClientHandler?displayProperty=nameWithType> (`false`) on .NET Core 2.1-3.1. The switch is no longer available starting with .NET 5.|
 
 ## Examples
  The following line of code sets a switch named `Switch.AmazingLib.ThrowOnException` to `true`, which enables a legacy behavior. The library can then check whether a library consumer has set the value of the switch by calling the <xref:System.AppContext.TryGetSwitch%2A> method.


### PR DESCRIPTION
Clarify availability of switch `UseSocketsHttpHandler` on .NET Core 2.1-3.1 only.