### PR TITLE
Update DNS resolution method in SocketAddress example

### DIFF
--- a/snippets/csharp/System.Net/SocketAddress/Overview/source.cs
+++ b/snippets/csharp/System.Net/SocketAddress/Overview/source.cs
@@ -10,7 +10,7 @@ public static void MySerializeIPEndPointClassMethod(){
 //<Snippet1>
 
 //Creates an IpEndPoint.
-IPAddress ipAddress = Dns.Resolve("www.contoso.com").AddressList[0];
+IPAddress ipAddress = Dns.GetHostEntry("www.contoso.com").AddressList[0];
 IPEndPoint ipLocalEndPoint = new IPEndPoint(ipAddress, 11000);
 
 //Serializes the IPEndPoint.


### PR DESCRIPTION
## Summary

Describe your changes here.
Just updated the example with GetHostEntry because Resolve has been deprecated

Fixes #Issue_Number (if available)
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

