### PR TITLE
Update System.Net.* APIs for .NET 10

### DIFF
--- a/xml/System.Net.Security/SslStream.xml
+++ b/xml/System.Net.Security/SslStream.xml
@@ -4410,6 +4410,7 @@ This property gets the cipher suite that is going to be used in the communicatio
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
+        <inheritdoc />
       </Docs>
     </Member>
     <Member MemberName="Read">
@@ -5162,6 +5163,7 @@ If the property is accessed, the remote certificate will not be disposed when th
         <param name="buffer">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
+        <inheritdoc />
       </Docs>
     </Member>
     <Member MemberName="Write">
@@ -5385,6 +5387,7 @@ The <xref:System.Net.Security.SslStream> class does not support multiple simulta
         <param name="value">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
+        <inheritdoc />
       </Docs>
     </Member>
     <Member MemberName="WriteTimeout">

--- a/xml/System.Net.WebSockets/WebSocketStream.xml
+++ b/xml/System.Net.WebSockets/WebSocketStream.xml
@@ -347,6 +347,7 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
+        <inheritdoc />
       </Docs>
     </Member>
     <Member MemberName="EndRead">

--- a/xml/System.Net/IPAddress.xml
+++ b/xml/System.Net/IPAddress.xml
@@ -1606,7 +1606,8 @@
       <Docs>
         <param name="ipSpan">The text to parse.</param>
         <summary>Determines whether the provided span contains a valid <see cref="T:System.Net.IPAddress" />.</summary>
-        <returns>To be added.</returns>
+        <returns>
+          <see langword="true" /> if <paramref name="ipSpan" /> contains a valid IP address; otherwise, <see langword="false" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -1640,7 +1641,8 @@
       <Docs>
         <param name="utf8Text">The text to parse.</param>
         <summary>Determines whether the provided span contains a valid <see cref="T:System.Net.IPAddress" />.</summary>
-        <returns>To be added.</returns>
+        <returns>
+          <see langword="true" /> if <paramref name="utf8Text" /> contains a valid IP address; otherwise, <see langword="false" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -2774,6 +2776,7 @@ The scope identifier is &gt; 0x00000000FFFFFFFF</exception>
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
+        <inheritdoc />
       </Docs>
     </Member>
     <Member MemberName="ToString">

--- a/xml/System.Net/IPNetwork.xml
+++ b/xml/System.Net/IPNetwork.xml
@@ -717,6 +717,7 @@
         <summary>To be added.</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
+        <inheritdoc />
       </Docs>
     </Member>
     <Member MemberName="ToString">


### PR DESCRIPTION
Add missing `<inheritdoc/>` and `<returns>` for System.Net.* APIs

Fixes dotnet/runtime#120497
Fixes dotnet/runtime#120498
Fixes dotnet/runtime#120499

