### PR TITLE
Specify that Assembly.Load[File/From] throwing on remote only applies to .NET Framework

### DIFF
--- a/xml/System.Reflection/Assembly.xml
+++ b/xml/System.Reflection/Assembly.xml
@@ -4730,7 +4730,7 @@ See [`<loadFromRemoteSources>`](/dotnet/framework/configure-apps/file-schema/run
 
 ## Remarks
 
-See [`<loadFromRemoteSources>`](/dotnet/framework/configure-apps/file-schema/runtime/loadfromremotesources-element) for loading assemblies from remote locations.
+**.NET Framework only:** See [`<loadFromRemoteSources>`](/dotnet/framework/configure-apps/file-schema/runtime/loadfromremotesources-element) for loading assemblies from remote locations.
 
        ]]></format>
         </remarks>


### PR DESCRIPTION
## Summary

The `Assembly.Load[File/From]` docs indicate that they throw `FileLoadException` on .NET Framework 4 and later for remote assemblies/paths. This is confusing as it can be interpreted as applying to .NET Core/5+, which does not do this.

- Replace comments about remote assemblies with link to [<loadFromRemoteSources>](https://learn.microsoft.com/dotnet/framework/configure-apps/file-schema/runtime/loadfromremotesources-element) which has more accurate information
- For the overloads that exist in .NET Core/5+, to specify that behaviour is .NET Framework only

cc @AaronRobinsonMSFT @GrabYourPitchforks 