### PR TITLE
Fix SystemParameters.MenuDropAlignment's description

### DIFF
--- a/xml/System.Windows/SystemParameters.xml
+++ b/xml/System.Windows/SystemParameters.xml
@@ -5087,7 +5087,7 @@
       <Docs>
         <summary>Gets a value indicating whether pop-up menus are left-aligned or right-aligned, relative to the corresponding menu item.</summary>
         <value>
-          <see langword="true" /> if left-aligned; otherwise, <see langword="false" />.</value>
+          <see langword="true" /> if right-aligned; otherwise, <see langword="false" />.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
## Summary
The current description indicates that when the return value is true, it means the menus are left-aligned. However, it's the opposite for SPI_GETMENUDROPALIGNMENT for the Win32 API [SystemParametersInfoA](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-systemparametersinfoa), and the [source code](https://source.dot.net/#PresentationFramework/System/Windows/SystemParameters.cs,2e88725c97fc3540) doesn't do any negation.

Fixes #7920

