### PR TITLE
Incorrect statement in BigInteger.Pow(BigInteger, Int32) remarks (#11815)

### DIFF
--- a/xml/System.Numerics/BigInteger.xml
+++ b/xml/System.Numerics/BigInteger.xml
@@ -9342,7 +9342,7 @@ If `provider` is `null`, the <xref:System.Globalization.NumberFormatInfo> object
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The <xref:System.Numerics.BigInteger.Pow%2A> method returns 1 if the value of the exponent parameter is 0, or if the values of both the `value` and `exponent` parameters are 0. If `exponent` is 1, the <xref:System.Numerics.BigInteger.Pow%2A> method returns `value`. If `value` is negative, the method returns a negative result.
+ The <xref:System.Numerics.BigInteger.Pow%2A> method returns 1 if the value of the exponent parameter is 0, or if the values of both the `value` and `exponent` parameters are 0. If `exponent` is 1, the <xref:System.Numerics.BigInteger.Pow%2A> method returns `value`. If `value` is negative and exponent is odd, the method returns a negative result.
 
  This method corresponds to the <xref:System.Math.Pow%2A?displayProperty=nameWithType> method for primitive numeric types.
 


### PR DESCRIPTION
## Summary

Fix incorrect statement in BigInteger.Pow(BigInteger, Int32) remarks 

Fixes dotnet/dotnet-api-docs/issues/https://github.com/dotnet/dotnet-api-docs/issues/11815
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

