### PR TITLE
Mark some comments about `Assembly.GetEntryAssembly` as .NET Framework only

### DIFF
--- a/xml/System.Reflection/Assembly.xml
+++ b/xml/System.Reflection/Assembly.xml
@@ -1596,7 +1596,7 @@ In .NET 5 and later versions, for bundled assemblies, this property throws an ex
 
 ## Remarks
 
- **.NET Framework only:** In the default application domain, this returns the process executable. In other application domains, this returns the first executable that was executed by <see cref="M:System.AppDomain.ExecuteAssembly(System.String)" />.
+ **.NET Framework only:** In the default application domain, this method returns the process executable. In other application domains, this method returns the first executable that was executed by <xref:System.AppDomain.ExecuteAssembly%2A>.
 
  The <xref:System.Reflection.Assembly.GetEntryAssembly%2A> method can return `null` when a managed assembly has been loaded from an unmanaged application. For example, if an unmanaged application creates an instance of a COM component written in C#, a call to the <xref:System.Reflection.Assembly.GetEntryAssembly%2A> method from the C# component returns null, because the entry point for the process was unmanaged code rather than a managed assembly.
 


### PR DESCRIPTION
The comments on `Assembly.GetEntryAssembly` behaviour around app domains and `AppDomain.ExecuteAssembly` only apply to .NET Framework.

cc @gewarren @jkotas @dotnet/appmodel 