### PR TITLE
ReadOnlySpan created from a null array does not return a null ReadOnlySpan (#10611)

### DIFF
--- a/xml/System/ReadOnlySpan`1.xml
+++ b/xml/System/ReadOnlySpan`1.xml
@@ -179,7 +179,7 @@ A `ReadOnlySpan<T>` instance is often used to reference the elements of an array
         <param name="array">The array from which to create the <see cref="T:System.ReadOnlySpan`1" />.</param>
         <summary>Creates a new <see cref="T:System.ReadOnlySpan`1" /> over the entirety of a specified array.</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[If the array is null, this constructor returns a null `ReadOnlySpan<T>`.]]></format>
+          <format type="text/markdown"><![CDATA[If the `array` is null, this constructor returns a `default` `ReadOnlySpan<T>`.]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -290,7 +290,7 @@ A `ReadOnlySpan<T>` instance is often used to reference the elements of an array
 
 ### Remarks
 
-This method returns `default` when `array` is `null`.
+If the `array` is null, this constructor returns a `default` `ReadOnlySpan<T>`.
 
             ]]></format>
         </remarks>


### PR DESCRIPTION
## Summary

Update remark for creating ReadOnlySpan with null array

Fixes dotnet/dotnet-api-docs/issues/https://github.com/dotnet/dotnet-api-docs/issues/10611

