### PR TITLE
Fix default value for MaxTransferWindowSize

### DIFF
--- a/xml/System.ServiceModel.Channels/ReliableSessionBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/ReliableSessionBindingElement.xml
@@ -667,7 +667,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the largest number of messages that can exist in either the send buffer or the receive buffer.</summary>
-        <value>The largest number of messages that can be buffered. The minimum value is 1; the maximum value is 4096; and the default value is 32.</value>
+        <value>The largest number of messages that can be buffered. The minimum value is 1; the maximum value is 4096; and the default value is 8.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
## Summary

Default value is specified incorrectly for ReliableSessionBindingElement.MaxTransferWindowSize. It should be 8 and not 32.

Fixes #7324

