### PR TITLE
Add remarks showing new method names in .NET 10

### DIFF
--- a/xml/System.Runtime.Intrinsics.Arm/Sve.xml
+++ b/xml/System.Runtime.Intrinsics.Arm/Sve.xml
@@ -34115,7 +34115,7 @@
           <para>void svprfb(svbool_t pg, const void *base, enum svprfop op)</para>
           <para>  PRFB op, Pg, [Xbase, #0, MUL VL]</para>
         </summary>
-        <remarks>This method was renamed to in <see cref="M:System.Runtime.Intrinsics.Arm.Sve.Prefetch8Bit(System.Numerics.Vector{System.UInt8},System.Void*,System.Runtime.Intrinsics.Arm.SvePrefetchType)" /> .NET 10.</remarks>
+        <remarks>This method was renamed to in <see cref="M:System.Runtime.Intrinsics.Arm.Sve.Prefetch8Bit(System.Numerics.Vector{System.Byte},System.Void*,System.Runtime.Intrinsics.Arm.SvePrefetchType)" /> .NET 10.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PrefetchInt16">


### PR DESCRIPTION
Fixes #11427.