### PR TITLE
Clarify FileShare enum descriptions to remove ambiguity Fixes #10572

### DIFF
--- a/xml/System.IO/FileShare.xml
+++ b/xml/System.IO/FileShare.xml
@@ -142,7 +142,7 @@
       </ReturnValue>
       <MemberValue>4</MemberValue>
       <Docs>
-        <summary>Allows subsequent deleting of a file.</summary>
+         <summary>Allows the file to be deleted by this process or other processes. The file can be deleted while it remains open.</summary>
       </Docs>
     </Member>
     <Member MemberName="Inheritable">
@@ -277,7 +277,7 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>Allows subsequent opening of the file for reading. If this flag is not specified, any request to open the file for reading (by this process or another process) will fail until the file is closed. However, even if this flag is specified, additional permissions might still be needed to access the file.</summary>
+         <summary>Allows the file to be opened for reading by this process or other processes. If this flag is not specified, any request to open the file for reading (by this process or another process) will fail until the file is closed. However, even if this flag is specified, additional permissions might still be needed to access the file.</summary>
       </Docs>
     </Member>
     <Member MemberName="ReadWrite">
@@ -322,7 +322,7 @@
       </ReturnValue>
       <MemberValue>3</MemberValue>
       <Docs>
-        <summary>Allows subsequent opening of the file for reading or writing. If this flag is not specified, any request to open the file for reading or writing (by this process or another process) will fail until the file is closed. However, even if this flag is specified, additional permissions might still be needed to access the file.</summary>
+        <summary>Allows the file to be opened for reading or writing by this process or other processes. If this flag is not specified, any request to open the file for reading or writing (by this process or another process) will fail until the file is closed. However, even if this flag is specified, additional permissions might still be needed to access the file.</summary>
       </Docs>
     </Member>
     <Member MemberName="Write">
@@ -367,7 +367,7 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>Allows subsequent opening of the file for writing. If this flag is not specified, any request to open the file for writing (by this process or another process) will fail until the file is closed. However, even if this flag is specified, additional permissions might still be needed to access the file.</summary>
+        <summary>Allows the file to be opened for writing by this process or other processes. If this flag is not specified, any request to open the file for writing (by this process or another process) will fail until the file is closed. However, even if this flag is specified, additional permissions might still be needed to access the file.</summary>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
## Summary

  - Removed misleading word "subsequent" from all FileShare enum member descriptions
  - Clarified that FileShare flags control access for all file operations, not just future ones
  - Updated descriptions for Delete, Read, ReadWrite, and Write enum members

  ## Details
  The original FileShare enum documentation used the word "subsequent" in descriptions like "Allows subsequent
  opening of the file for reading", which incorrectly implied that these flags only affect future file open attempts
   after the current one.

  In reality, FileShare flags control whether **any** attempt to open the file (including the current one) will
  succeed, based on how existing file handles were opened. This was demonstrated in issue #10572 with this example:

  ```csharp
  using var fileStream1 = new FileStream("test.file", FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
  using var fileStream2 = new FileStream("test.file", FileMode.Open, FileAccess.Read, FileShare.Read);
```

  The second open fails because the first handle has Write access, even though both specify FileShare.Read. The
  original documentation's use of "subsequent" made this behavior unclear.

  Changes

  - Delete: "Allows subsequent deleting" → "Allows the file to be deleted by this process or other processes"
  - Read: "Allows subsequent opening for reading" → "Allows the file to be opened for reading by this process or
  other processes"
  - ReadWrite: "Allows subsequent opening for reading or writing" → "Allows the file to be opened for reading or
  writing by this process or other processes"
  - Write: "Allows subsequent opening for writing" → "Allows the file to be opened for writing by this process or
  other processes"

  Fixes #10572 