### PR TITLE
Complete unfinished sentences in FreezableCollection

### DIFF
--- a/xml/System.Windows/FreezableCollection`1.xml
+++ b/xml/System.Windows/FreezableCollection`1.xml
@@ -79,7 +79,7 @@
   
     -   As long as you do not hide the parameterless constructor, the derived collection can also support an object element syntax (where the object element is explicit, as opposed to the implicit usage shown above). It does not need to be the root element. Or, you can also use the derived collection as a root element, without needing to specify , although using a collection as a root element is uncommon.  
   
--   Any child elements of the collection in either of the above scenarios must be of the type of either the implemented constraint, or as specified by .  
+-   Any child elements of the collection in either of the above scenarios must be of the type of either the implemented constraint, or as specified by the [x:TypeArguments Directive](/dotnet/framework/xaml-services/x-typearguments-directive).  
   
  ]]></format>
     </remarks>


### PR DESCRIPTION
## Complete unfinished sentences in FreezableCollection

Complete sentences explaining:
 - why one can freely use in XAML a type derived from FreezableCollection that fixes its type argument,
 - the expected types of element in FreezableCollection.

No existing issue found for this.
