### PR TITLE
Fix use of forInternalUseOnly in ExtensionMarkerAttribute

### DIFF
--- a/xml/System.Runtime.CompilerServices/ExtensionMarkerAttribute.xml
+++ b/xml/System.Runtime.CompilerServices/ExtensionMarkerAttribute.xml
@@ -30,9 +30,9 @@
   <Docs>
     <summary>
       <para>Represents an attribute that's used to mark extension members and associate them with a specific marker type (which provides detailed information about an extension block and its receiver parameter).</para>
-      <forInternalUseOnly />
     </summary>
     <remarks>To be added.</remarks>
+    <forInternalUseOnly />
   </Docs>
   <Members>
     <Member MemberName=".ctor">


### PR DESCRIPTION
I misused this tag in #11847.

It needs to be placed outside other tags, directly under docs.