### PR TITLE
Updated Documentation for RequestLengthDiskThreshold

### DIFF
--- a/snippets/csharp/VS_Snippets_WebNet/System.Web.Configuration.HttpRuntimeSection/CS/httpruntimesection.cs
+++ b/snippets/csharp/VS_Snippets_WebNet/System.Web.Configuration.HttpRuntimeSection/CS/httpruntimesection.cs
@@ -112,7 +112,7 @@ public partial class _Default : System.Web.UI.Page
       Response.Write("RequestLengthDiskThreshold: " +
         configSection.RequestLengthDiskThreshold + "<br>");
 
-      // Set the RequestLengthDiskThreshold property value to 512 bytes.
+      // Set the RequestLengthDiskThreshold property value to 512 kilobytes.
       configSection.RequestLengthDiskThreshold = 512;
       // </Snippet12>
 

--- a/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Configuration.HttpRuntimeSection/VB/httpruntimesection.vb
+++ b/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Configuration.HttpRuntimeSection/VB/httpruntimesection.vb
@@ -113,7 +113,7 @@ Partial Class _Default
       Response.Write("RequestLengthDiskThreshold: " & _
         configSection.RequestLengthDiskThreshold & "<br>")
 
-      ' Set the RequestLengthDiskThreshold property value to 512 bytes.
+      ' Set the RequestLengthDiskThreshold property value to 512 kilobytes.
       configSection.RequestLengthDiskThreshold = 512
       ' </Snippet12>
 

--- a/xml/System.Web.Configuration/HttpRuntimeSection.xml
+++ b/xml/System.Web.Configuration/HttpRuntimeSection.xml
@@ -1009,12 +1009,12 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the input-stream buffering threshold.</summary>
-        <value>The number of bytes that indicate the input-stream buffering threshold. The default is 80 kilobytes.</value>
+        <value>The number of kilobytes that indicate the input-stream buffering threshold. The default is 80 kilobytes.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The <xref:System.Web.Configuration.HttpRuntimeSection.RequestLengthDiskThreshold%2A> property specifies the input-stream buffering threshold limit in number of bytes. Its value should not exceed the <xref:System.Web.Configuration.HttpRuntimeSection.MaxRequestLength%2A> property value. After a request entity exceeds this threshold, it is buffered transparently onto disk.
+ The <xref:System.Web.Configuration.HttpRuntimeSection.RequestLengthDiskThreshold%2A> property specifies the input-stream buffering threshold limit in number of kilobytes. Its value should not exceed the <xref:System.Web.Configuration.HttpRuntimeSection.MaxRequestLength%2A> property value. After a request entity exceeds this threshold, it is buffered transparently onto disk.
 
 
 


### PR DESCRIPTION
## Summary

As noted in the issue, the value that is specified here is a value in KB, however, the documentation contained mixed references to both kilobytes and bytes.

I updated this to reflect kilobytes properly in all locations, including the snippets and actual documentation

Fixes #12083

