### PR TITLE
Fix documentation for ReadOnlySequence.GetOffset

### DIFF
--- a/xml/System.Buffers/ReadOnlySequence`1.xml
+++ b/xml/System.Buffers/ReadOnlySequence`1.xml
@@ -465,7 +465,7 @@
         <param name="position">The <see cref="T:System.SequencePosition" /> of which to get the offset.</param>
         <summary>Returns the offset of a <paramref name="position" /> within this sequence.</summary>
         <returns>The offset in the sequence.</returns>
-        <remarks>The returned offset is not a zero-based index from the start. Subtract <code>mySequence.GetOffset(mySequence.Start)</code> from the returned offset to obtain the zero-based index offset.</remarks>
+        <remarks>The returned offset is not a zero-based index from the start. To obtain the zero-based index offset, subtract <code>mySequence.GetOffset(mySequence.Start)</code> from the returned offset.</remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The position is out of range.</exception>
       </Docs>
     </Member>


### PR DESCRIPTION
Corresponding docs change for dotnet/runtime#116524