### PR TITLE
Correct stride units

### DIFF
--- a/xml/System.Windows.Media.Imaging/WriteableBitmap.xml
+++ b/xml/System.Windows.Media.Imaging/WriteableBitmap.xml
@@ -755,7 +755,7 @@
       <Docs>
         <param name="sourceRect">The rectangle of the <see cref="T:System.Windows.Media.Imaging.WriteableBitmap" /> to update.</param>
         <param name="pixels">The pixel array used to update the bitmap.</param>
-        <param name="stride">The stride of the update region in <paramref name="pixels" />.</param>
+        <param name="stride">The stride of the input buffer, in bytes.</param>
         <param name="offset">The input buffer offset.</param>
         <summary>Updates the pixels in the specified region of the bitmap.</summary>
         <remarks>
@@ -824,7 +824,7 @@
         <param name="sourceRect">The rectangle of the <see cref="T:System.Windows.Media.Imaging.WriteableBitmap" /> to update.</param>
         <param name="buffer">The input buffer used to update the bitmap.</param>
         <param name="bufferSize">The size of the input buffer.</param>
-        <param name="stride">The stride of the update region in <paramref name="buffer" />.</param>
+        <param name="stride">The stride of the input buffer, in bytes.</param>
         <summary>Updates the pixels in the specified region of the bitmap.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  


### PR DESCRIPTION
## Summary
The "stride" is expressed in bytes, not in pixels. The current documentation was only correct for https://learn.microsoft.com/en-us/dotnet/api/system.windows.media.imaging.writeablebitmap.writepixels?view=windowsdesktop-7.0#system-windows-media-imaging-writeablebitmap-writepixels(system-windows-int32rect-system-array-system-int32-system-int32-system-int32)