### PR TITLE
Revert "Use `nint` for native-sized integers in `Marshal` (#11652)"

### DIFF
--- a/xml/System.Runtime.InteropServices/Marshal.xml
+++ b/xml/System.Runtime.InteropServices/Marshal.xml
@@ -329,7 +329,7 @@
       </Docs>
     </Member>
     <Member MemberName="AllocHGlobal">
-      <MemberSignature Language="C#" Value="public static IntPtr AllocHGlobal (nint cb);" />
+      <MemberSignature Language="C#" Value="public static IntPtr AllocHGlobal (IntPtr cb);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig native int AllocHGlobal(native int cb) cil managed" />
       <MemberSignature Language="DocId" Value="M:System.Runtime.InteropServices.Marshal.AllocHGlobal(System.IntPtr)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Function AllocHGlobal (cb As IntPtr) As IntPtr" />
@@ -9249,7 +9249,7 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
       </Docs>
     </MemberGroup>
     <Member MemberName="ReadIntPtr">
-      <MemberSignature Language="C#" Value="public static nint ReadIntPtr (IntPtr ptr);" />
+      <MemberSignature Language="C#" Value="public static IntPtr ReadIntPtr (IntPtr ptr);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig native int ReadIntPtr(native int ptr) cil managed" />
       <MemberSignature Language="DocId" Value="M:System.Runtime.InteropServices.Marshal.ReadIntPtr(System.IntPtr)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Function ReadIntPtr (ptr As IntPtr) As IntPtr" />
@@ -9337,7 +9337,7 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
       </Docs>
     </Member>
     <Member MemberName="ReadIntPtr">
-      <MemberSignature Language="C#" Value="public static nint ReadIntPtr (IntPtr ptr, int ofs);" />
+      <MemberSignature Language="C#" Value="public static IntPtr ReadIntPtr (IntPtr ptr, int ofs);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig native int ReadIntPtr(native int ptr, int32 ofs) cil managed" />
       <MemberSignature Language="DocId" Value="M:System.Runtime.InteropServices.Marshal.ReadIntPtr(System.IntPtr,System.Int32)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Function ReadIntPtr (ptr As IntPtr, ofs As Integer) As IntPtr" />
@@ -9419,7 +9419,7 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
       </Docs>
     </Member>
     <Member MemberName="ReadIntPtr">
-      <MemberSignature Language="C#" Value="public static nint ReadIntPtr (object ptr, int ofs);" />
+      <MemberSignature Language="C#" Value="public static IntPtr ReadIntPtr (object ptr, int ofs);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig native int ReadIntPtr(object ptr, int32 ofs) cil managed" FrameworkAlternate="dotnet-uwp-10.0;net-10.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0;netcore-1.0;netcore-1.1;netcore-2.0;netcore-2.1;netcore-2.2;netcore-3.0;netcore-3.1;netframework-4.6.2-pp;netframework-4.7.1-pp;netframework-4.7.2-pp;netframework-4.7-pp;netframework-4.8.1-pp;netframework-4.8-pp;netstandard-1.1;netstandard-1.2;netstandard-1.3;netstandard-1.4;netstandard-1.5;netstandard-1.6;netstandard-2.0;netstandard-2.1" />
       <MemberSignature Language="DocId" Value="M:System.Runtime.InteropServices.Marshal.ReadIntPtr(System.Object,System.Int32)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Function ReadIntPtr (ptr As Object, ofs As Integer) As IntPtr" />
@@ -9575,7 +9575,7 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
       </Docs>
     </Member>
     <Member MemberName="ReAllocHGlobal">
-      <MemberSignature Language="C#" Value="public static IntPtr ReAllocHGlobal (IntPtr pv, nint cb);" />
+      <MemberSignature Language="C#" Value="public static IntPtr ReAllocHGlobal (IntPtr pv, IntPtr cb);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig native int ReAllocHGlobal(native int pv, native int cb) cil managed" />
       <MemberSignature Language="DocId" Value="M:System.Runtime.InteropServices.Marshal.ReAllocHGlobal(System.IntPtr,System.IntPtr)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Function ReAllocHGlobal (pv As IntPtr, cb As IntPtr) As IntPtr" />
@@ -13233,7 +13233,7 @@ public static void ThrowExceptionForHR(interrorCode,IntPtrerrorInfo)
       </Docs>
     </MemberGroup>
     <Member MemberName="WriteIntPtr">
-      <MemberSignature Language="C#" Value="public static void WriteIntPtr (IntPtr ptr, nint val);" />
+      <MemberSignature Language="C#" Value="public static void WriteIntPtr (IntPtr ptr, IntPtr val);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void WriteIntPtr(native int ptr, native int val) cil managed" />
       <MemberSignature Language="DocId" Value="M:System.Runtime.InteropServices.Marshal.WriteIntPtr(System.IntPtr,System.IntPtr)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Sub WriteIntPtr (ptr As IntPtr, val As IntPtr)" />
@@ -13318,7 +13318,7 @@ public static void ThrowExceptionForHR(interrorCode,IntPtrerrorInfo)
       </Docs>
     </Member>
     <Member MemberName="WriteIntPtr">
-      <MemberSignature Language="C#" Value="public static void WriteIntPtr (IntPtr ptr, int ofs, nint val);" />
+      <MemberSignature Language="C#" Value="public static void WriteIntPtr (IntPtr ptr, int ofs, IntPtr val);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void WriteIntPtr(native int ptr, int32 ofs, native int val) cil managed" />
       <MemberSignature Language="DocId" Value="M:System.Runtime.InteropServices.Marshal.WriteIntPtr(System.IntPtr,System.Int32,System.IntPtr)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Sub WriteIntPtr (ptr As IntPtr, ofs As Integer, val As IntPtr)" />
@@ -13399,7 +13399,7 @@ public static void ThrowExceptionForHR(interrorCode,IntPtrerrorInfo)
       </Docs>
     </Member>
     <Member MemberName="WriteIntPtr">
-      <MemberSignature Language="C#" Value="public static void WriteIntPtr (object ptr, int ofs, nint val);" />
+      <MemberSignature Language="C#" Value="public static void WriteIntPtr (object ptr, int ofs, IntPtr val);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void WriteIntPtr(object ptr, int32 ofs, native int val) cil managed" FrameworkAlternate="dotnet-uwp-10.0;net-10.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0;netcore-1.0;netcore-1.1;netcore-2.0;netcore-2.1;netcore-2.2;netcore-3.0;netcore-3.1;netframework-4.6.2-pp;netframework-4.7.1-pp;netframework-4.7.2-pp;netframework-4.7-pp;netframework-4.8.1-pp;netframework-4.8-pp;netstandard-1.1;netstandard-1.2;netstandard-1.3;netstandard-1.4;netstandard-1.5;netstandard-1.6;netstandard-2.0;netstandard-2.1" />
       <MemberSignature Language="DocId" Value="M:System.Runtime.InteropServices.Marshal.WriteIntPtr(System.Object,System.Int32,System.IntPtr)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Sub WriteIntPtr (ptr As Object, ofs As Integer, val As IntPtr)" />


### PR DESCRIPTION
This reverts commit 369ed46b4e28b0d0b7615526800933fe87aa1215.

> @jkotas The member signatures are autogenerated and will be overwritten. I'm not sure if the autogenerated signature will be the same as the change that was merged here, or if [this user story](https://dev.azure.com/ceapex/Engineering/_workitems/edit/722510) (which was bulk removed in June :-( ) will prevent the proper display.

_Originally posted by @gewarren in https://github.com/dotnet/dotnet-api-docs/issues/11652#issuecomment-3156208144_
            

