### PR TITLE
Update docs for SRC.MemoryCache

### DIFF
--- a/xml/System.Runtime.Caching/MemoryCache.xml
+++ b/xml/System.Runtime.Caching/MemoryCache.xml
@@ -430,7 +430,7 @@ private void btnGet_Click(object sender, EventArgs e)
 
 In .NET Framework (4.x), if the current instance of the cache exceeds the limit on memory set by the <xref:System.Runtime.Caching.MemoryCache.CacheMemoryLimit%2A> property, the cache implementation removes cache entries. Each cache instance in the application can use the amount of memory that is specified by the <xref:System.Runtime.Caching.MemoryCache.CacheMemoryLimit%2A> property. In .NET Core and later, this property returns the value from configuration or constructor parameters but is not enforced.
 
-The settings for the <xref:System.Runtime.Caching.MemoryCache.CacheMemoryLimit%2A> property can be specified in the application configuration file. Alternatively, they can be passed in the constructor or by a caller when the <xref:System.Runtime.Caching.MemoryCache> instance is initialized.
+You can specify the settings for the <xref:System.Runtime.Caching.MemoryCache.CacheMemoryLimit%2A> property in the application configuration file. Alternatively, they can be passed in the constructor or by a caller when the <xref:System.Runtime.Caching.MemoryCache> instance is initialized.
 
   ]]></format>
         </remarks>
@@ -935,9 +935,9 @@ The settings for the <xref:System.Runtime.Caching.MemoryCache.CacheMemoryLimit%2
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The <xref:System.Runtime.Caching.MemoryCache.PhysicalMemoryLimit%2A> property specifies the percentage of total physical memory usage on the system (by all processes) at which the cache will begin to evict entries. This setting is not a limit on the memory that a single <xref:System.Runtime.Caching.MemoryCache> instance can use. Instead, when overall system physical memory usage exceeds this percentage, the cache will proactively remove entries to help reduce memory pressure and avoid exhausting system memory, even if the cache itself is not over its other size limits.
+ The <xref:System.Runtime.Caching.MemoryCache.PhysicalMemoryLimit%2A> property specifies the percentage of total physical memory usage on the system (by all processes) at which the cache will begin to evict entries. This setting is not a limit on the memory that a single <xref:System.Runtime.Caching.MemoryCache> instance can use. Instead, when overall system physical memory usage exceeds this percentage, the cache proactively removes entries to help reduce memory pressure and avoid exhausting system memory, even if the cache itself is not over its other size limits.
 
- The settings for the <xref:System.Runtime.Caching.MemoryCache.PhysicalMemoryLimit%2A> property can be specified in the application configuration file. Alternatively, they can be passed by a caller when the <xref:System.Runtime.Caching.MemoryCache> instance is initialized.
+ You can specify the settings for the <xref:System.Runtime.Caching.MemoryCache.PhysicalMemoryLimit%2A> property in the application configuration file. Alternatively, they can be passed by a caller when the <xref:System.Runtime.Caching.MemoryCache> instance is initialized.
 
  ]]></format>
         </remarks>


### PR DESCRIPTION
Update docs for SRC.MemoryCache - memory limits were being presented 
This pull request updates the documentation for the `MemoryCache` class in `System.Runtime.Caching` to clarify the behavior of memory limit properties (`CacheMemoryLimit` and `PhysicalMemoryLimit`) across different .NET versions and their impact on cache eviction.

### Updates to `MemoryCache` documentation:

#### Changes to `CacheMemoryLimit` property:
* Clarified that the `CacheMemoryLimit` property does not enforce memory limits in .NET Core and .NET 5.0 or later, but remains functional in .NET Framework. Updated remarks to reflect this behavior and removed outdated information about gradual enforcement using internal heuristics.

#### Changes to `PhysicalMemoryLimit` property:
* Updated the description to specify that the `PhysicalMemoryLimit` property triggers cache eviction based on overall system memory usage rather than limiting the memory usage of a single `MemoryCache` instance. Revised remarks to emphasize its role in reducing memory pressure when system-wide physical memory usage exceeds the configured threshold.incorrectly

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
https://github.com/dotnet/runtime/issues/114714
https://github.com/dotnet/runtime/issues/74676
https://github.com/dotnet/runtime/issues/62516
