### PR TITLE
Update AntiXssEncoder.xml for issue 10378

### DIFF
--- a/xml/System.Web.Security.AntiXss/AntiXssEncoder.xml
+++ b/xml/System.Web.Security.AntiXss/AntiXssEncoder.xml
@@ -279,7 +279,7 @@
 
 | Input                                    | Output                                                        |
 |------------------------------------------|---------------------------------------------------------------|
-| `alert('XSS Attack!');`                  | `alert(&#39;XSS&#32;Attack!&#39;);`                           |
+| `alert('XSS Attack!');`                  | `alert(&#39;XSS Attack!&#39;);`                           |
 | `<script>alert('XSS Attack!');</script>` | `&lt;script&gt;alert(&#39;XSS Attack!&#39;);&lt;/script&gt;`  |
 | `alert('XSSあAttack!');`                 | `alert(&#39;XSS&#12354;Attack!&#39;);`                        |
 | `user@contoso.com`                       | `user@contoso.com`                                            |
@@ -367,7 +367,7 @@
 
 | Input | Output |
 |-------|--------|
-|`alert('XSS Attack!');`|`alert(&#39;XSS&#32;Attack!&#39;);`|
+|`alert('XSS Attack!');`|`alert(&#39;XSS Attack!&#39;);`|
 |`<script>alert('XSS Attack!');</script>`|`&lt;script&gt;alert(&#39;XSS Attack!&#39;);&lt;/script&gt;`|
 |`alert('XSSあAttack!');`|`alert(&#39;XSS&#12354;Attack!&#39;);`|
 |`user@contoso.com`|`user@contoso.com`|


### PR DESCRIPTION
## Summary
Fixes Issue #10378 
- Corrected examples where (Space) was incorrectly encoded as `&#32;` 
- Added headings to the example table where they were missing.
