### PR TITLE
Clarify documentation for Process.Start return value

### DIFF
--- a/xml/System.Diagnostics/Process.xml
+++ b/xml/System.Diagnostics/Process.xml
@@ -5252,7 +5252,7 @@ There is a similar issue when you read all text from both the standard output an
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Use this overload to start a process resource and associate it with the current <xref:System.Diagnostics.Process> component. The return value `true` indicates that a new process resource was started. If the process resource specified by the <xref:System.Diagnostics.ProcessStartInfo.FileName%2A> member of the <xref:System.Diagnostics.Process.StartInfo%2A> property is already running on the computer, no additional process resource is started. Instead, the running process resource is reused and `false` is returned.
+The return value `true` indicates that a new process resource was started. If <xref:System.Diagnostics.ProcessStartInfo.UseShellExecute%2A> is set to `false` (or on Unix systems where `UseShellExecute` is ignored), the method will always return `true` as the process is started directly. If `UseShellExecute` is `true`, the operating system may reuse an existing process in some cases, and `false` is returned. For instance, if you start a URL with a default browser and an instance of the browser is already running, a new process may not be created, and `false` will be returned.
 
  You can start a ClickOnce application by specifying the location (for example, a Web address) from which you originally installed the application. Do not start a ClickOnce application by specifying its installed location on your hard drive.
 


### PR DESCRIPTION
## Summary

Describe your changes here.

This PR clarifies the documentation of the `Process.Start` method's return value, addressing issue dotnet/dotnet-api-docs#10664.

- Explains how the return value depends on the `UseShellExecute` property.
- Provides examples of when `false` may be returned.

Fixes #Issue_Number (if available)
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

