### PR TITLE
Return type of ValueTuple.Create with 8 arguments is rendered incorrectly (#11939)

### DIFF
--- a/xml/System/ValueTuple.xml
+++ b/xml/System/ValueTuple.xml
@@ -951,7 +951,7 @@
       </Docs>
     </Member>
     <Member MemberName="Create&lt;T1,T2,T3,T4,T5,T6,T7,T8&gt;">
-      <MemberSignature Language="C#" Value="public static (T1, T2, T3, T4, T5, T6, T7, (T8)) Create&lt;T1,T2,T3,T4,T5,T6,T7,T8&gt; (T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8);" />
+      <MemberSignature Language="C#" Value="public static (T1, T2, T3, T4, T5, T6, T7, T8) Create&lt;T1,T2,T3,T4,T5,T6,T7,T8&gt; (T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig valuetype System.ValueTuple`8&lt;!!T1, !!T2, !!T3, !!T4, !!T5, !!T6, !!T7, valuetype System.ValueTuple`1&lt;!!T8&gt;&gt; Create&lt;T1, T2, T3, T4, T5, T6, T7, T8&gt;(!!T1 item1, !!T2 item2, !!T3 item3, !!T4 item4, !!T5 item5, !!T6 item6, !!T7 item7, !!T8 item8) cil managed" />
       <MemberSignature Language="DocId" Value="M:System.ValueTuple.Create``8(``0,``1,``2,``3,``4,``5,``6,``7)" />
       <MemberSignature Language="VB.NET" Value="Public Shared Function Create(Of T1, T2, T3, T4, T5, T6, T7, T8) (item1 As T1, item2 As T2, item3 As T3, item4 As T4, item5 As T5, item6 As T6, item7 As T7, item8 As T8) As ValueTuple(Of T1, T2, T3, T4, T5, T6, T7, ValueTuple(Of T8))" />


### PR DESCRIPTION
## Summary

Fix return type of ValueTuple.Create with 8 arguments 

Fixes dotnet/dotnet-api-docs/issues/#11939 
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

