### PR TITLE
Fix typo on documentation page.

### DIFF
--- a/xml/System.Numerics/Vector2.xml
+++ b/xml/System.Numerics/Vector2.xml
@@ -982,7 +982,7 @@
       <Docs>
         <param name="index">The index of the element to get or set.</param>
         <summary>Gets or sets the element at the specified index.</summary>
-        <value>The the element at <paramref name="index" />.</value>
+        <value>The element at <paramref name="index" />.</value>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="index" /> was less than zero or greater than the number of elements.</exception>


### PR DESCRIPTION
## Summary

Remove duplicate "the" on the (.NET 7.0) Vector2.Index[Int32] page.
