### PR TITLE
Extend description for IsWhiteSpace() for empty spans (#11560)

### DIFF
--- a/xml/System/MemoryExtensions.xml
+++ b/xml/System/MemoryExtensions.xml
@@ -7833,9 +7833,9 @@ Invalid sequences will be represented in the enumeration by <xref:System.Text.Ru
       </Parameters>
       <Docs>
         <param name="span">The source span.</param>
-        <summary>Indicates whether the specified span contains only whitespace characters.</summary>
+        <summary>Indicates whether the specified span is empty or contains only whitespace characters.</summary>
         <returns>
-          <see langword="true" /> if the span contains only whitespace characters, <see langword="false" /> otherwise.</returns>
+          <see langword="true" /> if the span is empty or contains only whitespace characters, <see langword="false" /> otherwise.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
## Summary

Extend description for IsWhiteSpace() for empty spans

Fixes dotnet/dotnet-api-docs/issues/https://github.com/dotnet/dotnet-api-docs/issues/11560
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

