### PR TITLE
MathF.SinCos remarks use Math.PI instead of MathF.PI (#11824)

### DIFF
--- a/xml/System/MathF.xml
+++ b/xml/System/MathF.xml
@@ -2405,7 +2405,7 @@ If the value of the `x` argument is <xref:System.Single.NaN?displayProperty=name
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The angle, `x`, must be in radians. Multiply by <xref:System.Math.PI?displayProperty=nameWithType>/180 to convert degrees to radians.
+ The angle, `x`, must be in radians. Multiply by <xref:System.MathF.PI?displayProperty=nameWithType>/180 to convert degrees to radians.
 
  This method calls into the underlying C runtime, and the exact result or valid input range may differ between different operating systems or architectures.
 


### PR DESCRIPTION
## Summary

Fix MathF.SinCos remarks use Math.PI instead of MathF.PI (#11824)

Fixes dotnet/dotnet-api-docs/issues/https://github.com/dotnet/dotnet-api-docs/issues/11824
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

