### PR TITLE
Document usage of two-letter and three-letter codes

### DIFF
--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -99,12 +99,12 @@
 
 <a name="CultureNames"></a>
 ## Culture names and identifiers
- The <xref:System.Globalization.CultureInfo> class specifies a unique name for each culture, based on RFC 4646. The name is a combination of an ISO 639 two-letter lowercase culture code associated with a language and an ISO 3166 two-letter uppercase subculture code associated with a country or region. In addition, for apps that target .NET Framework 4 or later and are running under Windows 10 or later, culture names that correspond to valid BCP-47 language tags are supported.
+ The <xref:System.Globalization.CultureInfo> class specifies a unique name for each culture, based on RFC 4646. The name is a combination of an ISO 639 two-letter or three-letter lowercase culture code associated with a language and an ISO 3166 two-letter uppercase subculture code associated with a country or region. In addition, for apps that target .NET Framework 4 or later and are running under Windows 10 or later, culture names that correspond to valid BCP-47 language tags are supported.
 
 > [!NOTE]
 > When a culture name is passed to a class constructor or a method such as <xref:System.Globalization.CultureInfo.CreateSpecificCulture%2A> or <xref:System.Globalization.CultureInfo>, its case is not significant.
 
- The format for the culture name based on RFC 4646 is *`languagecode2`*-*`country/regioncode2`*, where *`languagecode2`* is the two-letter language code and *`country/regioncode2`* is the two-letter subculture code. Examples include `ja-JP` for Japanese (Japan) and `en-US` for English (United States). In cases where a two-letter language code is not available, a three-letter code derived from ISO 639-2 is used.
+ The format for the culture name based on RFC 4646 is *`languagecode2`*-*`country/regioncode2`*, where *`languagecode2`* is the two-letter language code and *`country/regioncode2`* is the two-letter subculture code. Examples include `ja-JP` for Japanese (Japan) and `en-US` for English (United States). In cases where a two-letter language code is not available, a three-letter code as defined in ISO 639-3 is used.
 
  Some culture names also specify an ISO 15924 script. For example, Cyrl specifies the Cyrillic script and Latn specifies the Latin script. A culture name that includes a script uses the pattern *`languagecode2`*-*`scripttag`*-*`country/regioncode2`*. An example of this type of culture name is `uz-Cyrl-UZ` for Uzbek (Cyrillic, Uzbekistan). On Windows operating systems before Windows Vista, a culture name that includes a script uses the pattern *`languagecode2`*-*`country/regioncode2`*-*`scripttag`*, for example, `uz-UZ-Cyrl` for Uzbek (Cyrillic, Uzbekistan).
 
@@ -3138,7 +3138,7 @@ Setting `predefinedOnly` to `true` will ensure a culture is created only if the 
       </ReturnValue>
       <Docs>
         <summary>Gets the culture name in the format *languagecode2*-*country/regioncode2*.</summary>
-        <value>The culture name in the format *languagecode2*-*country/regioncode2*, if the current <see cref="T:System.Globalization.CultureInfo" /> is culture-dependent; or an empty string, if it's an invariant culture. *languagecode2* is a lowercase two-letter code derived from ISO 639-1. *country/regioncode2* is derived from ISO 3166 and usually consists of two uppercase letters, or a BCP-47 language tag.</value>
+        <value>The culture name in the format *languagecode2*-*country/regioncode2*, if the current <see cref="T:System.Globalization.CultureInfo" /> is culture-dependent; or an empty string, if it's an invariant culture. *languagecode2* is a lowercase two-letter code as defined in ISO 639-1, or, if no two-letter code is available, a three-letter code as defined in ISO 639-3. *country/regioncode2* contains a value defined in ISO 3166 and usually consists of two uppercase letters, or a BCP-47 language tag.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -3831,8 +3831,8 @@ For a list of predefined culture names and identifiers that the <xref:System.Glo
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the ISO 639-1 two-letter code for the language of the current <see cref="T:System.Globalization.CultureInfo" />.</summary>
-        <value>The ISO 639-1 two-letter code for the language of the current <see cref="T:System.Globalization.CultureInfo" />.</value>
+        <summary>Gets the ISO 639-1 two-letter or ISO 639-3 three-letter code for the language of the current <see cref="T:System.Globalization.CultureInfo" />.</summary>
+      <value>The ISO 639-1 two-letter code for the language of the current <see cref="T:System.Globalization.CultureInfo" />. If no two-letter code is available, the three-letter code from ISO 639-3 is used.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 


### PR DESCRIPTION
## Summary

Document usage of two-letter and three-letter codes

Fixes #7465
