### PR TITLE
Use `nint` for native-sized integers in `Interlocked`

### DIFF
--- a/xml/System.Threading/Interlocked.xml
+++ b/xml/System.Threading/Interlocked.xml
@@ -807,7 +807,7 @@
       </Docs>
     </Member>
     <Member MemberName="CompareExchange">
-      <MemberSignature Language="C#" Value="public static nint CompareExchange (ref nint location1, nint value, nint comparand);" />
+      <MemberSignature Language="C#" Value="public static IntPtr CompareExchange (ref IntPtr location1, IntPtr value, IntPtr comparand);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig native int CompareExchange(native int&amp; location1, native int value, native int comparand) cil managed" />
       <MemberSignature Language="DocId" Value="M:System.Threading.Interlocked.CompareExchange(System.IntPtr@,System.IntPtr,System.IntPtr)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Function CompareExchange (ByRef location1 As IntPtr, value As IntPtr, comparand As IntPtr) As IntPtr" />
@@ -1216,7 +1216,7 @@ If `comparand` and the object in `location1` are equal by reference, then `value
       </Docs>
     </Member>
     <Member MemberName="CompareExchange">
-      <MemberSignature Language="C#" Value="public static nuint CompareExchange (ref nuint location1, nuint value, nuint comparand);" />
+      <MemberSignature Language="C#" Value="public static UIntPtr CompareExchange (ref UIntPtr location1, UIntPtr value, UIntPtr comparand);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig native unsigned int CompareExchange(native unsigned int&amp; location1, native unsigned int value, native unsigned int comparand) cil managed" />
       <MemberSignature Language="DocId" Value="M:System.Threading.Interlocked.CompareExchange(System.UIntPtr@,System.UIntPtr,System.UIntPtr)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Function CompareExchange (ByRef location1 As UIntPtr, value As UIntPtr, comparand As UIntPtr) As UIntPtr" />
@@ -1867,7 +1867,7 @@ If `comparand` and the value in `location1` are equal by reference, then `value`
       </Docs>
     </Member>
     <Member MemberName="Exchange">
-      <MemberSignature Language="C#" Value="public static nint Exchange (ref nint location1, nint value);" />
+      <MemberSignature Language="C#" Value="public static IntPtr Exchange (ref IntPtr location1, IntPtr value);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig native int Exchange(native int&amp; location1, native int value) cil managed" />
       <MemberSignature Language="DocId" Value="M:System.Threading.Interlocked.Exchange(System.IntPtr@,System.IntPtr)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Function Exchange (ByRef location1 As IntPtr, value As IntPtr) As IntPtr" />
@@ -2238,7 +2238,7 @@ If `comparand` and the value in `location1` are equal by reference, then `value`
       </Docs>
     </Member>
     <Member MemberName="Exchange">
-      <MemberSignature Language="C#" Value="public static nuint Exchange (ref nuint location1, nuint value);" />
+      <MemberSignature Language="C#" Value="public static UIntPtr Exchange (ref UIntPtr location1, UIntPtr value);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig native unsigned int Exchange(native unsigned int&amp; location1, native unsigned int value) cil managed" />
       <MemberSignature Language="DocId" Value="M:System.Threading.Interlocked.Exchange(System.UIntPtr@,System.UIntPtr)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Function Exchange (ByRef location1 As UIntPtr, value As UIntPtr) As UIntPtr" />


### PR DESCRIPTION
Related: https://github.com/dotnet/runtime/pull/118336
