### PR TITLE
Fix incorrect snippet description

### DIFF
--- a/xml/System.Data.SqlClient/SqlCommand.xml
+++ b/xml/System.Data.SqlClient/SqlCommand.xml
@@ -554,7 +554,7 @@ class Program {
 
 
 ## Examples
- The following example creates a <xref:System.Data.SqlClient.SqlCommand>, passing in the connection string and command text.
+ The following example creates a <xref:System.Data.SqlClient.SqlCommand>, passing in the command text.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_ADO.NET/Classic WebData SqlCommand.SqlCommand1 Example/CS/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Data.SqlClient/SqlCommand/.ctor/source.vb" id="Snippet1":::


### PR DESCRIPTION
Fixes #11583

> ### Type of issue
> Typo
> 
> ### Description
> The example used for SqlCommand(String) has the following description:
> 
> "The following example creates a SqlCommand, passing in the **connection string and** command text."
> 
> The problem is the lack of a connection string in the example. How should the the connection string be provided in this example? I assume the proper description would be:
> 
> "The following example creates a SqlCommand, passing in the command text."