### PR TITLE
Fixed typos in System.Numerics.Vector Shift* operator return elements

### DIFF
--- a/xml/System.Numerics/Vector.xml
+++ b/xml/System.Numerics/Vector.xml
@@ -9222,7 +9222,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts each element of a vector left by the specified amount.</summary>
-        <returns>A vector whose elements where shifted left by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted left by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9255,7 +9255,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts each element of a vector left by the specified amount.</summary>
-        <returns>A vector whose elements where shifted left by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted left by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9288,7 +9288,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts each element of a vector left by the specified amount.</summary>
-        <returns>A vector whose elements where shifted left by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted left by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9321,7 +9321,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts each element of a vector left by the specified amount.</summary>
-        <returns>A vector whose elements where shifted left by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted left by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9354,7 +9354,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts each element of a vector left by the specified amount.</summary>
-        <returns>A vector whose elements where shifted left by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted left by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9393,7 +9393,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts each element of a vector left by the specified amount.</summary>
-        <returns>A vector whose elements where shifted left by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted left by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9432,7 +9432,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts each element of a vector left by the specified amount.</summary>
-        <returns>A vector whose elements where shifted left by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted left by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9471,7 +9471,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts each element of a vector left by the specified amount.</summary>
-        <returns>A vector whose elements where shifted left by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted left by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9510,7 +9510,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts each element of a vector left by the specified amount.</summary>
-        <returns>A vector whose elements where shifted left by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted left by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9549,7 +9549,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts each element of a vector left by the specified amount.</summary>
-        <returns>A vector whose elements where shifted left by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted left by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9582,7 +9582,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (signed) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9615,7 +9615,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (signed) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9648,7 +9648,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (signed) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9681,7 +9681,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (signed) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9720,7 +9720,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (signed) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9753,7 +9753,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (unsigned) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9786,7 +9786,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (unsigned) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9819,7 +9819,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (unsigned) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9852,7 +9852,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (unsigned) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9885,7 +9885,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (unsigned) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9924,7 +9924,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (unsigned) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -9963,7 +9963,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (unsigned) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -10002,7 +10002,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (unsigned) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -10041,7 +10041,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (unsigned) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -10080,7 +10080,7 @@ Note that this method returns a <xref:System.Single> instead of an integral type
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (unsigned) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/xml/System.Numerics/Vector`1.xml
+++ b/xml/System.Numerics/Vector`1.xml
@@ -2305,7 +2305,7 @@ The type `T` can be any of the following numeric types:
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts each element of a vector left by the specified amount.</summary>
-        <returns>A vector whose elements where shifted left by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted left by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -2584,7 +2584,7 @@ The type `T` can be any of the following numeric types:
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (signed) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -2798,7 +2798,7 @@ The type `T` can be any of the following numeric types:
         <param name="value">The vector whose elements are to be shifted.</param>
         <param name="shiftCount">The number of bits by which to shift each element.</param>
         <summary>Shifts (unsigned) each element of a vector right by the specified amount.</summary>
-        <returns>A vector whose elements where shifted right by <paramref name="shiftCount" />.</returns>
+        <returns>A vector whose elements were shifted right by <paramref name="shiftCount" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
## Summary

Fixed typo in all Vector Shift\* operator return sections, changing "whose elements ***where*** shifted" to "whose elements ***were*** shifted".

CLA previously signed for other contributions.

Ready to go.