### PR TITLE
Clarify IReflect interface COM casting behavior

### DIFF
--- a/xml/System.Reflection/IReflect.xml
+++ b/xml/System.Reflection/IReflect.xml
@@ -55,11 +55,12 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Since .NET 10, no COM object casts successfully to this interface. It is recommended to project and define a managed definition of `IDispatch` or `IDispatchEx` if access is needed.
 
- From .NET 5 until .NET 9, COM objects that implement `IDispatchEx` can be cast to this interface, but all methods throw `TypeLoadException`.
+In .NET 10 and later versions, no COM object casts successfully to this interface. If you need access, it's recommended to project and define a managed definition of `IDispatch` or `IDispatchEx`.
 
- On .NET Framework, the <xref:System.Reflection.IReflect> interface is used to interoperate with the [IDispatch interface](/windows/win32/api/oaidl/nn-oaidl-idispatch). <xref:System.Reflection.IReflect> defines a subset of the <xref:System.Type> reflection methods. Implementing this interface enables a type to customize its behavior when the object is being accessed from COM as an `IDispatch` object. The <xref:System.Runtime.InteropServices.CustomMarshalers.ExpandoToDispatchExMarshaler> class can be used to marshal an object that implements <xref:System.Reflection.IReflect> or <xref:System.Runtime.InteropServices.Expando.IExpando> as a COM `IDispatch` object, and vice versa.
+In .NET 5 through .NET 9, COM objects that implement `IDispatchEx` can be cast to this interface, but all methods throw `TypeLoadException`.
+
+On .NET Framework, the <xref:System.Reflection.IReflect> interface is used to interoperate with the [IDispatch interface](/windows/win32/api/oaidl/nn-oaidl-idispatch). <xref:System.Reflection.IReflect> defines a subset of the <xref:System.Type> reflection methods. Implementing this interface enables a type to customize its behavior when the object is being accessed from COM as an `IDispatch` object. The <xref:System.Runtime.InteropServices.CustomMarshalers.ExpandoToDispatchExMarshaler> class can be used to marshal an object that implements <xref:System.Reflection.IReflect> or <xref:System.Runtime.InteropServices.Expando.IExpando> as a COM `IDispatch` object, and vice versa.
 
  ]]></format>
     </remarks>


### PR DESCRIPTION
Updated remarks to clarify COM object casting behavior in .NET versions.

See https://github.com/dotnet/runtime/issues/121635 and https://github.com/dotnet/docs/issues/49921

