### PR TITLE
Expose platform guard attributes

### DIFF
--- a/xml/_filter.xml
+++ b/xml/_filter.xml
@@ -66,8 +66,10 @@
     <namespaceFilter name="System.Runtime.Versioning">
       <typeFilter name="RequiresPreviewFeaturesAttribute" expose="true" />
       <typeFilter name="SupportedOSPlatformAttribute" expose="true" />
+      <typeFilter name="SupportedOSPlatformGuardAttribute" expose="true" />
       <typeFilter name="TargetPlatformAttribute" expose="true" />
       <typeFilter name="UnsupportedOSPlatformAttribute" expose="true" />
+      <typeFilter name="UnsupportedOSPlatformGuardAttribute" expose="true" />
       <typeFilter name="*" expose="false" />
     </namespaceFilter>
     <!-- Attributes in System.Security might hint as security implementation details. Don't show them. -->


### PR DESCRIPTION
This change allows the attributes to be shown in the API signature on docs.microsoft.com.