### PR TITLE
Add inheritdoc elements to XML documentation

### DIFF
--- a/xml/System.Xml/XmlDictionaryWriter.xml
+++ b/xml/System.Xml/XmlDictionaryWriter.xml
@@ -183,6 +183,7 @@
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
+        <inheritdoc />
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateBinaryWriter">
@@ -838,6 +839,7 @@ binarywriter.WriteEndAttribute();
         <param name="disposing">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
+        <inheritdoc />
       </Docs>
     </Member>
     <Member MemberName="EndCanonicalization">


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/120511

Fixes missing docs for XML namespace in .NET 10.0


