### PR TITLE
Update README with API reference documentation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ To contribute, see:
 
 - The [.NET Contributor Guide :ledger:](https://learn.microsoft.com/contribute/dotnet/dotnet-contribute) for instructions on procedures we use.
 - Issues labeled [`help wanted` :label:](https://github.com/dotnet/dotnet-api-docs/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+) for ideas.
-- The API reference docs for some assemblies are maintained in the assembly's source code outside this repo. Edits to the XML here are auto-generated and ported, so docs for APIs in those assemblies should be updated by editing the source code comments. See [here](https://github.com/dotnet/runtime/docs/adding-api-guidelines.md#documentation) for details.
+- The API reference docs for some assemblies are maintained in the assembly's source code outside this repo. For those assemblies, edits to the XML here are auto-generated and ported, so docs for APIs in those assemblies should be updated by editing the source code comments. For more information, see [here](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/adding-api-guidelines.md#documentation).
+
+  Namespaces and types whose docs are maintained in the assembly's source code repo set the [`open_to_public_contributors`](https://github.com/dotnet/dotnet-api-docs/blob/0ddbf94c587e7bdbbadc813a8b58fc4160a47b1f/docfx.json#L164) metadata to `false`. (That metadata disables the Edit button on the published docs.)
 
 ## :bookmark_tabs: Code of conduct
 


### PR DESCRIPTION
The links from the api-docs repo has a bunch of general info about the doc updates and desired content style, but I didn't see anything that tells contibutors if their edit should be made in this repo or elsewhere. The runtime docs do talk about that, but those docs weren't easily discoverable from here.

I'm not sure if the front README is the right place for this, but I didn't see a better place.

