### PR TITLE
Remove interactive snippets

### DIFF
--- a/xml/System.Collections.Generic/Comparer`1.xml
+++ b/xml/System.Collections.Generic/Comparer`1.xml
@@ -94,7 +94,7 @@
 ## Examples
  The following example derives a class, `BoxLengthFirst`, from the <xref:System.Collections.Generic.Comparer%601> class. This comparer compares two objects of type `Box`. It sorts them first by length, then by height, and then by width. The `Box` class implements the <xref:System.IComparable%601> interface to control the default comparison between two `Box` objects. This default implementation sorts first by height, then by length, and then by width. The example shows the differences between the two comparisons by sorting a list of `Box` objects first by using the `BoxLengthFirst` comparer and then by using the default comparer.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ComparerT/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ComparerT/Overview/program.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/ComparerT/Overview/program.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ComparerT/Overview/program.vb" id="Snippet1":::
 

--- a/xml/System.Collections.Generic/Dictionary`2.xml
+++ b/xml/System.Collections.Generic/Dictionary`2.xml
@@ -326,7 +326,7 @@
 ## Examples
  The following code example shows how to use the <xref:System.Collections.Generic.Dictionary%602.%23ctor%28System.Collections.Generic.IEqualityComparer%7B%600%7D%29> constructor to initialize a <xref:System.Collections.Generic.Dictionary%602> with sorted content from another dictionary. The code example creates a <xref:System.Collections.Generic.SortedDictionary%602> and populates it with data in random order, then passes the <xref:System.Collections.Generic.SortedDictionary%602> to the <xref:System.Collections.Generic.Dictionary%602.%23ctor%28System.Collections.Generic.IEqualityComparer%7B%600%7D%29> constructor, creating a <xref:System.Collections.Generic.Dictionary%602> that is sorted. This is useful if you need to build a sorted dictionary that at some point becomes static; copying the data from a <xref:System.Collections.Generic.SortedDictionary%602> to a <xref:System.Collections.Generic.Dictionary%602> improves retrieval speed.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source.vb" id="Snippet1":::
 
@@ -455,7 +455,7 @@
 ## Examples
  The following code example creates a <xref:System.Collections.Generic.Dictionary%602> with a case-insensitive equality comparer for the current culture. The example adds four elements, some with lower-case keys and some with upper-case keys. The example then attempts to add an element with a key that differs from an existing key only by case, catches the resulting exception, and displays an error message. Finally, the example displays the elements in the dictionary.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source2.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source2.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source2.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source2.vb" id="Snippet1":::
 
@@ -524,7 +524,7 @@
 ## Examples
  The following code example creates a dictionary with an initial capacity of 4 and populates it with 4 entries.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source3.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source3.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source3.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source3.vb" id="Snippet1":::
 
@@ -610,7 +610,7 @@
 > [!NOTE]
 >  When you create a new dictionary with a case-insensitive comparer and populate it with entries from a dictionary that uses a case-sensitive comparer, as in this example, an exception occurs if the input dictionary has keys that differ only by case.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source1.vb" id="Snippet1":::
 
@@ -753,7 +753,7 @@
 ## Examples
  The following code example creates a <xref:System.Collections.Generic.Dictionary%602> with an initial capacity of 5 and a case-insensitive equality comparer for the current culture. The example adds four elements, some with lower-case keys and some with upper-case keys. The example then attempts to add an element with a key that differs from an existing key only by case, catches the resulting exception, and displays an error message. Finally, the example displays the elements in the dictionary.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source4.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source4.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source4.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/DictionaryTKey,TValue/.ctor/source4.vb" id="Snippet1":::
 

--- a/xml/System.Collections.Generic/EqualityComparer`1.xml
+++ b/xml/System.Collections.Generic/EqualityComparer`1.xml
@@ -91,7 +91,7 @@ In .NET 8 and later versions, we recommend using the <xref:System.Collections.Ge
   
  The dictionary is recreated with an equality comparer that defines equality in a different way: Two boxes are considered equal if their volumes are the same.  
   
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/EqualityComparerT/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/EqualityComparerT/Overview/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/EqualityComparerT/Overview/program.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Generic/ICollection`1.xml
+++ b/xml/System.Collections.Generic/ICollection`1.xml
@@ -82,7 +82,7 @@
   
  This example also implements an <xref:System.Collections.Generic.IEnumerator%601> interface for the `BoxCollection` class so that the collection can be enumerated.  
  
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ICollectionT/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ICollectionT/Overview/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ICollectionT/Overview/program.vb" id="Snippet1":::
   
  ]]></format>

--- a/xml/System.Collections.Generic/IDictionary`2.xml
+++ b/xml/System.Collections.Generic/IDictionary`2.xml
@@ -111,7 +111,7 @@
 
  Finally, the example shows how to enumerate the keys and values in the dictionary, and how to enumerate the values alone using the <xref:System.Collections.Generic.IDictionary%602.Values%2A> property.
 
-  :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/IDictionaryTKey,TValue/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+  :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/IDictionaryTKey,TValue/Overview/source.cs" id="Snippet1":::
   :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/IDictionaryTKey,TValue/Overview/source.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Generic/IEqualityComparer`1.xml
+++ b/xml/System.Collections.Generic/IEqualityComparer`1.xml
@@ -74,7 +74,7 @@
 ## Examples  
  The following example adds custom `Box` objects to a dictionary collection. The `Box` objects are considered equal if their dimensions are the same.  
   
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/IEqualityComparerT/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/IEqualityComparerT/Overview/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/IEqualityComparerT/Overview/program.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Generic/LinkedListNode`1.xml
+++ b/xml/System.Collections.Generic/LinkedListNode`1.xml
@@ -77,7 +77,7 @@
 ## Examples
  The following code example creates a <xref:System.Collections.Generic.LinkedListNode%601>, adds it to a <xref:System.Collections.Generic.LinkedList%601>, and tracks the values of its properties as the <xref:System.Collections.Generic.LinkedList%601> changes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.vb" id="Snippet1":::
 
  ]]></format>
@@ -140,7 +140,7 @@
 ## Examples
  The following code example creates a <xref:System.Collections.Generic.LinkedListNode%601>, adds it to a <xref:System.Collections.Generic.LinkedList%601>, and tracks the values of its properties as the <xref:System.Collections.Generic.LinkedList%601> changes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.vb" id="Snippet1":::
 
  ]]></format>
@@ -203,7 +203,7 @@
 ## Examples
  The following code example creates a <xref:System.Collections.Generic.LinkedListNode%601>, adds it to a <xref:System.Collections.Generic.LinkedList%601>, and tracks the values of its properties as the <xref:System.Collections.Generic.LinkedList%601> changes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.vb" id="Snippet1":::
 
  ]]></format>
@@ -262,7 +262,7 @@
 ## Examples
  The following code example creates a <xref:System.Collections.Generic.LinkedListNode%601>, adds it to a <xref:System.Collections.Generic.LinkedList%601>, and tracks the values of its properties as the <xref:System.Collections.Generic.LinkedList%601> changes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.vb" id="Snippet1":::
 
  ]]></format>
@@ -321,7 +321,7 @@
 ## Examples
  The following code example creates a <xref:System.Collections.Generic.LinkedListNode%601>, adds it to a <xref:System.Collections.Generic.LinkedList%601>, and tracks the values of its properties as the <xref:System.Collections.Generic.LinkedList%601> changes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.vb" id="Snippet1":::
 
  ]]></format>
@@ -388,7 +388,7 @@
 ## Examples
  The following code example creates a <xref:System.Collections.Generic.LinkedListNode%601>, adds it to a <xref:System.Collections.Generic.LinkedList%601>, and tracks the values of its properties as the <xref:System.Collections.Generic.LinkedList%601> changes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/LinkedListNodeT/Overview/llnctor.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Generic/LinkedList`1.xml
+++ b/xml/System.Collections.Generic/LinkedList`1.xml
@@ -218,7 +218,7 @@
 ## Examples
  The following code example creates and initializes a <xref:System.Collections.Generic.LinkedList%601> of type <xref:System.String>, adds several nodes, and then displays its contents.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListT/.ctor/llctor.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/LinkedListT/.ctor/llctor.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/LinkedListT/.ctor/llctor.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Generic/List`1.xml
+++ b/xml/System.Collections.Generic/List`1.xml
@@ -247,7 +247,7 @@
 ## Examples
  The following example demonstrates the <xref:System.Collections.Generic.List%601.%23ctor%2A> constructor and various methods of the <xref:System.Collections.Generic.List%601> class that act on ranges. An array of strings is created and passed to the constructor, populating the list with the elements of the array. The <xref:System.Collections.Generic.List%601.Capacity%2A> property is then displayed, to show that the initial capacity is exactly what is required to hold the input elements.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/.ctor/source2.vb" id="Snippet1":::
 
  ]]></format>
@@ -318,7 +318,7 @@
 ## Examples
  The following example demonstrates the <xref:System.Collections.Generic.List%601.%23ctor%28System.Int32%29> constructor. A <xref:System.Collections.Generic.List%601> of strings with a capacity of 4 is created, because the ultimate size of the list is known to be exactly 4. The list is populated with four strings, and a read-only copy is created by using the <xref:System.Collections.Generic.List%601.AsReadOnly%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/.ctor/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -387,7 +387,7 @@
 
  The following example demonstrates how to add, remove, and insert a simple business object in a <xref:System.Collections.Generic.List%601>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Overview/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Add/module1.vb" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs" id="Snippet1":::
 
@@ -462,7 +462,7 @@
 ## Examples
  The following example demonstrates the <xref:System.Collections.Generic.List%601.AddRange%2A> method and various other methods of the <xref:System.Collections.Generic.List%601> class that act on ranges. An array of strings is created and passed to the constructor, populating the list with the elements of the array. The <xref:System.Collections.Generic.List%601.AddRange%2A> method is called, with the list as its argument. The result is that the current elements of the list are added to the end of the list, duplicating all the elements.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/.ctor/source2.vb" id="Snippet1":::
 
  ]]></format>
@@ -530,7 +530,7 @@
 
  An element of the original list is set to "Coelophysis" using the <xref:System.Collections.Generic.List%601.Item%2A> property (the indexer in C#), and the contents of the read-only list are displayed again to demonstrate that it is just a wrapper for the original list.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/.ctor/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -707,7 +707,7 @@
 
  The <xref:System.Collections.Generic.List%601.BinarySearch%28%600%2CSystem.Collections.Generic.IComparer%7B%600%7D%29> method overload is then used to search for several strings that are not in the list, employing the alternate comparer. The <xref:System.Collections.Generic.List%601.Insert%2A> method is used to insert the strings. These two methods are located in the function named `SearchAndInsert`, along with code to take the bitwise complement (the ~ operator in C#, `Xor` -1 in Visual Basic) of the negative number returned by <xref:System.Collections.Generic.List%601.BinarySearch%28%600%2CSystem.Collections.Generic.IComparer%7B%600%7D%29> and use it as an index for inserting the new string.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/BinarySearch/source1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/BinarySearch/source1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/BinarySearch/source1.vb" id="Snippet1":::
 
  ]]></format>
@@ -803,7 +803,7 @@
 
  The <xref:System.Collections.Generic.List%601.BinarySearch%28System.Int32%2CSystem.Int32%2C%600%2CSystem.Collections.Generic.IComparer%7B%600%7D%29> method overload is then used to search only the range of herbivores for "Brachiosaurus". The string is not found, and the bitwise complement (the ~ operator in C#, `Xor` -1 in Visual Basic) of the negative number returned by the <xref:System.Collections.Generic.List%601.BinarySearch%28System.Int32%2CSystem.Int32%2C%600%2CSystem.Collections.Generic.IComparer%7B%600%7D%29> method is used as an index for inserting the new string.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/BinarySearch/source2.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/BinarySearch/source2.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/BinarySearch/source2.vb" id="Snippet1":::
 
  ]]></format>
@@ -884,7 +884,7 @@
 
  The following example demonstrates how to check the capacity and count of a <xref:System.Collections.Generic.List%601> that contains a simple business object, and illustrates using the <xref:System.Collections.Generic.List%601.TrimExcess%2A> method to remove extra capacity.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Capacity/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Capacity/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Capacity/module1.vb" id="Snippet1":::
 
  The following example shows the <xref:System.Collections.Generic.List%601.Capacity%2A> property at several points in the life of a list. The parameterless constructor is used to create a list of strings with a capacity of 0, and the <xref:System.Collections.Generic.List%601.Capacity%2A> property is displayed to demonstrate this. After the <xref:System.Collections.Generic.List%601.Add%2A> method has been used to add several items, the items are listed, and then the <xref:System.Collections.Generic.List%601.Capacity%2A> property is displayed again, along with the <xref:System.Collections.Generic.List%601.Count%2A> property, to show that the capacity has been increased as needed.
@@ -1029,12 +1029,12 @@
 ## Examples
  The following example demonstrates the <xref:System.Collections.Generic.List%601.Contains%2A> and <xref:System.Collections.Generic.List%601.Exists%2A> methods on a <xref:System.Collections.Generic.List%601> that contains a simple business object that implements <xref:System.IEquatable%601.Equals%2A>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Contains/program1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Contains/program1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Contains/module1.vb" id="Snippet1":::
 
  The following example contains a list of complex objects of type `Cube`. The `Cube` class implements the <xref:System.IEquatable%601.Equals%2A?displayProperty=nameWithType> method so that two cubes are considered equal if their dimensions are the same. In this example, the <xref:System.Collections.Generic.List%601.Contains%2A> method returns `true`, because a cube that has the specified dimensions is already in the collection.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Contains/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Contains/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Contains/program.vb" id="Snippet1":::
 
  ]]></format>
@@ -1109,7 +1109,7 @@
 ## Examples
  The following example defines a method named `PointFToPoint` that converts a <xref:System.Drawing.PointF> structure to a <xref:System.Drawing.Point> structure. The example then creates a <xref:System.Collections.Generic.List%601> of <xref:System.Drawing.PointF> structures, creates a `Converter\<PointF, Point>` delegate (`Converter(Of PointF, Point)` in Visual Basic) to represent the `PointFToPoint` method, and passes the delegate to the <xref:System.Collections.Generic.List%601.ConvertAll%2A> method. The <xref:System.Collections.Generic.List%601.ConvertAll%2A> method passes each element of the input list to the `PointFToPoint` method and puts the converted elements into a new list of <xref:System.Drawing.Point> structures. Both lists are displayed.
 
- :::code language="csharp" source="~/snippets/csharp/System/ConverterTInput,TOutput/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System/ConverterTInput,TOutput/Overview/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System/ConverterTInput,TOutput/Overview/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -1134,7 +1134,7 @@
 ## Examples
  The following example demonstrates all three overloads of the <xref:System.Collections.Generic.List%601.CopyTo%2A> method. A <xref:System.Collections.Generic.List%601> of strings is created and populated with 5 strings. An empty string array of 15 elements is created, and the <xref:System.Collections.Generic.List%601.CopyTo%28%600%5B%5D%29> method overload is used to copy all the elements of the list to the array beginning at the first element of the array. The <xref:System.Collections.Generic.List%601.CopyTo%28%600%5B%5D%2CSystem.Int32%29> method overload is used to copy all the elements of the list to the array beginning at array index 6 (leaving index 5 empty). Finally, the <xref:System.Collections.Generic.List%601.CopyTo%28System.Int32%2C%600%5B%5D%2CSystem.Int32%2CSystem.Int32%29> method overload is used to copy 3 elements from the list, beginning with index 2, to the array beginning at array index 12 (leaving index 11 empty). The contents of the array are then displayed.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/CopyTo/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/CopyTo/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/CopyTo/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -1410,7 +1410,7 @@
 
  The following example demonstrates how to check the capacity and count of a  <xref:System.Collections.Generic.List%601> that contains a simple business object, and illustrates using the <xref:System.Collections.Generic.List%601.TrimExcess%2A> method to remove extra capacity.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Capacity/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Capacity/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Capacity/module1.vb" id="Snippet1":::
 
  The following example shows the value of the <xref:System.Collections.Generic.List%601.Count%2A> property at various points in the life of a list. After the list has been created and populated and its elements displayed, the <xref:System.Collections.Generic.List%601.Capacity%2A> and <xref:System.Collections.Generic.List%601.Count%2A> properties are displayed. These properties are displayed again after the <xref:System.Collections.Generic.List%601.TrimExcess%2A> method has been called, and again after the contents of the list are cleared.
@@ -1514,7 +1514,7 @@
 ## Examples
  The following example demonstrates the <xref:System.Collections.Generic.List%601.Contains%2A> and <xref:System.Collections.Generic.List%601.Exists%2A> methods on a <xref:System.Collections.Generic.List%601> that contains a simple business object that implements <xref:System.IEquatable%601.Equals%2A>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Contains/program1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Contains/program1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Contains/module1.vb" id="Snippet1":::
 
  The following example demonstrates the <xref:System.Collections.Generic.List%601.Exists%2A> method and several other methods that use the <xref:System.Predicate%601> generic delegate.
@@ -1528,7 +1528,7 @@
 > [!NOTE]
 > In C# and Visual Basic, it is not necessary to create the `Predicate<string>` delegate (`Predicate(Of String)` in Visual Basic) explicitly. These languages infer the correct delegate from context and create it automatically.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Exists/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Exists/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Exists/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -1605,7 +1605,7 @@
 ## Examples
  The following example demonstrates the <xref:System.Collections.Generic.List%601.Find%2A> method on a <xref:System.Collections.Generic.List%601> that contains a simple complex object.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Contains/program1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Contains/program1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Contains/module1.vb" id="Snippet1":::
 
  The following example demonstrates the find methods for the <xref:System.Collections.Generic.List%601> class. The example for the <xref:System.Collections.Generic.List%601> class contains `book` objects, of class `Book`, using the data from the [Sample XML File: Books (LINQ to XML)](/dotnet/standard/linq/sample-xml-file-books). The `FillList` method in the example uses [LINQ to XML](/dotnet/standard/linq/linq-xml-overview) to parse the values from the XML to property values of the `book` objects.
@@ -1809,7 +1809,7 @@ Public Function StartsWith(e As Employee) As Boolean
 
  corresponds to the signature of the delegate that can be passed to the <xref:System.Collections.Generic.List%601.FindIndex%2A> method. The example instantiates a `List<Employee>` object, adds a number of `Employee` objects to it, and then calls the <xref:System.Collections.Generic.List%601.FindIndex%28System.Int32%2CSystem.Int32%2CSystem.Predicate%7B%600%7D%29> method twice to search the entire collection, the first time for the first `Employee` object whose `Name` field begins with "J", and the second time for the first `Employee` object whose `Name` field begins with "Ju".
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/FindIndex/FindIndex2.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/FindIndex/FindIndex2.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/FindIndex/FindIndex2.vb" id="Snippet2":::
 
  ]]></format>
@@ -1903,7 +1903,7 @@ Public Function StartsWith(e As Employee) As Boolean
 
  corresponds to the signature of the delegate that can be passed to the <xref:System.Collections.Generic.List%601.FindIndex%2A> method. The example instantiates a `List<Employee>` object, adds a number of `Employee` objects to it, and then calls the <xref:System.Collections.Generic.List%601.FindIndex%28System.Int32%2CSystem.Int32%2CSystem.Predicate%7B%600%7D%29> method twice to search the collection starting with its fifth member (that is, the member at index 4). The first time, it searches for the first `Employee` object whose `Name` field begins with "J"; the second time, it searches for the first `Employee` object whose `Name` field begins with "Ju".
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/FindIndex/FindIndex3.cs" interactive="try-dotnet" id="Snippet3":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/FindIndex/FindIndex3.cs" id="Snippet3":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/FindIndex/FindIndex3.vb" id="Snippet3":::
 
  ]]></format>
@@ -2001,7 +2001,7 @@ Public Function StartsWith(e As Employee) As Boolean
 
  corresponds to the signature of the delegate that can be passed to the <xref:System.Collections.Generic.List%601.FindIndex%2A> method. The example instantiates a `List<Employee>` object, adds a number of `Employee` objects to it, and then calls the <xref:System.Collections.Generic.List%601.FindIndex%28System.Int32%2CSystem.Int32%2CSystem.Predicate%7B%600%7D%29> method twice to search the entire collection (that is, the members from index 0 to index <xref:System.Collections.Generic.List%601.Count%2A> - 1). The first time, it searches for the first `Employee` object whose `Name` field begins with "J"; the second time, it searches for the first `Employee` object whose `Name` field begins with "Ju".
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/FindIndex/FindIndex1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/FindIndex/FindIndex1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/FindIndex/FindIndex1.vb" id="Snippet1":::
 
  ]]></format>
@@ -2588,7 +2588,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Examples
  The following example demonstrates the <xref:System.Collections.Generic.List%601.GetRange%2A> method and other methods of the <xref:System.Collections.Generic.List%601> class that act on ranges. At the end of the example, the <xref:System.Collections.Generic.List%601.GetRange%2A> method is used to get three items from the list, beginning with index location 2. The <xref:System.Collections.Generic.List%601.ToArray%2A> method is called on the resulting <xref:System.Collections.Generic.List%601>, creating an array of three elements. The elements of the array are displayed.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/.ctor/source2.vb" id="Snippet1":::
 
  ]]></format>
@@ -2621,7 +2621,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Examples
  The following example demonstrates all three overloads of the <xref:System.Collections.Generic.List%601.IndexOf%2A> method. A <xref:System.Collections.Generic.List%601> of strings is created, with one entry that appears twice, at index location 0 and index location 5. The <xref:System.Collections.Generic.List%601.IndexOf%28%600%29> method overload searches the list from the beginning, and finds the first occurrence of the string. The <xref:System.Collections.Generic.List%601.IndexOf%28%600%2CSystem.Int32%29> method overload is used to search the list beginning with index location 3 and continuing to the end of the list, and finds the second occurrence of the string. Finally, the <xref:System.Collections.Generic.List%601.IndexOf%28%600%2CSystem.Int32%2CSystem.Int32%29> method overload is used to search a range of two entries, beginning at index location two; it returns -1 because there are no instances of the search string in that range.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/IndexOf/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/IndexOf/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/IndexOf/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -2898,7 +2898,7 @@ Public Function StartsWith(e As Employee) As Boolean
 
  The following example demonstrates how to add, remove, and insert a simple business object in a <xref:System.Collections.Generic.List%601>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Overview/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Add/module1.vb" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs" id="Snippet1":::
 
@@ -2982,7 +2982,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Examples
  The following example demonstrates <xref:System.Collections.Generic.List%601.InsertRange%2A> method and various other methods of the <xref:System.Collections.Generic.List%601> class that act on ranges. After the list has been created and populated with the names of several peaceful plant-eating dinosaurs, the <xref:System.Collections.Generic.List%601.InsertRange%2A> method is used to insert an array of three ferocious meat-eating dinosaurs into the list, beginning at index location 3.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/.ctor/source2.vb" id="Snippet1":::
 
  ]]></format>
@@ -3106,7 +3106,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Examples
  The following example demonstrates all three overloads of the <xref:System.Collections.Generic.List%601.LastIndexOf%2A> method. A <xref:System.Collections.Generic.List%601> of strings is created, with one entry that appears twice, at index location 0 and index location 5. The <xref:System.Collections.Generic.List%601.LastIndexOf%28%600%29> method overload searches the entire list from the end, and finds the second occurrence of the string. The <xref:System.Collections.Generic.List%601.LastIndexOf%28%600%2CSystem.Int32%29> method overload is used to search the list backward beginning with index location 3 and continuing to the beginning of the list, so it finds the first occurrence of the string in the list. Finally, the <xref:System.Collections.Generic.List%601.LastIndexOf%28%600%2CSystem.Int32%2CSystem.Int32%29> method overload is used to search a range of four entries, beginning at index location 4 and extending backward (that is, it searches the items at locations 4, 3, 2, and 1); this search returns -1 because there are no instances of the search string in that range.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/LastIndexOf/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/LastIndexOf/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/LastIndexOf/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -3376,7 +3376,7 @@ Public Function StartsWith(e As Employee) As Boolean
 
  The following example demonstrates how to add, remove, and insert a simple business object in a <xref:System.Collections.Generic.List%601>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Overview/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Add/module1.vb" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs" id="Snippet1":::
 
@@ -3460,7 +3460,7 @@ Public Function StartsWith(e As Employee) As Boolean
 
  Finally, the <xref:System.Collections.Generic.List%601.Exists%2A> method verifies that there are no strings in the list that end with "saurus".
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Exists/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Exists/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Exists/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -3531,7 +3531,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Examples
  The following example demonstrates how to add, remove, and insert a simple business object in a <xref:System.Collections.Generic.List%601>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Overview/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Add/module1.vb" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs" id="Snippet1":::
 
@@ -3604,7 +3604,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Examples
  The following example demonstrates the <xref:System.Collections.Generic.List%601.RemoveRange%2A> method and various other methods of the <xref:System.Collections.Generic.List%601> class that act on ranges. After the list has been created and modified, the <xref:System.Collections.Generic.List%601.RemoveRange%2A> method is used to remove two elements from the list, beginning at index location 2.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/.ctor/source2.vb" id="Snippet1":::
 
  ]]></format>
@@ -3639,7 +3639,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Examples
  The following example demonstrates both overloads of the <xref:System.Collections.Generic.List%601.Reverse%2A> method. The example creates a <xref:System.Collections.Generic.List%601> of strings and adds six strings. The <xref:System.Collections.Generic.List%601.Reverse> method overload is used to reverse the list, and then the <xref:System.Collections.Generic.List%601.Reverse%28System.Int32%2CSystem.Int32%29> method overload is used to reverse the middle of the list, beginning with element 1 and encompassing four elements.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Reverse/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Reverse/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Reverse/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -3880,7 +3880,7 @@ Public Function StartsWith(e As Employee) As Boolean
 
  The following code demonstrates the <xref:System.Collections.Generic.List%601.Sort> and <xref:System.Collections.Generic.List%601.Sort%28System.Comparison%7B%600%7D%29> method overloads on a simple business object. Calling the <xref:System.Collections.Generic.List%601.Sort> method results in the use of the default comparer for the Part type, and the <xref:System.Collections.Generic.List%601.Sort%28System.Comparison%7B%600%7D%29> method is implemented by using an anonymous method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Sort/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Sort/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Sort/module1.vb" id="Snippet1":::
 
  The following example demonstrates the <xref:System.Collections.Generic.List%601.Sort> method overload and the <xref:System.Collections.Generic.List%601.BinarySearch%28%600%29> method overload. A <xref:System.Collections.Generic.List%601> of strings is created and populated with four strings, in no particular order. The list is displayed, sorted, and displayed again.
@@ -3975,7 +3975,7 @@ Public Function StartsWith(e As Employee) As Boolean
 
  The <xref:System.Collections.Generic.List%601.BinarySearch%28%600%2CSystem.Collections.Generic.IComparer%7B%600%7D%29> method overload is then used to search for several strings that are not in the list, employing the alternate comparer. The <xref:System.Collections.Generic.List%601.Insert%2A> method is used to insert the strings. These two methods are located in the function named `SearchAndInsert`, along with code to take the bitwise complement (the ~ operator in C#, `Xor` -1 in Visual Basic) of the negative number returned by <xref:System.Collections.Generic.List%601.BinarySearch%28%600%2CSystem.Collections.Generic.IComparer%7B%600%7D%29> and use it as an index for inserting the new string.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/BinarySearch/source1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/BinarySearch/source1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/BinarySearch/source1.vb" id="Snippet1":::
 
  ]]></format>
@@ -4051,7 +4051,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Examples
  The following code demonstrates the <xref:System.Collections.Generic.List%601.Sort%2A> and <xref:System.Collections.Generic.List%601.Sort%2A> method overloads on a simple business object. Calling the <xref:System.Collections.Generic.List%601.Sort%2A> method results in the use of the default comparer for the Part type, and the <xref:System.Collections.Generic.List%601.Sort%2A> method is implemented using an anonymous method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Sort/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Sort/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Sort/module1.vb" id="Snippet1":::
 
  The following example demonstrates the <xref:System.Collections.Generic.List%601.Sort%28System.Comparison%7B%600%7D%29> method overload.
@@ -4060,7 +4060,7 @@ Public Function StartsWith(e As Employee) As Boolean
 
  A <xref:System.Collections.Generic.List%601> of strings is created and populated with four strings, in no particular order. The list also includes an empty string and a null reference. The list is displayed, sorted using a <xref:System.Comparison%601> generic delegate representing the `CompareDinosByLength` method, and displayed again.
 
- :::code language="csharp" source="~/snippets/csharp/System/ComparisonT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System/ComparisonT/Overview/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System/ComparisonT/Overview/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -4155,7 +4155,7 @@ Public Function StartsWith(e As Employee) As Boolean
 
  The <xref:System.Collections.Generic.List%601.BinarySearch%28System.Int32%2CSystem.Int32%2C%600%2CSystem.Collections.Generic.IComparer%7B%600%7D%29> method overload is then used to search only the range of herbivores for "Brachiosaurus". The string is not found, and the bitwise complement (the ~ operator in C#, `Xor` -1 in Visual Basic) of the negative number returned by the <xref:System.Collections.Generic.List%601.BinarySearch%28System.Int32%2CSystem.Int32%2C%600%2CSystem.Collections.Generic.IComparer%7B%600%7D%29> method is used as an index for inserting the new string.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/BinarySearch/source2.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/BinarySearch/source2.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/BinarySearch/source2.vb" id="Snippet1":::
 
  ]]></format>
@@ -5171,7 +5171,7 @@ Retrieving the value of this property is an O(1) operation.
 ## Examples
  The following example demonstrates the <xref:System.Collections.Generic.List%601.ToArray%2A> method and other methods of the <xref:System.Collections.Generic.List%601> class that act on ranges. At the end of the example, the <xref:System.Collections.Generic.List%601.GetRange%2A> method is used to get three items from the list, beginning with index location 2. The <xref:System.Collections.Generic.List%601.ToArray%2A> method is called on the resulting <xref:System.Collections.Generic.List%601>, creating an array of three elements. The elements of the array are displayed.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/.ctor/source1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/.ctor/source2.vb" id="Snippet1":::
 
  ]]></format>
@@ -5236,7 +5236,7 @@ Retrieving the value of this property is an O(1) operation.
 
  The following example demonstrates how to check the capacity and count of a  <xref:System.Collections.Generic.List%601> that contains a simple business object, and illustrates using the <xref:System.Collections.Generic.List%601.TrimExcess%2A> method to remove extra capacity.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Capacity/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Capacity/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Capacity/module1.vb" id="Snippet1":::
 
  The following example demonstrates the <xref:System.Collections.Generic.List%601.TrimExcess%2A> method. Several properties and methods of the <xref:System.Collections.Generic.List%601> class are used to add, insert, and remove items from a list of strings. Then the <xref:System.Collections.Generic.List%601.TrimExcess%2A> method is used to reduce the capacity to match the count, and the <xref:System.Collections.Generic.List%601.Capacity%2A> and <xref:System.Collections.Generic.List%601.Count%2A> properties are displayed. If the unused capacity had been less than 10 percent of total capacity, the list would not have been resized. Finally, the contents of the list are cleared.
@@ -5314,7 +5314,7 @@ Retrieving the value of this property is an O(1) operation.
 > [!NOTE]
 > In C# and Visual Basic, it is not necessary to create the `Predicate<string>` delegate (`Predicate(Of String)` in Visual Basic) explicitly. These languages infer the correct delegate from context and create it automatically.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Exists/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/ListT/Exists/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/ListT/Exists/source.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Generic/Queue`1.xml
+++ b/xml/System.Collections.Generic/Queue`1.xml
@@ -128,7 +128,7 @@
 
  The <xref:System.Collections.Generic.Queue%601.Contains%2A> method is used to show that the string "four" is in the first copy of the queue, after which the <xref:System.Collections.Generic.Queue%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Queue%601.Count%2A> property shows that the queue is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/QueueT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/QueueT/Overview/source.vb" id="Snippet1":::
 
@@ -161,7 +161,7 @@
 
  The <xref:System.Collections.Generic.Queue%601.Contains%2A> method is used to show that the string "four" is in the first copy of the queue, after which the <xref:System.Collections.Generic.Queue%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Queue%601.Count%2A> property shows that the queue is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/QueueT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/QueueT/Overview/source.vb" id="Snippet1":::
 
@@ -426,7 +426,7 @@
 
  The <xref:System.Collections.Generic.Queue%601.Contains%2A> method is used to show that the string "four" is in the first copy of the queue, after which the <xref:System.Collections.Generic.Queue%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Queue%601.Count%2A> property shows that the queue is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/QueueT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/QueueT/Overview/source.vb" id="Snippet1":::
 
@@ -500,7 +500,7 @@
 
  The <xref:System.Collections.Generic.Queue%601.Contains%2A> method is used to show that the string "four" is in the first copy of the queue, after which the <xref:System.Collections.Generic.Queue%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Queue%601.Count%2A> property shows that the queue is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/QueueT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/QueueT/Overview/source.vb" id="Snippet1":::
 
@@ -642,7 +642,7 @@
 
  The <xref:System.Collections.Generic.Queue%601.Contains%2A> method is used to show that the string "four" is in the first copy of the queue, after which the <xref:System.Collections.Generic.Queue%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Queue%601.Count%2A> property shows that the queue is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/QueueT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/QueueT/Overview/source.vb" id="Snippet1":::
 
@@ -713,7 +713,7 @@
 
  The <xref:System.Collections.Generic.Queue%601.Contains%2A> method is used to show that the string "four" is in the first copy of the queue, after which the <xref:System.Collections.Generic.Queue%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Queue%601.Count%2A> property shows that the queue is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/QueueT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/QueueT/Overview/source.vb" id="Snippet1":::
 
@@ -787,7 +787,7 @@
 
  The <xref:System.Collections.Generic.Queue%601.Contains%2A> method is used to show that the string "four" is in the first copy of the queue, after which the <xref:System.Collections.Generic.Queue%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Queue%601.Count%2A> property shows that the queue is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/QueueT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/QueueT/Overview/source.vb" id="Snippet1":::
 
@@ -907,7 +907,7 @@
 
  The <xref:System.Collections.Generic.Queue%601.Contains%2A> method is used to show that the string "four" is in the first copy of the queue, after which the <xref:System.Collections.Generic.Queue%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Queue%601.Count%2A> property shows that the queue is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/QueueT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/QueueT/Overview/source.vb" id="Snippet1":::
 
@@ -980,7 +980,7 @@
 
  The <xref:System.Collections.Generic.Queue%601.Contains%2A> method is used to show that the string "four" is in the first copy of the queue, after which the <xref:System.Collections.Generic.Queue%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Queue%601.Count%2A> property shows that the queue is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/QueueT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/QueueT/Overview/source.vb" id="Snippet1":::
 
@@ -1409,7 +1409,7 @@ Retrieving the value of this property is an O(1) operation.
 
  The <xref:System.Collections.Generic.Queue%601.Contains%2A> method is used to show that the string "four" is in the first copy of the queue, after which the <xref:System.Collections.Generic.Queue%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Queue%601.Count%2A> property shows that the queue is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/QueueT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/QueueT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/QueueT/Overview/source.vb" id="Snippet1":::
 

--- a/xml/System.Collections.Generic/SortedDictionary`2.xml
+++ b/xml/System.Collections.Generic/SortedDictionary`2.xml
@@ -301,7 +301,7 @@
 ## Examples
  The following code example creates a <xref:System.Collections.Generic.SortedDictionary%602> with a case-insensitive comparer for the current culture. The example adds four elements, some with lower-case keys and some with upper-case keys. The example then attempts to add an element with a key that differs from an existing key only by case, catches the resulting exception, and displays an error message. Finally, the example displays the elements in case-insensitive sort order.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedDictionaryTKey,TValue/.ctor/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedDictionaryTKey,TValue/.ctor/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/SortedDictionaryTKey,TValue/.ctor/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -372,7 +372,7 @@
 ## Examples
  The following code example shows how to use <xref:System.Collections.Generic.SortedDictionary%602> to create a sorted copy of the information in a <xref:System.Collections.Generic.Dictionary%602>, by passing the <xref:System.Collections.Generic.Dictionary%602> to the <xref:System.Collections.Generic.SortedDictionary%602.%23ctor%28System.Collections.Generic.IComparer%7B%600%7D%29> constructor.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedDictionaryTKey,TValue/.ctor/source1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedDictionaryTKey,TValue/.ctor/source1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/SortedDictionaryTKey,TValue/.ctor/source1.vb" id="Snippet1":::
 
  ]]></format>
@@ -451,7 +451,7 @@
 ## Examples
  The following code example shows how to use <xref:System.Collections.Generic.SortedDictionary%602> to create a case-insensitive sorted copy of the information in a case-insensitive <xref:System.Collections.Generic.Dictionary%602>, by passing the <xref:System.Collections.Generic.Dictionary%602> to the <xref:System.Collections.Generic.SortedDictionary%602.%23ctor%28System.Collections.Generic.IDictionary%7B%600%2C%601%7D%2CSystem.Collections.Generic.IComparer%7B%600%7D%29> constructor. In this example, the case-insensitive comparers are for the current culture.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedDictionaryTKey,TValue/.ctor/source2.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedDictionaryTKey,TValue/.ctor/source2.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/SortedDictionaryTKey,TValue/.ctor/source2.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Generic/SortedList`2.xml
+++ b/xml/System.Collections.Generic/SortedList`2.xml
@@ -317,7 +317,7 @@
 ## Examples
  The following code example creates a sorted list with a case-insensitive comparer for the current culture. The example adds four elements, some with lower-case keys and some with upper-case keys. The example then attempts to add an element with a key that differs from an existing key only by case, catches the resulting exception, and displays an error message. Finally, the example displays the elements in case-insensitive sort order.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedListTKey,TValue/.ctor/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedListTKey,TValue/.ctor/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/SortedListTKey,TValue/.ctor/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -389,7 +389,7 @@
 ## Examples
  The following code example shows how to use <xref:System.Collections.Generic.SortedList%602> to create a sorted copy of the information in a <xref:System.Collections.Generic.Dictionary%602>, by passing the <xref:System.Collections.Generic.Dictionary%602> to the <xref:System.Collections.Generic.SortedList%602.%23ctor%28System.Collections.Generic.IDictionary%7B%600%2C%601%7D%29> constructor.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedListTKey,TValue/.ctor/source1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedListTKey,TValue/.ctor/source1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/SortedListTKey,TValue/.ctor/source1.vb" id="Snippet1":::
 
  ]]></format>
@@ -463,7 +463,7 @@
 ## Examples
  The following code example creates a sorted list with an initial capacity of 4 and populates it with 4 entries.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedListTKey,TValue/.ctor/source3.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedListTKey,TValue/.ctor/source3.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/SortedListTKey,TValue/.ctor/source3.vb" id="Snippet1":::
 
  ]]></format>
@@ -543,7 +543,7 @@
 ## Examples
  The following code example shows how to use <xref:System.Collections.Generic.SortedList%602> to create a case-insensitive sorted copy of the information in a case-insensitive <xref:System.Collections.Generic.Dictionary%602>, by passing the <xref:System.Collections.Generic.Dictionary%602> to the <xref:System.Collections.Generic.SortedList%602.%23ctor%28System.Collections.Generic.IDictionary%7B%600%2C%601%7D%2CSystem.Collections.Generic.IComparer%7B%600%7D%29> constructor. In this example, the case-insensitive comparers are for the current culture.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedListTKey,TValue/.ctor/source2.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedListTKey,TValue/.ctor/source2.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/SortedListTKey,TValue/.ctor/source2.vb" id="Snippet1":::
 
  ]]></format>
@@ -630,7 +630,7 @@
 ## Examples
  The following code example creates a sorted list with an initial capacity of 5 and a case-insensitive comparer for the current culture. The example adds four elements, some with lower-case keys and some with upper-case keys. The example then attempts to add an element with a key that differs from an existing key only by case, catches the resulting exception, and displays an error message. Finally, the example displays the elements in case-insensitive sort order.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedListTKey,TValue/.ctor/source4.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/SortedListTKey,TValue/.ctor/source4.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/SortedListTKey,TValue/.ctor/source4.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Generic/Stack`1.xml
+++ b/xml/System.Collections.Generic/Stack`1.xml
@@ -136,7 +136,7 @@
 
  The <xref:System.Collections.Generic.Stack%601.Contains%2A> method is used to show that the string "four" is in the first copy of the stack, after which the <xref:System.Collections.Generic.Stack%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Stack%601.Count%2A> property shows that the stack is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/StackT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/StackT/Overview/source.vb" id="Snippet1":::
 
@@ -220,7 +220,7 @@
 
  The <xref:System.Collections.Generic.Stack%601.Contains%2A> method is used to show that the string "four" is in the first copy of the stack, after which the <xref:System.Collections.Generic.Stack%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Stack%601.Count%2A> property shows that the stack is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/StackT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/StackT/Overview/source.vb" id="Snippet1":::
 
@@ -294,7 +294,7 @@
 
  The <xref:System.Collections.Generic.Stack%601.Contains%2A> method is used to show that the string "four" is in the first copy of the stack, after which the <xref:System.Collections.Generic.Stack%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Stack%601.Count%2A> property shows that the stack is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/StackT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/StackT/Overview/source.vb" id="Snippet1":::
 
@@ -453,7 +453,7 @@
 
  The <xref:System.Collections.Generic.Stack%601.Contains%2A> method is used to show that the string "four" is in the first copy of the stack, after which the <xref:System.Collections.Generic.Stack%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Stack%601.Count%2A> property shows that the stack is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/StackT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/StackT/Overview/source.vb" id="Snippet1":::
 
@@ -526,7 +526,7 @@
 
  The <xref:System.Collections.Generic.Stack%601.Contains%2A> method is used to show that the string "four" is in the first copy of the stack, after which the <xref:System.Collections.Generic.Stack%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Stack%601.Count%2A> property shows that the stack is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/StackT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/StackT/Overview/source.vb" id="Snippet1":::
 
@@ -600,7 +600,7 @@
 
  The <xref:System.Collections.Generic.Stack%601.Contains%2A> method is used to show that the string "four" is in the first copy of the stack, after which the <xref:System.Collections.Generic.Stack%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Stack%601.Count%2A> property shows that the stack is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/StackT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/StackT/Overview/source.vb" id="Snippet1":::
 
@@ -686,7 +686,7 @@
 
  The <xref:System.Collections.Generic.Stack%601.Contains%2A> method is used to show that the string "four" is in the first copy of the stack, after which the <xref:System.Collections.Generic.Stack%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Stack%601.Count%2A> property shows that the stack is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/StackT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/StackT/Overview/source.vb" id="Snippet1":::
 
@@ -802,7 +802,7 @@
 
  The <xref:System.Collections.Generic.Stack%601.Contains%2A> method is used to show that the string "four" is in the first copy of the stack, after which the <xref:System.Collections.Generic.Stack%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Stack%601.Count%2A> property shows that the stack is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/StackT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/StackT/Overview/source.vb" id="Snippet1":::
 
@@ -875,7 +875,7 @@
 
  The <xref:System.Collections.Generic.Stack%601.Contains%2A> method is used to show that the string "four" is in the first copy of the stack, after which the <xref:System.Collections.Generic.Stack%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Stack%601.Count%2A> property shows that the stack is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/StackT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/StackT/Overview/source.vb" id="Snippet1":::
 
@@ -949,7 +949,7 @@
 
  The <xref:System.Collections.Generic.Stack%601.Contains%2A> method is used to show that the string "four" is in the first copy of the stack, after which the <xref:System.Collections.Generic.Stack%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Stack%601.Count%2A> property shows that the stack is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/StackT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/StackT/Overview/source.vb" id="Snippet1":::
 
@@ -1027,7 +1027,7 @@
 
  The <xref:System.Collections.Generic.Stack%601.Contains%2A> method is used to show that the string "four" is in the first copy of the stack, after which the <xref:System.Collections.Generic.Stack%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Stack%601.Count%2A> property shows that the stack is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/StackT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/StackT/Overview/source.vb" id="Snippet1":::
 
@@ -1453,7 +1453,7 @@ Retrieving the value of this property is an O(1) operation.
 
  The <xref:System.Collections.Generic.Stack%601.Contains%2A> method is used to show that the string "four" is in the first copy of the stack, after which the <xref:System.Collections.Generic.Stack%601.Clear%2A> method clears the copy and the <xref:System.Collections.Generic.Stack%601.Count%2A> property shows that the stack is empty.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Generic/StackT/Overview/source.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Collections.Generic/StackT/Overview/source.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Generic/StackT/Overview/source.vb" id="Snippet1":::
 

--- a/xml/System.Collections.Specialized/BitVector32+Section.xml
+++ b/xml/System.Collections.Specialized/BitVector32+Section.xml
@@ -71,7 +71,7 @@
 ## Examples
  The following code example uses a <xref:System.Collections.Specialized.BitVector32> as a collection of sections.
   
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/BitVector32+Section/Overview/bitvector32_sections.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/BitVector32+Section/Overview/bitvector32_sections.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/BitVector32+Section/Overview/bitvector32_sections.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Specialized/BitVector32.xml
+++ b/xml/System.Collections.Specialized/BitVector32.xml
@@ -70,12 +70,12 @@
 ## Examples
  The following code example uses a <xref:System.Collections.Specialized.BitVector32> as a collection of bit flags.
   
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/BitVector32/Overview/bitvector32_bitflags.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/BitVector32/Overview/bitvector32_bitflags.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/BitVector32/Overview/bitvector32_bitflags.vb" id="Snippet1":::
 
  The following code example uses a <xref:System.Collections.Specialized.BitVector32> as a collection of sections.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/BitVector32+Section/Overview/bitvector32_sections.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/BitVector32+Section/Overview/bitvector32_sections.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/BitVector32+Section/Overview/bitvector32_sections.vb" id="Snippet1":::
 
  ]]></format>
@@ -213,7 +213,7 @@
 ## Examples
  The following code example shows how to create and use masks.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/BitVector32/CreateMask/bitvector32_createmasks.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/BitVector32/CreateMask/bitvector32_createmasks.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/BitVector32/CreateMask/bitvector32_createmasks.vb" id="Snippet1":::
 
  ]]></format>
@@ -363,7 +363,7 @@
 ## Examples
  The following code example uses a <xref:System.Collections.Specialized.BitVector32> as a collection of sections.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/BitVector32+Section/Overview/bitvector32_sections.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/BitVector32+Section/Overview/bitvector32_sections.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/BitVector32+Section/Overview/bitvector32_sections.vb" id="Snippet1":::
 
  ]]></format>
@@ -664,7 +664,7 @@
 ## Examples
  The following code example compares a <xref:System.Collections.Specialized.BitVector32> with another <xref:System.Collections.Specialized.BitVector32> and with an <xref:System.Int32>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/BitVector32/Equals/bitvector32_equals.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/BitVector32/Equals/bitvector32_equals.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/BitVector32/Equals/bitvector32_equals.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Specialized/HybridDictionary.xml
+++ b/xml/System.Collections.Specialized/HybridDictionary.xml
@@ -91,7 +91,7 @@
 ## Examples
  The following code example demonstrates several of the properties and methods of <xref:System.Collections.Specialized.HybridDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Overview/hybriddictionary.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Overview/hybriddictionary.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/HybridDictionary/Overview/hybriddictionary.vb" id="Snippet1":::
 
  ]]></format>
@@ -177,7 +177,7 @@
 ## Examples
  The following code example demonstrates several of the properties and methods of <xref:System.Collections.Specialized.HybridDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Overview/hybriddictionary.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Overview/hybriddictionary.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/HybridDictionary/Overview/hybriddictionary.vb" id="Snippet1":::
 
  ]]></format>
@@ -441,7 +441,7 @@
 ## Examples
  The following code example adds to and removes elements from a <xref:System.Collections.Specialized.HybridDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Add/hybriddictionary_addremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Add/hybriddictionary_addremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/HybridDictionary/Add/hybriddictionary_addremove.vb" id="Snippet1":::
 
  ]]></format>
@@ -512,7 +512,7 @@
 ## Examples
  The following code example adds to and removes elements from a <xref:System.Collections.Specialized.HybridDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Add/hybriddictionary_addremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Add/hybriddictionary_addremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/HybridDictionary/Add/hybriddictionary_addremove.vb" id="Snippet1":::
 
  ]]></format>
@@ -579,7 +579,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example searches for an element in a <xref:System.Collections.Specialized.HybridDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Contains/hybriddictionary_contains.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Contains/hybriddictionary_contains.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/HybridDictionary/Contains/hybriddictionary_contains.vb" id="Snippet1":::
 
  ]]></format>
@@ -653,7 +653,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example copies the elements of a <xref:System.Collections.Specialized.HybridDictionary> to an array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/CopyTo/hybriddictionary_copyto.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/CopyTo/hybriddictionary_copyto.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/HybridDictionary/CopyTo/hybriddictionary_copyto.vb" id="Snippet1":::
 
  ]]></format>
@@ -801,7 +801,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example enumerates the elements of a <xref:System.Collections.Specialized.HybridDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Count/hybriddictionary_enumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Count/hybriddictionary_enumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/HybridDictionary/Count/hybriddictionary_enumerator.vb" id="Snippet1":::
 
  ]]></format>
@@ -1069,7 +1069,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example enumerates the elements of a <xref:System.Collections.Specialized.HybridDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Count/hybriddictionary_enumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Count/hybriddictionary_enumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/HybridDictionary/Count/hybriddictionary_enumerator.vb" id="Snippet1":::
 
  ]]></format>
@@ -1138,7 +1138,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example enumerates the elements of a <xref:System.Collections.Specialized.HybridDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Count/hybriddictionary_enumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Count/hybriddictionary_enumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/HybridDictionary/Count/hybriddictionary_enumerator.vb" id="Snippet1":::
 
  ]]></format>
@@ -1208,7 +1208,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example adds to and removes elements from a <xref:System.Collections.Specialized.HybridDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Add/hybriddictionary_addremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Add/hybriddictionary_addremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/HybridDictionary/Add/hybriddictionary_addremove.vb" id="Snippet1":::
 
  ]]></format>
@@ -1422,7 +1422,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example enumerates the elements of a <xref:System.Collections.Specialized.HybridDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Count/hybriddictionary_enumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/HybridDictionary/Count/hybriddictionary_enumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/HybridDictionary/Count/hybriddictionary_enumerator.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Specialized/IOrderedDictionary.xml
+++ b/xml/System.Collections.Specialized/IOrderedDictionary.xml
@@ -75,7 +75,7 @@
 ## Examples
  The following code example demonstrates the implementation of a simple <xref:System.Collections.Specialized.IOrderedDictionary> based on the <xref:System.Collections.ArrayList> class. The implemented <xref:System.Collections.Specialized.IOrderedDictionary> stores first names as the keys and last names as the values, with the added requirement that each first name is unique.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/IOrderedDictionary/Overview/iordereddictionary.cs" interactive="try-dotnet" id="Snippet00":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/IOrderedDictionary/Overview/iordereddictionary.cs" id="Snippet00":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/IOrderedDictionary/Overview/iordereddictionary.vb" id="Snippet00":::
 
  ]]></format>

--- a/xml/System.Collections.Specialized/ListDictionary.xml
+++ b/xml/System.Collections.Specialized/ListDictionary.xml
@@ -91,7 +91,7 @@
 ## Examples
  The following code example demonstrates several of the properties and methods of <xref:System.Collections.Specialized.ListDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Overview/listdictionary.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Overview/listdictionary.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/Overview/listdictionary.vb" id="Snippet1":::
 
  ]]></format>
@@ -171,7 +171,7 @@
 ## Examples
  The following code example demonstrates several of the properties and methods of <xref:System.Collections.Specialized.ListDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Overview/listdictionary.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Overview/listdictionary.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/Overview/listdictionary.vb" id="Snippet1":::
 
  ]]></format>
@@ -318,7 +318,7 @@
 ## Examples
  The following code example adds to and removes elements from a <xref:System.Collections.Specialized.ListDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Add/listdictionary_addremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Add/listdictionary_addremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/Add/listdictionary_addremove.vb" id="Snippet1":::
 
  ]]></format>
@@ -387,7 +387,7 @@
 ## Examples
  The following code example adds to and removes elements from a <xref:System.Collections.Specialized.ListDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Add/listdictionary_addremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Add/listdictionary_addremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/Add/listdictionary_addremove.vb" id="Snippet1":::
 
  ]]></format>
@@ -454,7 +454,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example searches for an element in a <xref:System.Collections.Specialized.ListDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Contains/listdictionary_contains.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Contains/listdictionary_contains.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/Contains/listdictionary_contains.vb" id="Snippet1":::
 
  ]]></format>
@@ -530,7 +530,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example copies the elements of a <xref:System.Collections.Specialized.ListDictionary> to an array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/CopyTo/listdictionary_copyto.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/CopyTo/listdictionary_copyto.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/CopyTo/listdictionary_copyto.vb" id="Snippet1":::
 
  ]]></format>
@@ -611,7 +611,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example enumerates the elements of a <xref:System.Collections.Specialized.ListDictionary>.
 
-:::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.cs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.vb" id="Snippet1":::
 
  ]]></format>
@@ -687,7 +687,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example enumerates the elements of a <xref:System.Collections.Specialized.ListDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.vb" id="Snippet1":::
 
  ]]></format>
@@ -955,7 +955,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example enumerates the elements of a <xref:System.Collections.Specialized.ListDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.vb" id="Snippet1":::
 
  ]]></format>
@@ -1024,7 +1024,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example enumerates the elements of a <xref:System.Collections.Specialized.ListDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.vb" id="Snippet1":::
 
  ]]></format>
@@ -1092,7 +1092,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example adds to and removes elements from a <xref:System.Collections.Specialized.ListDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Add/listdictionary_addremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Add/listdictionary_addremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/Add/listdictionary_addremove.vb" id="Snippet1":::
 
  ]]></format>
@@ -1239,7 +1239,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example enumerates the elements of a <xref:System.Collections.Specialized.ListDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.vb" id="Snippet1":::
 
  ]]></format>
@@ -1306,7 +1306,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example enumerates the elements of a <xref:System.Collections.Specialized.ListDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/ListDictionary/Count/listdictionary_enumerator.vb" id="Snippet1":::
 
 

--- a/xml/System.Collections.Specialized/NameObjectCollectionBase.xml
+++ b/xml/System.Collections.Specialized/NameObjectCollectionBase.xml
@@ -99,7 +99,7 @@
 ## Examples
  The following code example shows how to implement and use the <xref:System.Collections.Specialized.NameObjectCollectionBase> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/Overview/nameobjectcollectionbase.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/Overview/nameobjectcollectionbase.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/NameObjectCollectionBase/Overview/nameobjectcollectionbase.vb" id="Snippet1":::
 
  ]]></format>
@@ -644,7 +644,7 @@
 ## Examples
  The following code example uses <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseAdd%2A> to create a new <xref:System.Collections.Specialized.NameObjectCollectionBase> with elements from an <xref:System.Collections.IDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseAdd/nocb_baseadd.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseAdd/nocb_baseadd.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/NameObjectCollectionBase/BaseAdd/nocb_baseadd.vb" id="Snippet1":::
 
  ]]></format>
@@ -705,7 +705,7 @@
 ## Examples
  The following code example uses <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseClear%2A> to remove all elements from a <xref:System.Collections.Specialized.NameObjectCollectionBase>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseClear/nocb_baseclear.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseClear/nocb_baseclear.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/NameObjectCollectionBase/BaseClear/nocb_baseclear.vb" id="Snippet1":::
 
  ]]></format>
@@ -727,7 +727,7 @@
 ## Examples
  The following code example uses <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseGetKey%2A> and <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseGet%2A> to get specific keys and values.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseGetKey/nocb_baseget.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseGetKey/nocb_baseget.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/NameObjectCollectionBase/BaseGetKey/nocb_baseget.vb" id="Snippet1":::
 
  ]]></format>
@@ -905,7 +905,7 @@
 ## Examples
  The following code example uses <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseGetAllKeys%2A> and <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseGetAllValues%2A> to get an array of the keys or an array of the values.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseGetAllKeys/nocb_basegetall.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseGetAllKeys/nocb_basegetall.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/NameObjectCollectionBase/BaseGetAllKeys/nocb_basegetall.vb" id="Snippet1":::
 
  ]]></format>
@@ -975,7 +975,7 @@
 ## Examples
  The following code example uses <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseGetAllKeys%2A> and <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseGetAllValues%2A> to get an array of the keys or an array of the values.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseGetAllKeys/nocb_basegetall.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseGetAllKeys/nocb_basegetall.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/NameObjectCollectionBase/BaseGetAllKeys/nocb_basegetall.vb" id="Snippet1":::
 
  ]]></format>
@@ -1098,7 +1098,7 @@
 ## Examples
  The following code example uses <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseGetKey%2A> and <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseGet%2A> to get specific keys and values.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseGetKey/nocb_baseget.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseGetKey/nocb_baseget.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/NameObjectCollectionBase/BaseGetKey/nocb_baseget.vb" id="Snippet1":::
 
  ]]></format>
@@ -1160,7 +1160,7 @@
 ## Examples
  The following code example uses <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseHasKeys%2A> to determine if the collection contains keys that are not `null`.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseHasKeys/nocb_basehaskeys.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseHasKeys/nocb_basehaskeys.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/NameObjectCollectionBase/BaseHasKeys/nocb_basehaskeys.vb" id="Snippet1":::
 
  ]]></format>
@@ -1291,7 +1291,7 @@
 ## Examples
  The following code example uses <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseRemove%2A> and <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseRemoveAt%2A> to remove elements from a <xref:System.Collections.Specialized.NameObjectCollectionBase>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseRemove/nocb_baseremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseRemove/nocb_baseremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/NameObjectCollectionBase/BaseRemove/nocb_baseremove.vb" id="Snippet1":::
 
  ]]></format>
@@ -1315,7 +1315,7 @@
 ## Examples
  The following code example uses <xref:System.Collections.Specialized.NameObjectCollectionBase.BaseSet%2A> to set the value of a specific element.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseSet/nocb_baseset.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/BaseSet/nocb_baseset.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/NameObjectCollectionBase/BaseSet/nocb_baseset.vb" id="Snippet1":::
 
  ]]></format>
@@ -1709,7 +1709,7 @@
 ## Examples
  The following code example creates a read-only collection.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/IsReadOnly/nocb_isreadonly.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameObjectCollectionBase/IsReadOnly/nocb_isreadonly.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/NameObjectCollectionBase/IsReadOnly/nocb_isreadonly.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Specialized/NameValueCollection.xml
+++ b/xml/System.Collections.Specialized/NameValueCollection.xml
@@ -79,7 +79,7 @@
 > The <xref:System.Collections.Specialized.NameValueCollection.Get%2A> method does not distinguish between `null` that's returned because the specified key is not found and `null` that's returned because the value associated with the key is `null`.
 
 ## Examples
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameValueCollection/Overview/nvc.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/NameValueCollection/Overview/nvc.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/NameValueCollection/Overview/nvc.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Specialized/OrderedDictionary.xml
+++ b/xml/System.Collections.Specialized/OrderedDictionary.xml
@@ -104,7 +104,7 @@
 ## Examples
  The following code example demonstrates the creation, population and modification of an <xref:System.Collections.Specialized.OrderedDictionary> collection, as well as two techniques to display the contents of the <xref:System.Collections.Specialized.OrderedDictionary>: one using the <xref:System.Collections.Specialized.OrderedDictionary.Keys%2A> and <xref:System.Collections.Specialized.OrderedDictionary.Values%2A> properties and the other creating an enumerator through the <xref:System.Collections.Specialized.OrderedDictionary.GetEnumerator%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/OrderedDictionary/Overview/OrderedDictionary1.cs" interactive="try-dotnet" id="Snippet00":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/OrderedDictionary/Overview/OrderedDictionary1.cs" id="Snippet00":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/OrderedDictionary/Overview/OrderedDictionary1.vb" id="Snippet00":::
 
  ]]></format>

--- a/xml/System.Collections.Specialized/StringCollection.xml
+++ b/xml/System.Collections.Specialized/StringCollection.xml
@@ -82,7 +82,7 @@
 ## Examples
  The following code example demonstrates several of the properties and methods of <xref:System.Collections.Specialized.StringCollection>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Overview/stringcollection.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Overview/stringcollection.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringCollection/Overview/stringcollection.vb" id="Snippet1":::
 
  ]]></format>
@@ -199,7 +199,7 @@
 ## Examples
  The following code example adds new elements to the <xref:System.Collections.Specialized.StringCollection>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Add/stringcollectionadd.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Add/stringcollectionadd.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringCollection/Add/stringcollectionadd.vb" id="Snippet1":::
 
  ]]></format>
@@ -272,7 +272,7 @@
 ## Examples
  The following code example adds new elements to the <xref:System.Collections.Specialized.StringCollection>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Add/stringcollectionadd.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Add/stringcollectionadd.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringCollection/Add/stringcollectionadd.vb" id="Snippet1":::
 
  ]]></format>
@@ -339,7 +339,7 @@
 ## Examples
  The following code example removes elements from the <xref:System.Collections.Specialized.StringCollection>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Clear/stringcollectionremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Clear/stringcollectionremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringCollection/Clear/stringcollectionremove.vb" id="Snippet1":::
 
  ]]></format>
@@ -408,7 +408,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example searches the <xref:System.Collections.Specialized.StringCollection> for an element.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Contains/stringcollectioncontains.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Contains/stringcollectioncontains.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringCollection/Contains/stringcollectioncontains.vb" id="Snippet1":::
 
  ]]></format>
@@ -485,7 +485,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example copies a <xref:System.Collections.Specialized.StringCollection> to an array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/CopyTo/stringcollectioncopyto.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/CopyTo/stringcollectioncopyto.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringCollection/CopyTo/stringcollectioncopyto.vb" id="Snippet1":::
 
  ]]></format>
@@ -559,7 +559,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example copies a <xref:System.Collections.Specialized.StringCollection> to an array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/CopyTo/stringcollectioncopyto.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/CopyTo/stringcollectioncopyto.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringCollection/CopyTo/stringcollectioncopyto.vb" id="Snippet1":::
 
  ]]></format>
@@ -692,7 +692,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example searches the <xref:System.Collections.Specialized.StringCollection> for an element.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Contains/stringcollectioncontains.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Contains/stringcollectioncontains.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringCollection/Contains/stringcollectioncontains.vb" id="Snippet1":::
 
  ]]></format>
@@ -764,7 +764,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example adds new elements to the <xref:System.Collections.Specialized.StringCollection>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Add/stringcollectionadd.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Add/stringcollectionadd.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringCollection/Add/stringcollectionadd.vb" id="Snippet1":::
 
  ]]></format>
@@ -1034,7 +1034,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example removes elements from the <xref:System.Collections.Specialized.StringCollection>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Clear/stringcollectionremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Clear/stringcollectionremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringCollection/Clear/stringcollectionremove.vb" id="Snippet1":::
 
  ]]></format>
@@ -1101,7 +1101,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example removes elements from the <xref:System.Collections.Specialized.StringCollection>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Clear/stringcollectionremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringCollection/Clear/stringcollectionremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringCollection/Clear/stringcollectionremove.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Collections.Specialized/StringDictionary.xml
+++ b/xml/System.Collections.Specialized/StringDictionary.xml
@@ -87,7 +87,7 @@
 ## Examples
  The following code example demonstrates several of the properties and methods of <xref:System.Collections.Specialized.StringDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/Overview/stringdictionary.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/Overview/stringdictionary.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringDictionary/Overview/stringdictionary.vb" id="Snippet1":::
 
  ]]></format>
@@ -221,7 +221,7 @@
 ## Examples
  The following code example demonstrates how to add and remove elements from a <xref:System.Collections.Specialized.StringDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/Add/stringdictionary_addremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/Add/stringdictionary_addremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringDictionary/Add/stringdictionary_addremove.vb" id="Snippet1":::
 
  ]]></format>
@@ -284,7 +284,7 @@
 ## Examples
  The following code example demonstrates how to add and remove elements from a <xref:System.Collections.Specialized.StringDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/Add/stringdictionary_addremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/Add/stringdictionary_addremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringDictionary/Add/stringdictionary_addremove.vb" id="Snippet1":::
 
  ]]></format>
@@ -350,7 +350,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example searches for an element in a <xref:System.Collections.Specialized.StringDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/ContainsKey/stringdictionary_contains.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/ContainsKey/stringdictionary_contains.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringDictionary/ContainsKey/stringdictionary_contains.vb" id="Snippet1":::
 
  ]]></format>
@@ -418,7 +418,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example searches for an element in a <xref:System.Collections.Specialized.StringDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/ContainsKey/stringdictionary_contains.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/ContainsKey/stringdictionary_contains.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringDictionary/ContainsKey/stringdictionary_contains.vb" id="Snippet1":::
 
  ]]></format>
@@ -486,7 +486,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example shows how a StringDictionary can be copied to an array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/CopyTo/stringdictionary_copyto.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/CopyTo/stringdictionary_copyto.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringDictionary/CopyTo/stringdictionary_copyto.vb" id="Snippet1":::
 
  ]]></format>
@@ -895,7 +895,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example demonstrates how to add and remove elements from a <xref:System.Collections.Specialized.StringDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/Add/stringdictionary_addremove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/Add/stringdictionary_addremove.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringDictionary/Add/stringdictionary_addremove.vb" id="Snippet1":::
 
  ]]></format>
@@ -1023,7 +1023,7 @@ This method uses the collection's objects' <xref:System.Object.Equals%2A> and <x
 ## Examples
  The following code example enumerates the elements of a <xref:System.Collections.Specialized.StringDictionary>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/Count/values.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringDictionary/Count/values.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringDictionary/Count/values.vb" id="Snippet2":::
 
  ]]></format>

--- a/xml/System.Collections.Specialized/StringEnumerator.xml
+++ b/xml/System.Collections.Specialized/StringEnumerator.xml
@@ -74,7 +74,7 @@
 ## Examples
  The following code example demonstrates several of the properties and methods of <xref:System.Collections.Specialized.StringEnumerator>.
   
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringEnumerator/Overview/stringenumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringEnumerator/Overview/stringenumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringEnumerator/Overview/stringenumerator.vb" id="Snippet1":::
 
  ]]></format>
@@ -145,7 +145,7 @@
 ## Examples
  The following code example demonstrates several of the properties and methods of <xref:System.Collections.Specialized.StringEnumerator>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringEnumerator/Overview/stringenumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringEnumerator/Overview/stringenumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringEnumerator/Overview/stringenumerator.vb" id="Snippet1":::
 
  ]]></format>
@@ -213,7 +213,7 @@
 ## Examples
  The following code example demonstrates several of the properties and methods of <xref:System.Collections.Specialized.StringEnumerator>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringEnumerator/Overview/stringenumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringEnumerator/Overview/stringenumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringEnumerator/Overview/stringenumerator.vb" id="Snippet1":::
 
  ]]></format>
@@ -275,7 +275,7 @@
 ## Examples
  The following code example demonstrates several of the properties and methods of <xref:System.Collections.Specialized.StringEnumerator>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringEnumerator/Overview/stringenumerator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Collections.Specialized/StringEnumerator/Overview/stringenumerator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Collections.Specialized/StringEnumerator/Overview/stringenumerator.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/Calendar.xml
+++ b/xml/System.Globalization/Calendar.xml
@@ -139,7 +139,7 @@
 ## Examples
  The following code example demonstrates the members of the <xref:System.Globalization.Calendar> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/Overview/calendar.vb" id="Snippet1":::
 
  ]]></format>
@@ -209,7 +209,7 @@
 ## Examples
  The following example demonstrates the members of the <xref:System.Globalization.Calendar> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/Overview/calendar.vb" id="Snippet1":::
 
  ]]></format>
@@ -286,7 +286,7 @@
 ## Examples
  The following code example demonstrates the members of the <xref:System.Globalization.Calendar> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/Overview/calendar.vb" id="Snippet1":::
 
  ]]></format>
@@ -802,7 +802,7 @@
 ## Examples
  The following code example demonstrates the members of the <xref:System.Globalization.Calendar> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/Overview/calendar.vb" id="Snippet1":::
 
  ]]></format>
@@ -891,7 +891,7 @@
 ## Examples
  The following code example demonstrates the members of the <xref:System.Globalization.Calendar> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/Overview/calendar.vb" id="Snippet1":::
 
  ]]></format>
@@ -1253,7 +1253,7 @@ The <xref:System.Globalization.JapaneseCalendar> and <xref:System.Globalization.
 ## Examples
  The following code example demonstrates the members of the <xref:System.Globalization.Calendar> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/Overview/calendar.vb" id="Snippet1":::
 
  ]]></format>
@@ -1329,7 +1329,7 @@ The <xref:System.Globalization.JapaneseCalendar> and <xref:System.Globalization.
 ## Examples
  The following code example demonstrates the members of the <xref:System.Globalization.Calendar> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/Overview/calendar.vb" id="Snippet1":::
 
  ]]></format>
@@ -1406,7 +1406,7 @@ The <xref:System.Globalization.JapaneseCalendar> and <xref:System.Globalization.
 ## Examples
  The following code example demonstrates the members of the <xref:System.Globalization.Calendar> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/Overview/calendar.vb" id="Snippet1":::
 
  ]]></format>
@@ -1494,7 +1494,7 @@ The <xref:System.Globalization.JapaneseCalendar> and <xref:System.Globalization.
 ## Examples
  The following code example compares different implementations of the <xref:System.Globalization.Calendar> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/GetDaysInMonth/calendar_compare.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/GetDaysInMonth/calendar_compare.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/GetDaysInMonth/calendar_compare.vb" id="Snippet1":::
 
  ]]></format>
@@ -2231,7 +2231,7 @@ Only the <xref:System.Globalization.JapaneseCalendar> and the <xref:System.Globa
 ## Examples
  The following code example demonstrates the members of the <xref:System.Globalization.Calendar> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/Overview/calendar.vb" id="Snippet1":::
 
  ]]></format>
@@ -2571,7 +2571,7 @@ Only the <xref:System.Globalization.JapaneseCalendar> and the <xref:System.Globa
 ## Examples
  The following code example shows how the result of <xref:System.Globalization.Calendar.GetWeekOfYear%2A> varies depending on the <xref:System.Globalization.DateTimeFormatInfo.FirstDayOfWeek%2A> and the <xref:System.Globalization.CalendarWeekRule> used. If the specified date is the last day of the year, <xref:System.Globalization.Calendar.GetWeekOfYear%2A> returns the total number of weeks in that year.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/GetWeekOfYear/yslin_calendar_getweekofyear.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/GetWeekOfYear/yslin_calendar_getweekofyear.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/GetWeekOfYear/yslin_calendar_getweekofyear.vb" id="Snippet1":::
 
  ]]></format>
@@ -2654,7 +2654,7 @@ Only the <xref:System.Globalization.JapaneseCalendar> and the <xref:System.Globa
 ## Examples
  The following code example demonstrates the members of the <xref:System.Globalization.Calendar> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/Overview/calendar.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/Overview/calendar.vb" id="Snippet1":::
 
  ]]></format>
@@ -3097,7 +3097,7 @@ Only the <xref:System.Globalization.JapaneseCalendar> and the <xref:System.Globa
 ## Examples
  The following code example compares different implementations of the <xref:System.Globalization.Calendar> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/GetDaysInMonth/calendar_compare.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/GetDaysInMonth/calendar_compare.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/GetDaysInMonth/calendar_compare.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/CalendarAlgorithmType.xml
+++ b/xml/System.Globalization/CalendarAlgorithmType.xml
@@ -60,7 +60,7 @@
 ## Examples
  The following code example demonstrates the <xref:System.Globalization.Calendar.AlgorithmType%2A> property and the <xref:System.Globalization.CalendarAlgorithmType> enumeration.
   
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/CalendarAlgorithmType/Overview/caltype.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/CalendarAlgorithmType/Overview/caltype.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CalendarAlgorithmType/Overview/caltype.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/CharUnicodeInfo.xml
+++ b/xml/System.Globalization/CharUnicodeInfo.xml
@@ -197,7 +197,7 @@ Each version of the Unicode standard includes information on changes to the Unic
 ## Examples
  The following code example shows the values returned by each method for different types of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/CharUnicodeInfo/Overview/charunicodeinfo_char.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/CharUnicodeInfo/Overview/charunicodeinfo_char.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CharUnicodeInfo/Overview/charunicodeinfo_char.vb" id="Snippet1":::
 
  ]]></format>
@@ -267,7 +267,7 @@ Each version of the Unicode standard includes information on changes to the Unic
 ## Examples
  The following code example shows the values returned by each method for different types of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/CharUnicodeInfo/GetDecimalDigitValue/charunicodeinfo_string.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/CharUnicodeInfo/GetDecimalDigitValue/charunicodeinfo_string.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CharUnicodeInfo/GetDecimalDigitValue/charunicodeinfo_string.vb" id="Snippet1":::
 
  ]]></format>
@@ -512,7 +512,7 @@ Each version of the Unicode standard includes information on changes to the Unic
 ## Examples
  The following code example shows the values returned by each method for different types of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/CharUnicodeInfo/Overview/charunicodeinfo_char.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/CharUnicodeInfo/Overview/charunicodeinfo_char.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CharUnicodeInfo/Overview/charunicodeinfo_char.vb" id="Snippet1":::
 
  ]]></format>
@@ -593,7 +593,7 @@ Each version of the Unicode standard includes information on changes to the Unic
 ## Examples
  The following code example shows the values returned by each method for different types of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/CharUnicodeInfo/GetDecimalDigitValue/charunicodeinfo_string.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/CharUnicodeInfo/GetDecimalDigitValue/charunicodeinfo_string.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CharUnicodeInfo/GetDecimalDigitValue/charunicodeinfo_string.vb" id="Snippet1":::
 
  ]]></format>
@@ -684,7 +684,7 @@ Each version of the Unicode standard includes information on changes to the Unic
 ## Examples
  The following code example shows the values returned by each method for different types of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/CharUnicodeInfo/Overview/charunicodeinfo_char.cs"  interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/CharUnicodeInfo/Overview/charunicodeinfo_char.cs"  id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CharUnicodeInfo/Overview/charunicodeinfo_char.vb" id="Snippet1":::
 
  ]]></format>
@@ -806,7 +806,7 @@ Each version of the Unicode standard includes information on changes to the Unic
 ## Examples
  The following code example shows the values returned by each method for different types of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/CharUnicodeInfo/GetDecimalDigitValue/charunicodeinfo_string.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/CharUnicodeInfo/GetDecimalDigitValue/charunicodeinfo_string.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CharUnicodeInfo/GetDecimalDigitValue/charunicodeinfo_string.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -676,7 +676,7 @@ If `name` is <xref:System.String.Empty?displayProperty=nameWithType>, the constr
 ## Examples
  The following code example shows that CultureInfo.Clone also clones the <xref:System.Globalization.DateTimeFormatInfo> and <xref:System.Globalization.NumberFormatInfo> instances associated with the <xref:System.Globalization.CultureInfo>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/CultureInfo/Clone/yslin_cultureinfo_clone.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/CultureInfo/Clone/yslin_cultureinfo_clone.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CultureInfo/Clone/yslin_cultureinfo_clone.vb" id="Snippet1":::
 
  ]]></format>
@@ -1115,7 +1115,7 @@ You might choose to override some of the values associated with the current cult
           <format type="text/markdown"><![CDATA[
  The following code example shows that CultureInfo.Clone also clones the <xref:System.Globalization.DateTimeFormatInfo> and <xref:System.Globalization.NumberFormatInfo> instances associated with the <xref:System.Globalization.CultureInfo>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/CultureInfo/Clone/yslin_cultureinfo_clone.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/CultureInfo/Clone/yslin_cultureinfo_clone.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CultureInfo/Clone/yslin_cultureinfo_clone.vb" id="Snippet1":::
           ]]></format>
         </example>
@@ -2948,7 +2948,7 @@ You might choose to override some of the values associated with the current cult
           <format type="text/markdown"><![CDATA[
 The following code example shows that CultureInfo.Clone also clones the <xref:System.Globalization.DateTimeFormatInfo> and <xref:System.Globalization.NumberFormatInfo> instances associated with the <xref:System.Globalization.CultureInfo>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/CultureInfo/Clone/yslin_cultureinfo_clone.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/CultureInfo/Clone/yslin_cultureinfo_clone.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CultureInfo/Clone/yslin_cultureinfo_clone.vb" id="Snippet1":::
           ]]></format>
         </example>

--- a/xml/System.Globalization/DateTimeFormatInfo.xml
+++ b/xml/System.Globalization/DateTimeFormatInfo.xml
@@ -99,7 +99,7 @@
 
         The following example uses reflection to get the properties of the <xref:System.Globalization.DateTimeFormatInfo> object for the English (United States) culture. It displays the value of those properties that contain custom format strings and uses those strings to display formatted dates.
 
-        :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/Overview/format1.cs" interactive="try-dotnet" id="Snippet5":::
+        :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/Overview/format1.cs" id="Snippet5":::
         :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/Overview/format1.vb" id="Snippet5":::
       ]]></format>
     </example>
@@ -216,7 +216,7 @@
 ## Examples
  The following example creates a read/write <xref:System.Globalization.CultureInfo> object that represents the English (United States) culture and assigns abbreviated day names to its <xref:System.Globalization.DateTimeFormatInfo.AbbreviatedDayNames%2A> property. It then uses the "ddd" format specifier in a [custom date and time format string](/dotnet/standard/base-types/custom-date-and-time-format-strings) to display the string representation of dates for one week beginning May 28, 2014.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/AbbreviatedDayNames/abbreviateddaynames1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/AbbreviatedDayNames/abbreviateddaynames1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/AbbreviatedDayNames/abbreviateddaynames1.vb" id="Snippet1":::
 
  ]]></format>
@@ -365,7 +365,7 @@
 ## Examples
  The following example creates a read/write <xref:System.Globalization.CultureInfo> object that represents the English (United States) culture and assigns abbreviated genitive month names to its <xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthNames%2A> and <xref:System.Globalization.DateTimeFormatInfo.AbbreviatedMonthGenitiveNames%2A> properties. It then displays the string representation of dates that include the abbreviated name of each month in the culture's supported calendar.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/AbbreviatedMonthGenitiveNames/abbreviatedmonthnames1.cs"  interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/AbbreviatedMonthGenitiveNames/abbreviatedmonthnames1.cs"  id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/AbbreviatedMonthGenitiveNames/abbreviatedmonthnames1.vb" id="Snippet1":::
 
  ]]></format>
@@ -768,7 +768,7 @@ Changing the value of this property affects the following properties as well: <x
 ## Examples
  The following example instantiates a <xref:System.Globalization.CultureInfo> object for the en-US culture, changes its date separator to "-", and displays a date by using the "d", "G", and "g" standard format strings.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/DateSeparator/dateseparatorex.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/DateSeparator/dateseparatorex.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/DateSeparator/dateseparatorex.vb" id="Snippet1":::
 
  ]]></format>
@@ -965,7 +965,7 @@ This property is affected if the value of the <xref:System.Globalization.DateTim
 ## Examples
  The following example displays the value of <xref:System.Globalization.DateTimeFormatInfo.FullDateTimePattern%2A> for a few cultures.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/FullDateTimePattern/dtfi_fulldatetimepattern.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/FullDateTimePattern/dtfi_fulldatetimepattern.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/FullDateTimePattern/dtfi_fulldatetimepattern.vb" id="Snippet1":::
 
  ]]></format>
@@ -1286,7 +1286,7 @@ This property is affected if the value of the <xref:System.Globalization.DateTim
 ## Examples
  The following example displays the date and time format strings for the invariant culture, as well as the result string that is produced when that format string is used to format a particular date.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/GetAllDateTimePatterns/getalldatetimepatternsinv.cs" interactive="try-dotnet" id="Snippet3":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/GetAllDateTimePatterns/getalldatetimepatternsinv.cs" id="Snippet3":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/GetAllDateTimePatterns/getalldatetimepatternsinv.vb" id="Snippet3":::
 
  The example instantiates a <xref:System.Globalization.DateTimeFormatInfo> object that represents the invariant culture by calling the <xref:System.Globalization.DateTimeFormatInfo.%23ctor%2A> constructor. It could also retrieve a <xref:System.Globalization.DateTimeFormatInfo> that represents the invariant culture from the <xref:System.Globalization.DateTimeFormatInfo.InvariantInfo%2A> property.
@@ -1349,7 +1349,7 @@ This property is affected if the value of the <xref:System.Globalization.DateTim
 
  You can use the custom format strings in the array returned by the <xref:System.Globalization.DateTimeFormatInfo.GetAllDateTimePatterns%2A> method in formatting operations. However, if you do, the string representation of a date and time value returned in that formatting operation cannot always be parsed successfully by the `Parse` and `TryParse` methods. Therefore, you cannot assume that the custom format strings returned by the <xref:System.Globalization.DateTimeFormatInfo.GetAllDateTimePatterns%2A> method can be used to round-trip date and time values. The following example illustrates this problem. It retrieves a <xref:System.Globalization.DateTimeFormatInfo> object that contains formatting information for the Russia (Russian) culture. It calls the <xref:System.Globalization.DateTimeFormatInfo.GetAllDateTimePatterns%28System.Char%29> method for each standard format string, and then passes each custom format string in the returned array to the <xref:System.DateTime.ToString%28System.String%29?displayProperty=nameWithType> method to create the string representation of a date and time. This example then attempts to parse this value by calling the <xref:System.DateTime.TryParse%28System.String%2CSystem.DateTime%40%29?displayProperty=nameWithType> method. As the output from the example shows, some of the custom format strings do not produce a date and time value that successfully round-trips.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/GetAllDateTimePatterns/getalldatetimepatternsex2.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/GetAllDateTimePatterns/getalldatetimepatternsex2.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/GetAllDateTimePatterns/getalldatetimepatternsex2.vb" id="Snippet2":::
 
  To parse the string representation of a date and time that can be expressed in a number of predefined custom formats, call one of the following methods:
@@ -1367,7 +1367,7 @@ This property is affected if the value of the <xref:System.Globalization.DateTim
 ## Examples
  The following example displays the date and time patterns for the current calendar.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/GetAllDateTimePatterns/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/GetAllDateTimePatterns/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/GetAllDateTimePatterns/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -2054,7 +2054,7 @@ This property is affected if the value of the <xref:System.Globalization.DateTim
 ## Remarks
  The <xref:System.Globalization.DateTimeFormatInfo.LongDatePattern%2A> property defines the culture-specific format of date strings that are returned by calls to the <xref:System.DateTime.ToString%2A?displayProperty=nameWithType> and <xref:System.DateTimeOffset.ToString%2A?displayProperty=nameWithType> methods and by composite format strings that are supplied the "D" standard format string. The following example illustrates the relationships among the following: the "D" standard format string, the custom format string returned by the <xref:System.Globalization.DateTimeFormatInfo.LongDatePattern%2A> property, and  the culture-specific representation of a date.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/LongDatePattern/longdatepattern1.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/LongDatePattern/longdatepattern1.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/LongDatePattern/longdatepattern1.vb" id="Snippet2":::
 
  See [Custom Date and Time Format Strings](/dotnet/standard/base-types/custom-date-and-time-format-strings) for individual custom format specifiers that can be combined to construct custom format strings such as "dddd, dd MMMM yyyy".
@@ -2069,7 +2069,7 @@ This property is affected if the value of the <xref:System.Globalization.DateTim
 ## Examples
  The following example displays the value of the <xref:System.Globalization.DateTimeFormatInfo.LongDatePattern%2A> property for a few cultures.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/LongDatePattern/dtfi_longdatepattern.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/LongDatePattern/dtfi_longdatepattern.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/LongDatePattern/dtfi_longdatepattern.vb" id="Snippet1":::
 
  ]]></format>
@@ -2144,7 +2144,7 @@ This property is affected if the value of the <xref:System.Globalization.DateTim
 ## Examples
  The following example displays the value of <xref:System.Globalization.DateTimeFormatInfo.LongTimePattern%2A> for a few cultures.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/LongTimePattern/dtfi_longtimepattern.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/LongTimePattern/dtfi_longtimepattern.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/LongTimePattern/dtfi_longtimepattern.vb" id="Snippet1":::
 
  ]]></format>
@@ -2617,7 +2617,7 @@ This property is affected if the value of the <xref:System.Globalization.DateTim
 ## Examples
  The following example displays the value of RFC1123Pattern for a few cultures.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/RFC1123Pattern/dtfi_rfc1123pattern.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/RFC1123Pattern/dtfi_rfc1123pattern.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/RFC1123Pattern/dtfi_rfc1123pattern.vb" id="Snippet1":::
 
  ]]></format>
@@ -2766,12 +2766,12 @@ This property is affected if the value of the <xref:System.Globalization.DateTim
 ## Examples
  The following example displays the value of the <xref:System.Globalization.DateTimeFormatInfo.ShortDatePattern%2A> property and the value of a date formatted using the <xref:System.Globalization.DateTimeFormatInfo.ShortDatePattern%2A> property for a few cultures.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/ShortDatePattern/dtfi_shortdatepattern.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/ShortDatePattern/dtfi_shortdatepattern.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/ShortDatePattern/dtfi_shortdatepattern.vb" id="Snippet1":::
 
  The following example modifies the <xref:System.Globalization.DateTimeFormatInfo.ShortDatePattern%2A> property of a <xref:System.Globalization.DateTimeFormatInfo> object that represents the formatting conventions of the English (United States) culture. It also displays a date value twice, first to reflect the original <xref:System.Globalization.DateTimeFormatInfo.ShortDatePattern%2A> property and then to reflect the new property value.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/ShortDatePattern/shortdatepattern1.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/ShortDatePattern/shortdatepattern1.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/ShortDatePattern/shortdatepattern1.vb" id="Snippet2":::
 
  ]]></format>
@@ -2914,7 +2914,7 @@ The default array starts on Sunday.
 ## Examples
  The following example displays the value of <xref:System.Globalization.DateTimeFormatInfo.ShortTimePattern%2A> for a few cultures.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/ShortTimePattern/dtfi_shorttimepattern.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/ShortTimePattern/dtfi_shorttimepattern.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/ShortTimePattern/dtfi_shorttimepattern.vb" id="Snippet1":::
 
  ]]></format>
@@ -2979,7 +2979,7 @@ The default array starts on Sunday.
 ## Examples
  The following example displays the value of <xref:System.Globalization.DateTimeFormatInfo.SortableDateTimePattern%2A> for a few cultures.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/SortableDateTimePattern/dtfi_sortabledatetimepattern.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/SortableDateTimePattern/dtfi_sortabledatetimepattern.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/SortableDateTimePattern/dtfi_sortabledatetimepattern.vb" id="Snippet1":::
 
  ]]></format>
@@ -3083,7 +3083,7 @@ If the custom pattern includes the format pattern ":", <xref:System.DateTime.ToS
 ## Examples
  The following example instantiates a <xref:System.Globalization.CultureInfo> object for the en-US culture, changes its date separator to ".", and displays a date by using the "t", "T", "F", "f", "G", and "g" standard format strings.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/TimeSeparator/timeseparatorex.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/TimeSeparator/timeseparatorex.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/TimeSeparator/timeseparatorex.vb" id="Snippet1":::
 
  ]]></format>
@@ -3149,7 +3149,7 @@ If the custom pattern includes the format pattern ":", <xref:System.DateTime.ToS
 ## Examples
  The following example displays the value of <xref:System.Globalization.DateTimeFormatInfo.UniversalSortableDateTimePattern%2A> for a few cultures.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/UniversalSortableDateTimePattern/dtfi_universalsortabledatetimepattern.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/DateTimeFormatInfo/UniversalSortableDateTimePattern/dtfi_universalsortabledatetimepattern.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/DateTimeFormatInfo/UniversalSortableDateTimePattern/dtfi_universalsortabledatetimepattern.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/GregorianCalendar.xml
+++ b/xml/System.Globalization/GregorianCalendar.xml
@@ -174,7 +174,7 @@
 ## Examples
  The following code example prints a <xref:System.DateTime> using a <xref:System.Globalization.GregorianCalendar> that is localized.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/GregorianCalendar/.ctor/gregorianlocalized.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/GregorianCalendar/.ctor/gregorianlocalized.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/GregorianCalendar/.ctor/gregorianlocalized.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/GregorianCalendarTypes.xml
+++ b/xml/System.Globalization/GregorianCalendarTypes.xml
@@ -87,7 +87,7 @@
 
  The following code example prints a <xref:System.DateTime> using a <xref:System.Globalization.GregorianCalendar> that is localized.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/GregorianCalendar/.ctor/gregorianlocalized.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/GregorianCalendar/.ctor/gregorianlocalized.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/GregorianCalendar/.ctor/gregorianlocalized.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/HijriCalendar.xml
+++ b/xml/System.Globalization/HijriCalendar.xml
@@ -1075,7 +1075,7 @@
 ## Examples
  The following code example displays the values of several components of a <xref:System.DateTime> in terms of the Hijri calendar.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/HijriCalendar/AddMonths/hijricalendar_addget.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/HijriCalendar/AddMonths/hijricalendar_addget.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/HijriCalendar/AddMonths/hijricalendar_addget.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/IdnMapping.xml
+++ b/xml/System.Globalization/IdnMapping.xml
@@ -87,7 +87,7 @@
 ## Examples
  The following example uses the <xref:System.Globalization.IdnMapping.GetAscii%28System.String%2CSystem.Int32%2CSystem.Int32%29> method to convert an array of internationalized domain names to Punycode. The <xref:System.Globalization.IdnMapping.GetUnicode%2A> method then converts the Punycode domain name back to the original domain name, but replaces the original label separators with the standard label separator.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/IdnMapping/Overview/conversion1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/IdnMapping/Overview/conversion1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/IdnMapping/Overview/conversion1.vb" id="Snippet1":::
 
  ]]></format>
@@ -338,7 +338,7 @@
 ## Examples
  The following example uses the <xref:System.Globalization.IdnMapping.GetAscii%28System.String%29> method to convert an array of internationalized domain names to Punycode, which is an encoded equivalent that consists of characters in the US-ASCII character range. The <xref:System.Globalization.IdnMapping.GetUnicode%28System.String%29> method then converts the Punycode domain name back into the original domain name, but replaces the original label separators with the standard label separator.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/IdnMapping/Overview/conversion1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/IdnMapping/Overview/conversion1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/IdnMapping/Overview/conversion1.vb" id="Snippet1":::
 
  ]]></format>
@@ -524,7 +524,7 @@
 ## Examples
  The following example uses the <xref:System.Globalization.IdnMapping.GetAscii%28System.String%2CSystem.Int32%2CSystem.Int32%29> method to convert an internationalized domain name to a domain name that complies with the IDNA standard. The <xref:System.Globalization.IdnMapping.GetUnicode%28System.String%2CSystem.Int32%2CSystem.Int32%29> method then converts the standardized domain name back into the original domain name, but replaces the original label separators with the standard label separator.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/IdnMapping/GetAscii/getx.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/IdnMapping/GetAscii/getx.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/IdnMapping/GetAscii/getx.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/JapaneseCalendar.xml
+++ b/xml/System.Globalization/JapaneseCalendar.xml
@@ -949,7 +949,7 @@
 ## Examples
  The following example displays the values of several components of a <xref:System.DateTime> in terms of the Japanese calendar.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/JapaneseCalendar/AddMonths/japanesecalendar_addget.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/JapaneseCalendar/AddMonths/japanesecalendar_addget.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/JapaneseCalendar/AddMonths/japanesecalendar_addget.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/JulianCalendar.xml
+++ b/xml/System.Globalization/JulianCalendar.xml
@@ -632,7 +632,7 @@
 ## Examples
  The following code example displays the values of several components of a <xref:System.DateTime> in terms of the Julian calendar.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/JulianCalendar/AddMonths/juliancalendar_addget.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/JulianCalendar/AddMonths/juliancalendar_addget.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/JulianCalendar/AddMonths/juliancalendar_addget.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/NumberFormatInfo.xml
+++ b/xml/System.Globalization/NumberFormatInfo.xml
@@ -226,7 +226,7 @@
 ## Examples
  The following example uses the <xref:System.Globalization.NumberFormatInfo.Clone%2A> method to create a read/write copy of a <xref:System.Globalization.NumberFormatInfo> object that represents the numeric formatting conventions of the current culture.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/Clone/isreadonly1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/Clone/isreadonly1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/Clone/isreadonly1.vb" id="Snippet1":::
 
  ]]></format>
@@ -287,7 +287,7 @@
 ## Examples
  The following example demonstrates the effect of changing the <xref:System.Globalization.NumberFormatInfo.CurrencyDecimalDigits%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/CurrencyDecimalDigits/currencydecimaldigits.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/CurrencyDecimalDigits/currencydecimaldigits.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/CurrencyDecimalDigits/currencydecimaldigits.vb" id="Snippet1":::
 
  ]]></format>
@@ -358,7 +358,7 @@ On Windows, the initial value of this property is derived from the settings in t
 ## Examples
  The following example demonstrates the effect of changing the <xref:System.Globalization.NumberFormatInfo.CurrencyDecimalSeparator%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/CurrencyDecimalSeparator/currencydecimalseparator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/CurrencyDecimalSeparator/currencydecimalseparator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/CurrencyDecimalSeparator/currencydecimalseparator.vb" id="Snippet1":::
 
  ]]></format>
@@ -430,7 +430,7 @@ On Windows, the initial value of this property is derived from the settings in t
 ## Examples
  The following example demonstrates the effect of changing the <xref:System.Globalization.NumberFormatInfo.CurrencyGroupSeparator%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/CurrencyGroupSeparator/currencygroupseparator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/CurrencyGroupSeparator/currencygroupseparator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/CurrencyGroupSeparator/currencygroupseparator.vb" id="Snippet1":::
 
  ]]></format>
@@ -503,7 +503,7 @@ On Windows, the initial value of this property is derived from the settings in t
 ## Examples
  The following example demonstrates the effect of changing the <xref:System.Globalization.NumberFormatInfo.CurrencyGroupSizes%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/CurrencyGroupSizes/currencygroupsizes.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/CurrencyGroupSizes/currencygroupsizes.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/CurrencyGroupSizes/currencygroupsizes.vb" id="Snippet1":::
 
  ]]></format>
@@ -597,7 +597,7 @@ On Windows, the initial value of this property is derived from the settings in t
 ## Examples
  The following example shows how the <xref:System.Globalization.NumberFormatInfo.CurrencyNegativePattern%2A> property defines the format of negative currency values.  It retrieves all the specific cultures that are defined on the host computer and displays each culture's <xref:System.Globalization.NumberFormatInfo.CurrencyNegativePattern%2A> property value, its associated pattern, and a number formatted as a currency value.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/CurrencyNegativePattern/currencynegativepattern1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/CurrencyNegativePattern/currencynegativepattern1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/CurrencyNegativePattern/currencynegativepattern1.vb" id="Snippet1":::
 
  ]]></format>
@@ -813,7 +813,7 @@ The pattern does not support a positive sign.
 ## Examples
  The following example shows that the objects returned by the <xref:System.Globalization.NumberFormatInfo.CurrentInfo%2A> and   `CultureInfo.CurrentCulture.NumberFormat` properties are identical. It then uses reflection to display the property values of the <xref:System.Globalization.NumberFormatInfo> object returned by the <xref:System.Globalization.NumberFormatInfo.CurrentInfo%2A> property on a system whose current culture is en-US.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/CurrentInfo/currentinfo1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/CurrentInfo/currentinfo1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/CurrentInfo/currentinfo1.vb" id="Snippet1":::
 
  ]]></format>
@@ -1456,7 +1456,7 @@ The pattern does not support a positive sign.
 ## Examples
  The following example demonstrates the effect of changing the <xref:System.Globalization.NumberFormatInfo.NumberDecimalDigits%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/NumberDecimalDigits/numberdecimaldigits.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/NumberDecimalDigits/numberdecimaldigits.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/NumberDecimalDigits/numberdecimaldigits.vb" id="Snippet1":::
 
  ]]></format>
@@ -1526,7 +1526,7 @@ On Windows, the initial value of this property is derived from the settings in t
 ## Examples
  The following example demonstrates the effect of changing the <xref:System.Globalization.NumberFormatInfo.NumberDecimalSeparator%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/NumberDecimalSeparator/numberdecimalseparator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/NumberDecimalSeparator/numberdecimalseparator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/NumberDecimalSeparator/numberdecimalseparator.vb" id="Snippet1":::
 
  ]]></format>
@@ -1597,7 +1597,7 @@ On Windows, the initial value of this property is derived from the settings in t
 ## Examples
  The following example demonstrates the effect of changing the <xref:System.Globalization.NumberFormatInfo.NumberGroupSeparator%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/NumberGroupSeparator/numbergroupseparator.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/NumberGroupSeparator/numbergroupseparator.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/NumberGroupSeparator/numbergroupseparator.vb" id="Snippet1":::
 
  ]]></format>
@@ -1671,12 +1671,12 @@ On Windows, the initial value of this property is derived from the settings in t
 ## Examples
  The following example demonstrates the effect of changing the <xref:System.Globalization.NumberFormatInfo.NumberGroupSizes%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/NumberGroupSizes/numbergroupsizes.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/NumberGroupSizes/numbergroupsizes.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/NumberGroupSizes/numbergroupsizes.vb" id="Snippet1":::
 
  The following example prints a value using different <xref:System.Globalization.NumberFormatInfo.NumberGroupSizes%2A> arrays.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/NumberGroupSizes/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/NumberGroupSizes/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/NumberGroupSizes/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -1759,7 +1759,7 @@ On Windows, the initial value of this property is derived from the settings in t
 ## Examples
  The following example displays a value using different <xref:System.Globalization.NumberFormatInfo.NumberNegativePattern%2A> patterns.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/NumberNegativePattern/source.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/NumberNegativePattern/source.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/NumberNegativePattern/source.vb" id="Snippet1":::
 
  ]]></format>
@@ -1827,7 +1827,7 @@ On Windows, the initial value of this property is derived from the settings in t
 ## Examples
  The following example demonstrates the effect of changing the <xref:System.Globalization.NumberFormatInfo.PercentDecimalDigits%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/PercentDecimalDigits/percentdecimaldigits.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberFormatInfo/PercentDecimalDigits/percentdecimaldigits.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberFormatInfo/PercentDecimalDigits/percentdecimaldigits.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/NumberStyles.xml
+++ b/xml/System.Globalization/NumberStyles.xml
@@ -97,7 +97,7 @@ The following table lists the composite number styles and indicates which indivi
 
 This example shows how to parse a string into a 32-bit integer by using various `NumberStyles` flags.
 
-:::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberStyles/Overview/NumberStyles.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Globalization/NumberStyles/Overview/NumberStyles.cs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Globalization/NumberStyles/Overview/numberstyles.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/RegionInfo.xml
+++ b/xml/System.Globalization/RegionInfo.xml
@@ -84,7 +84,7 @@
 
       The following example demonstrates several members of the <xref:System.Globalization.RegionInfo> class.
 
-      :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/Overview/regioninfo.cs" interactive="try-dotnet" id="Snippet1":::
+      :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/Overview/regioninfo.cs" id="Snippet1":::
       :::code language="vb" source="~/snippets/visualbasic/System.Globalization/RegionInfo/Overview/regioninfo.vb" id="Snippet1":::
 
       ]]></format>
@@ -162,7 +162,7 @@
 ## Examples
  The following code example compares two instances of <xref:System.Globalization.RegionInfo> that were created differently.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/.ctor/regioninfo_equals.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/.ctor/regioninfo_equals.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/RegionInfo/.ctor/regioninfo_equals.vb" id="Snippet1":::
 
  ]]></format>
@@ -244,12 +244,12 @@ This constructor throws an <xref:System.ArgumentException> if `name` is a neutra
 ## Examples
  The following code example compares two instances of <xref:System.Globalization.RegionInfo> that were created differently.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/.ctor/regioninfo_equals.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/.ctor/regioninfo_equals.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/RegionInfo/.ctor/regioninfo_equals.vb" id="Snippet1":::
 
  The following code example creates instances of <xref:System.Globalization.RegionInfo> using culture names.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/.ctor/regioninfo_ctorculturename.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/.ctor/regioninfo_ctorculturename.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/RegionInfo/.ctor/regioninfo_ctorculturename.vb" id="Snippet1":::
 
  ]]></format>
@@ -458,7 +458,7 @@ This constructor throws an <xref:System.ArgumentException> if `name` is a neutra
 ## Examples
  The following code example displays the properties of the <xref:System.Globalization.RegionInfo> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.vb" id="Snippet1":::
 
  ]]></format>
@@ -585,7 +585,7 @@ This constructor throws an <xref:System.ArgumentException> if `name` is a neutra
 ## Examples
  The following code example displays the properties of the <xref:System.Globalization.RegionInfo> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.vb" id="Snippet1":::
 
  ]]></format>
@@ -797,7 +797,7 @@ This constructor throws an <xref:System.ArgumentException> if `name` is a neutra
 ## Examples
  The following code example demonstrates the <xref:System.Globalization.RegionInfo.GeoId%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencyEnglishName/rgn5props.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencyEnglishName/rgn5props.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/RegionInfo/CurrencyEnglishName/rgn5props.vb" id="Snippet1":::
 
  ]]></format>
@@ -1098,7 +1098,7 @@ This constructor throws an <xref:System.ArgumentException> if `name` is a neutra
 ## Examples
  The following code example displays the properties of the <xref:System.Globalization.RegionInfo> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.vb" id="Snippet1":::
 
  ]]></format>
@@ -1164,7 +1164,7 @@ This constructor throws an <xref:System.ArgumentException> if `name` is a neutra
 ## Examples
  The following code example displays the properties of the <xref:System.Globalization.RegionInfo> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.vb" id="Snippet1":::
 
  ]]></format>
@@ -1306,7 +1306,7 @@ This constructor throws an <xref:System.ArgumentException> if `name` is a neutra
 ## Examples
  The following code example displays the properties of the <xref:System.Globalization.RegionInfo> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.vb" id="Snippet1":::
 
  ]]></format>
@@ -1516,7 +1516,7 @@ This constructor throws an <xref:System.ArgumentException> if `name` is a neutra
 ## Examples
  The following code example displays the properties of the <xref:System.Globalization.RegionInfo> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/RegionInfo/CurrencySymbol/regioninfo_properties.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/StringInfo.xml
+++ b/xml/System.Globalization/StringInfo.xml
@@ -102,14 +102,14 @@ The following example illustrates both ways of working with the text elements in
 
 Each string is parsed once by the <xref:System.Globalization.StringInfo.ParseCombiningCharacters%2A> method and then by the <xref:System.Globalization.StringInfo.GetTextElementEnumerator%2A> method. Both methods correctly parse the text elements in the two strings and display the results of the parsing operation.
 
-:::code language="csharp" source="~/snippets/csharp/System.Globalization/StringInfo/Overview/indexing1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Globalization/StringInfo/Overview/indexing1.cs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Globalization/StringInfo/Overview/indexing1.vb" id="Snippet1":::
 
 ## Examples
 
 This example uses the <xref:System.Globalization.StringInfo.GetTextElementEnumerator%2A> and <xref:System.Globalization.StringInfo.ParseCombiningCharacters%2A> methods of the <xref:System.Globalization.StringInfo> class to manipulate a string that contains surrogate and combining characters.
 
-:::code language="csharp" source="~/snippets/csharp/System.Globalization/StringInfo/Overview/StringInfo.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Globalization/StringInfo/Overview/StringInfo.cs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Globalization/StringInfo/Overview/stringinfo.vb" id="Snippet1":::
 
  ]]></format>
@@ -732,7 +732,7 @@ A grapheme cluster is a sequence of one or more Unicode code points that should 
 ## Examples
  The following example demonstrates calling the <xref:System.Globalization.StringInfo.GetTextElementEnumerator%2A> method. This example is part of a larger example provided for the <xref:System.Globalization.StringInfo> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/StringInfo/Overview/StringInfo.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/StringInfo/Overview/StringInfo.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/StringInfo/Overview/stringinfo.vb" id="Snippet1":::
 
  ]]></format>
@@ -944,7 +944,7 @@ A grapheme cluster is a sequence of one or more Unicode code points that should 
 ## Examples
  The following example demonstrates calling the <xref:System.Globalization.StringInfo.ParseCombiningCharacters%2A> method. This code example is part of a larger example provided for the <xref:System.Globalization.StringInfo> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/StringInfo/Overview/StringInfo.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/StringInfo/Overview/StringInfo.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/StringInfo/Overview/stringinfo.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/TextElementEnumerator.xml
+++ b/xml/System.Globalization/TextElementEnumerator.xml
@@ -110,7 +110,7 @@
 ## Examples
  The following example uses the <xref:System.Globalization.TextElementEnumerator> class to enumerate the text elements of a string.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/TextElementEnumerator/Overview/tee_summary.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/TextElementEnumerator/Overview/tee_summary.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/TextElementEnumerator/Overview/tee_summary.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Globalization/TextInfo.xml
+++ b/xml/System.Globalization/TextInfo.xml
@@ -960,7 +960,7 @@ The <xref:System.Globalization.TextInfo.LCID%2A> property always reflects a spec
 ## Examples
  The following code example changes the casing of a string based on the English (United States) culture, with the culture name en-US.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/TextInfo/ToTitleCase/textinfo_casing.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/TextInfo/ToTitleCase/textinfo_casing.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/TextInfo/ToTitleCase/textinfo_casing.vb" id="Snippet1":::
 
  ]]></format>
@@ -1245,12 +1245,12 @@ The <xref:System.Globalization.TextInfo.LCID%2A> property always reflects a spec
 ## Examples
  The following example changes the casing of a string based on the English (United States) culture, with the culture name en-US.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/TextInfo/ToTitleCase/textinfo_casing.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/TextInfo/ToTitleCase/textinfo_casing.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/TextInfo/ToTitleCase/textinfo_casing.vb" id="Snippet1":::
 
  The following example passes each string in an array to the <xref:System.Globalization.TextInfo.ToTitleCase%2A> method. The strings include proper title strings as well as acronyms. The strings are converted to title case by using the conventions of the en-US culture.
 
- :::code language="csharp" source="~/snippets/csharp/System.Globalization/TextInfo/ToTitleCase/totitlecase2.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Globalization/TextInfo/ToTitleCase/totitlecase2.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/TextInfo/ToTitleCase/totitlecase2.vb" id="Snippet1":::
 
  ]]></format>
@@ -1275,7 +1275,7 @@ The <xref:System.Globalization.TextInfo.LCID%2A> property always reflects a spec
  ## Examples
  The following code example changes the casing of a string based on the English (United States) culture, with the culture name en-US.
 
-:::code language="csharp" source="~/snippets/csharp/System.Globalization/TextInfo/ToTitleCase/textinfo_casing.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Globalization/TextInfo/ToTitleCase/textinfo_casing.cs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Globalization/TextInfo/ToTitleCase/textinfo_casing.vb" id="Snippet1":::
 
 ]]></format>

--- a/xml/System.Numerics/BigInteger.xml
+++ b/xml/System.Numerics/BigInteger.xml
@@ -1633,7 +1633,7 @@ The individual bytes in the `value` array should be in little-endian order, from
 ## Examples
  The following example creates an array of <xref:System.Numerics.BigInteger> values. It then uses each element as the quotient in a division operation that uses the <xref:System.Numerics.BigInteger.Divide%2A> method, the division operator (/), and the <xref:System.Numerics.BigInteger.DivRem%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Divide/Divide1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Divide/Divide1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/BigInteger/Divide/Divide1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/BigInteger/Divide/Divide1.vb" id="Snippet1":::
 
@@ -1752,7 +1752,7 @@ The individual bytes in the `value` array should be in little-endian order, from
 ## Examples
  The following example creates an array of <xref:System.Numerics.BigInteger> values. It then uses each element as the quotient in a division operation that uses the <xref:System.Numerics.BigInteger.Divide%2A> method, the division operator (/), and the <xref:System.Numerics.BigInteger.DivRem%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Divide/Divide1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Divide/Divide1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/BigInteger/Divide/Divide1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/BigInteger/Divide/Divide1.vb" id="Snippet1":::
 
@@ -2777,7 +2777,7 @@ A return value of `false` does not imply that <xref:System.Numerics.INumberBase%
 
  You can find the square root of a number by calling the <xref:System.Numerics.BigInteger.Log%2A> method along with the <xref:System.Math.Exp%2A?displayProperty=nameWithType> method. Note that the result is <xref:System.Double.PositiveInfinity?displayProperty=nameWithType> if the result is greater than <xref:System.Double.MaxValue?displayProperty=nameWithType>. The following example calculates the square root of each element in an array of <xref:System.Numerics.BigInteger> values.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/LogMethod/log1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/LogMethod/log1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/BigInteger/LogMethod/log1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/BigInteger/LogMethod/log1.vb" id="Snippet1":::
 
@@ -3030,7 +3030,7 @@ A return value of `false` does not imply that <xref:System.Numerics.INumberBase%
 ## Examples
  The following example uses the <xref:System.Numerics.BigInteger.Max%2A> method to select the largest number in an array of <xref:System.Numerics.BigInteger> values.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Max/Max1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Max/Max1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/BigInteger/Max/Max1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/BigInteger/Max/Max1.vb" id="Snippet1":::
 
@@ -3319,7 +3319,7 @@ For <xref:System.Numerics.IFloatingPointIeee754%601> this method matches the IEE
 ## Examples
  The following example provides a simple illustration of calling the <xref:System.Numerics.BigInteger.ModPow%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/ModPow/ModPow1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/ModPow/ModPow1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/BigInteger/ModPow/ModPow1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/BigInteger/ModPow/ModPow1.vb" id="Snippet1":::
 
@@ -3878,7 +3878,7 @@ For <xref:System.Numerics.IFloatingPointIeee754%601> this method matches the IEE
 ## Examples
  The following example creates an array of <xref:System.Numerics.BigInteger> values. It then uses each element as the quotient in a division operation that uses the <xref:System.Numerics.BigInteger.Divide%2A> method, the division operator (/), and the <xref:System.Numerics.BigInteger.DivRem%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Divide/Divide1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Divide/Divide1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/BigInteger/Divide/Divide1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/BigInteger/Divide/Divide1.vb" id="Snippet1":::
 
@@ -8265,7 +8265,7 @@ For <xref:System.Numerics.IFloatingPointIeee754%601> this method matches the IEE
 ## Remarks
  The <xref:System.Numerics.BigInteger.op_OnesComplement%2A> method defines the operation of the bitwise one's complement operator for <xref:System.Numerics.BigInteger> values. The bitwise one's complement operator reverses each bit in a numeric value. That is, bits in `value` that are 0 are set to 1 in the result, and bits that are 1 are set to 0 in the result. The <xref:System.Numerics.BigInteger.op_OnesComplement%2A> method enables code such as the following:
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/op_OnesComplement/OnesComplement1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/op_OnesComplement/OnesComplement1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/BigInteger/op_OnesComplement/OnesComplement1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/BigInteger/op_OnesComplement/OnesComplement1.vb" id="Snippet1":::
 
@@ -8820,7 +8820,7 @@ This operation performs an unsigned (otherwise known as a logical) right shift o
 
  If `value` is a hexadecimal string, the <xref:System.Numerics.BigInteger.Parse%28System.String%2CSystem.Globalization.NumberStyles%29> method interprets `value` as a negative number stored by using two's complement representation if its first two hexadecimal digits are greater than or equal to `0x80`. In other words, the method interprets the highest-order bit of the first byte in `value` as the sign bit. To make sure that a hexadecimal string is correctly interpreted as a positive number, the first digit in `value` must have a value of zero. For example, the method interprets `0x80` as a negative value, but it interprets either `0x080` or `0x0080` as a positive value. The following example illustrates the difference between hexadecimal strings that represent negative and positive values.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Parse/ParseHex1.cs" interactive="try-dotnet" id="Snippet3":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Parse/ParseHex1.cs" id="Snippet3":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/BigInteger/Parse/ParseHex1.fs" id="Snippet3":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/BigInteger/Parse/ParseHex1.vb" id="Snippet3":::
 
@@ -9213,7 +9213,7 @@ If `provider` is `null`, the <xref:System.Globalization.NumberFormatInfo> object
 
  If `value` is a hexadecimal string, the <xref:System.Numerics.BigInteger.Parse%28System.String%2CSystem.Globalization.NumberStyles%29> method interprets `value` as a negative number stored by using two's complement representation if its first two hexadecimal digits are greater than or equal to `0x80`. In other words, the method interprets the highest-order bit of the first byte in `value` as the sign bit. To make sure that a hexadecimal string is correctly interpreted as a positive number, the first digit in `value` must have a value of zero. For example, the method interprets `0x80` as a negative value, but it interprets either `0x080` or `0x0080` as a positive value. The following example illustrates the difference between hexadecimal strings that represent negative and positive values.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Parse/ParseHex1.cs" interactive="try-dotnet" id="Snippet3":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Parse/ParseHex1.cs" id="Snippet3":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/BigInteger/Parse/ParseHex1.fs" id="Snippet3":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/BigInteger/Parse/ParseHex1.vb" id="Snippet3":::
 
@@ -9425,7 +9425,7 @@ If `provider` is `null`, the <xref:System.Globalization.NumberFormatInfo> object
 ## Examples
  The following example compares the remainder from the <xref:System.Numerics.BigInteger.DivRem%2A> method with the remainder returned by the <xref:System.Numerics.BigInteger.Remainder%2A> method to establish that the two methods calculate identical remainders.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Remainder/Remainder1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/Remainder/Remainder1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/BigInteger/Remainder/Remainder1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/BigInteger/Remainder/Remainder1.vb" id="Snippet1":::
 
@@ -11188,7 +11188,7 @@ The following example calls the <xref:System.Numerics.BigInteger.CompareTo%28Sys
 ## Examples
  The following example illustrates how some <xref:System.Numerics.BigInteger> values are represented in byte arrays.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/ToByteArray/ToByteArray1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/ToByteArray/ToByteArray1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/BigInteger/ToByteArray/ToByteArray1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/BigInteger/ToByteArray/ToByteArray1.vb" id="Snippet1":::
 
@@ -12199,7 +12199,7 @@ If `provider` is `null`, the <xref:System.Globalization.NumberFormatInfo> object
 
  If `value` is a hexadecimal string, the <xref:System.Numerics.BigInteger.TryParse%28System.String%2CSystem.Globalization.NumberStyles%2CSystem.IFormatProvider%2CSystem.Numerics.BigInteger%40%29> method interprets `value` as a negative number stored by using two's complement representation if its first two hexadecimal digits are greater than or equal to `0x80`. In other words, the method interprets the highest-order bit of the first byte in `value` as the sign bit. To make sure that a hexadecimal string is correctly interpreted as a positive number, the first digit in `value` must have a value of zero. For example, the method interprets `0x80` as a negative value, but it interprets either `0x080` or `0x0080` as a positive value. The following example illustrates the difference between hexadecimal strings that represent negative and positive values.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/TryParse/TryParseHex1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/BigInteger/TryParse/TryParseHex1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/BigInteger/TryParse/TryParseHex1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/BigInteger/TryParse/TryParseHex1.vb" id="Snippet1":::
 

--- a/xml/System.Numerics/Complex.xml
+++ b/xml/System.Numerics/Complex.xml
@@ -232,7 +232,7 @@
 ## Examples
  The following example instantiates two complex numbers, and then uses them in addition, subtraction, multiplication, and division operations.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/.ctor/ctor1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/.ctor/ctor1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/.ctor/ctor1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/.ctor/ctor1.vb" id="Snippet1":::
 
@@ -296,7 +296,7 @@
 ## Examples
  The following example calculates the absolute value of a complex number and demonstrates that it is equivalent to the value of the <xref:System.Numerics.Complex.Magnitude%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Abs/abs1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Abs/abs1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/Abs/abs1.fs" id="Snippet1":::
 
  ]]></format>
@@ -387,7 +387,7 @@
 
  The following example illustrates addition with complex numbers.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Add/add1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Add/add1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/Add/add1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/Add/add1.vb" id="Snippet1":::
           ]]></format>
@@ -730,7 +730,7 @@ $(a + c) + bi$
 ## Examples
  The following example displays the conjugate of two complex numbers.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Conjugate/conjugate1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Conjugate/conjugate1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/Conjugate/conjugate1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/Conjugate/conjugate1.vb" id="Snippet1":::
 
@@ -1034,7 +1034,7 @@ $(a + c) + bi$
 ## Examples
  The following example divides a complex number by each element in an array of complex numbers.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Divide/divide1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Divide/divide1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/Divide/divide1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/Divide/divide1.vb" id="Snippet1":::
 
@@ -1426,7 +1426,7 @@ $\frac{ac + bd}{c^2 + d^2} + (\frac{bc - ad}{c^2 + d^2})i$
 ## Examples
  The following example illustrates the <xref:System.Numerics.Complex.Exp%2A> method. It shows that, with some allowance for the lack of precision of the <xref:System.Double> data type, passing the value returned by the <xref:System.Numerics.Complex.Log%2A> method to the <xref:System.Numerics.Complex.Exp%2A> method returns the original <xref:System.Numerics.Complex> value.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Exp/log1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Exp/log1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/Exp/log1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/Exp/log1.vb" id="Snippet1":::
 
@@ -1491,7 +1491,7 @@ $\frac{ac + bd}{c^2 + d^2} + (\frac{bc - ad}{c^2 + d^2})i$
 ## Examples
  The following example uses the <xref:System.Numerics.Complex.FromPolarCoordinates%2A> method to instantiate a complex number based on its polar coordinates and then displays the value of its <xref:System.Numerics.Complex.Magnitude%2A> and <xref:System.Numerics.Complex.Phase%2A> properties.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/FromPolarCoordinates/phase1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/FromPolarCoordinates/phase1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/FromPolarCoordinates/phase1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/FromPolarCoordinates/phase1.vb" id="Snippet1":::
 
@@ -1594,7 +1594,7 @@ $\frac{ac + bd}{c^2 + d^2} + (\frac{bc - ad}{c^2 + d^2})i$
 ## Examples
  The following example instantiates an array of <xref:System.Numerics.Complex> objects and displays the real and imaginary components of each in the form `a + bi`.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Imaginary/real1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Imaginary/real1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/Imaginary/real1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/Imaginary/real1.vb" id="Snippet1":::
 
@@ -1645,7 +1645,7 @@ $\frac{ac + bd}{c^2 + d^2} + (\frac{bc - ad}{c^2 + d^2})i$
 ## Examples
  The following example instantiates a <xref:System.Numerics.Complex> value by using the <xref:System.Numerics.Complex.ImaginaryOne> property. It then compares this value to another value that is instantiated by calling the <xref:System.Numerics.Complex> constructor with a real part equal to zero and an imaginary part equal to one. As the output from the example shows, the two values are equal.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/ImaginaryOne/imaginaryone1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/ImaginaryOne/imaginaryone1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/ImaginaryOne/imaginaryone1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/ImaginaryOne/imaginaryone1.vb" id="Snippet1":::
 
@@ -2581,7 +2581,7 @@ This function returns `true` for a complex number `a + bi` where `b` is zero.
 ## Examples
  The following example calculates the absolute value of a complex number and demonstrates that it is equivalent to the value of the <xref:System.Numerics.Complex.Magnitude%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Abs/abs1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Abs/abs1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/Abs/abs1.fs" id="Snippet1":::
 
  ]]></format>
@@ -2706,7 +2706,7 @@ The <xref:System.Numerics.Complex.Multiply%2A> method is implemented for Languag
 
 The following example multiples a complex number by each element in an array of complex numbers.
 
-:::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Multiply/multiply1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Multiply/multiply1.cs" id="Snippet1":::
 :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/Multiply/multiply1.fs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/Multiply/multiply1.vb" id="Snippet1":::
 
@@ -3052,7 +3052,7 @@ The <xref:System.Numerics.Complex.op_Addition%2A> operators that receive one dou
 
 The following example illustrates addition with complex numbers:
 
-:::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Add/add2.cs" interactive="try-dotnet" id="Snippet2":::
+:::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Add/add2.cs" id="Snippet2":::
 :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/Add/add2.fs" id="Snippet2":::
 :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/Add/add2.vb" id="Snippet2":::
 
@@ -5334,7 +5334,7 @@ Languages that don't support custom operators can call the <xref:System.Numerics
 ## Examples
  The following example uses the <xref:System.Numerics.Complex.FromPolarCoordinates%2A> method to instantiate a complex number based on its polar coordinates, and then displays the value of its <xref:System.Numerics.Complex.Magnitude%2A> and <xref:System.Numerics.Complex.Phase%2A> properties.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/FromPolarCoordinates/phase1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/FromPolarCoordinates/phase1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/FromPolarCoordinates/phase1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/FromPolarCoordinates/phase1.vb" id="Snippet1":::
 
@@ -5407,7 +5407,7 @@ Languages that don't support custom operators can call the <xref:System.Numerics
 ## Examples
  The following example illustrates exponentiation using a complex number and an exponent whose value ranges from -1 to 10.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Pow/pow1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Pow/pow1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/Pow/pow1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/Pow/pow1.vb" id="Snippet1":::
 
@@ -5513,7 +5513,7 @@ Languages that don't support custom operators can call the <xref:System.Numerics
 ## Examples
  The following example instantiates an array of <xref:System.Numerics.Complex> objects and displays the real and imaginary components of each in the form `a + bi`.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Imaginary/real1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Imaginary/real1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/Imaginary/real1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/Imaginary/real1.vb" id="Snippet1":::
 
@@ -5576,7 +5576,7 @@ $\frac{a}{a^2 + b^2} + -\frac{b}{a^2 + b^2}$
 ## Examples
  The following example uses the <xref:System.Numerics.Complex.Reciprocal%2A> method to calculate the reciprocal values of several complex numbers. It also demonstrates that the result of multiplying a complex number by its reciprocal is <xref:System.Numerics.Complex.One?displayProperty=nameWithType>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Reciprocal/reciprocal1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/Reciprocal/reciprocal1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/Reciprocal/reciprocal1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/Reciprocal/reciprocal1.vb" id="Snippet1":::
 
@@ -5781,7 +5781,7 @@ The <xref:System.Numerics.Complex.Subtract%2A> methods that receive one double a
 
 The following example subtracts each complex number in an array from a complex number:
 
-:::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/op_Subtraction/subtract1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/op_Subtraction/subtract1.cs" id="Snippet1":::
 :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/op_Subtraction/subtract1.fs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/op_Subtraction/subtract1.vb" id="Snippet1":::
 
@@ -6864,7 +6864,7 @@ Languages that support custom operators can use the <xref:System.Numerics.Comple
 ## Examples
  The following example displays the string representation of several complex numbers. The output uses the formatting conventions of the English - United States ("en-US") culture, which, in this case, is the current system culture.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/ToString/tostring1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/ToString/tostring1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/ToString/tostring1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/ToString/tostring1.vb" id="Snippet1":::
 
@@ -6938,7 +6938,7 @@ Languages that support custom operators can use the <xref:System.Numerics.Comple
 ## Examples
  The following example displays the string representation of several complex numbers. The result uses the formatting conventions of the English - United States ("en-US") and French - France ("fr-FR") cultures.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/ToString/tostring2.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/ToString/tostring2.cs" id="Snippet2":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/ToString/tostring2.fs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/ToString/tostring2.vb" id="Snippet2":::
 
@@ -7015,7 +7015,7 @@ Languages that support custom operators can use the <xref:System.Numerics.Comple
 ## Examples
  The following example initializes a complex number and displays it using several standard format strings.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/ToString/tostring3.cs" interactive="try-dotnet" id="Snippet3":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/ToString/tostring3.cs" id="Snippet3":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/ToString/tostring3.fs" id="Snippet3":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/ToString/tostring3.vb" id="Snippet3":::
 
@@ -7103,7 +7103,7 @@ Languages that support custom operators can use the <xref:System.Numerics.Comple
 ## Examples
  The following example creates an array of complex numbers, and displays each using several standard format strings as well as <xref:System.Globalization.CultureInfo> objects that represent the English - United States ("en-US") and French - France ("fr-FR") cultures.
 
- :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/ToString/tostring4.cs" interactive="try-dotnet" id="Snippet4":::
+ :::code language="csharp" source="~/snippets/csharp/System.Numerics/Complex/ToString/tostring4.cs" id="Snippet4":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Numerics/Complex/ToString/tostring4.fs" id="Snippet4":::
  :::code language="vb" source="~/snippets/visualbasic/System.Numerics/Complex/ToString/tostring4.vb" id="Snippet4":::
 

--- a/xml/System.Reflection/PropertyInfo.xml
+++ b/xml/System.Reflection/PropertyInfo.xml
@@ -1939,7 +1939,7 @@ Console.WriteLine("CurrCult: " +
 ## Examples
  The following example defines an `Employee` class that has five properties. It then uses retrieves an array of <xref:System.Reflection.PropertyInfo> objects that represent those properties and displays the name and type of each.
 
- :::code language="csharp" source="~/snippets/csharp/System.Reflection/PropertyInfo/PropertyType/propertytype1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Reflection/PropertyInfo/PropertyType/propertytype1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Reflection/PropertyInfo/PropertyType/propertytype1.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Security.Cryptography/Aes.xml
+++ b/xml/System.Security.Cryptography/Aes.xml
@@ -76,7 +76,7 @@
 ## Examples  
  The following example demonstrates how to encrypt and decrypt sample data by using the <xref:System.Security.Cryptography.Aes> class.  
   
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/Aes/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/Aes/Overview/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/Aes/Overview/program.vb" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/VS_Snippets_CLR/aessample/fs/program.fs" id="Snippet1":::
   

--- a/xml/System.Security.Cryptography/AesCryptoServiceProvider.xml
+++ b/xml/System.Security.Cryptography/AesCryptoServiceProvider.xml
@@ -70,7 +70,7 @@
 ## Examples  
  The following example demonstrates how to encrypt and decrypt sample data using the <xref:System.Security.Cryptography.AesCryptoServiceProvider> class.  
   
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/AesCryptoServiceProvider/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/AesCryptoServiceProvider/Overview/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/AesCryptoServiceProvider/Overview/program.vb" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/VS_Snippets_CLR/aescryptoservprovider/fs/program.fs" id="Snippet1":::
   

--- a/xml/System.Security.Cryptography/AesManaged.xml
+++ b/xml/System.Security.Cryptography/AesManaged.xml
@@ -82,7 +82,7 @@
 ## Examples  
  The following example demonstrates how to encrypt and decrypt sample data using the <xref:System.Security.Cryptography.AesManaged> class.  
   
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/AesManaged/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/AesManaged/Overview/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/AesManaged/Overview/program.vb" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/VS_Snippets_CLR/aesmanaged/fs/program.fs" id="Snippet1"::: 
   

--- a/xml/System.Security.Cryptography/CryptoStream.xml
+++ b/xml/System.Security.Cryptography/CryptoStream.xml
@@ -81,7 +81,7 @@ This type implements the <xref:System.IDisposable> interface. When you've finish
 
 The following example demonstrates how to use a <xref:System.Security.Cryptography.CryptoStream> to encrypt a string. This method uses the <xref:System.Security.Cryptography.Aes> class with the specified <xref:System.Security.Cryptography.SymmetricAlgorithm.Key%2A> and initialization vector (<xref:System.Security.Cryptography.SymmetricAlgorithm.IV%2A>).
 
-:::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/CryptoStream/Overview/CryptoStream.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/CryptoStream/Overview/CryptoStream.cs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/CryptoStream/Overview/CryptoStream.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Security.Cryptography/CspParameters.xml
+++ b/xml/System.Security.Cryptography/CspParameters.xml
@@ -159,7 +159,7 @@
 ## Examples
  The following code example creates a key container using the <xref:System.Security.Cryptography.CspParameters> class and saves the key in the container.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/CspParameters/Overview/capikey.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/CspParameters/Overview/capikey.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/CspParameters/Overview/capikey.vb" id="Snippet1":::
 
  ]]></format>
@@ -290,7 +290,7 @@
 ## Examples
  The following code example uses the <xref:System.Security.Cryptography.CspParameters> class to select a Smart Card Cryptographic Service Provider.  It then signs and verifies data using the smart card.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/CspParameters/Overview/example.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/CspParameters/Overview/example.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/CspParameters/Overview/example.vb" id="Snippet1":::
 
  ]]></format>
@@ -614,7 +614,7 @@
 ## Examples
  The following code example creates a key container using the <xref:System.Security.Cryptography.CspParameters> class and saves the key in the container.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/CspParameters/Overview/capikey.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/CspParameters/Overview/capikey.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/CspParameters/Overview/capikey.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Security.Cryptography/DESCryptoServiceProvider.xml
+++ b/xml/System.Security.Cryptography/DESCryptoServiceProvider.xml
@@ -407,12 +407,12 @@
 ## Examples
  The following code example shows how to create and use a <xref:System.Security.Cryptography.DESCryptoServiceProvider> object to encrypt and decrypt data in a file.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/DESCryptoServiceProvider/CreateEncryptor/fileexample.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/DESCryptoServiceProvider/CreateEncryptor/fileexample.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/DESCryptoServiceProvider/CreateEncryptor/fileexample.vb" id="Snippet1":::
 
  The following code example shows how to create and use a <xref:System.Security.Cryptography.DESCryptoServiceProvider> object to encrypt and decrypt data in memory.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/DESCryptoServiceProvider/CreateEncryptor/memoryexample.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/DESCryptoServiceProvider/CreateEncryptor/memoryexample.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/DESCryptoServiceProvider/CreateEncryptor/memoryexample.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Security.Cryptography/HashAlgorithm.xml
+++ b/xml/System.Security.Cryptography/HashAlgorithm.xml
@@ -1575,7 +1575,7 @@ For more information about Dispose and Finalize, see [Cleaning Up Unmanaged Reso
 ## Examples
  The following code examples use the <xref:System.Security.Cryptography.HashAlgorithm.TransformFinalBlock%2A> method with the <xref:System.Security.Cryptography.HashAlgorithm.TransformBlock%2A> method to hash a string.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/HashAlgorithm/TransformBlock/sample.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/HashAlgorithm/TransformBlock/sample.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/HashAlgorithm/TransformBlock/sample.vb" id="Snippet1":::
 
  ]]></format>
@@ -1664,7 +1664,7 @@ For more information about Dispose and Finalize, see [Cleaning Up Unmanaged Reso
 ## Examples
  The following code examples use the <xref:System.Security.Cryptography.HashAlgorithm.TransformFinalBlock%2A> method with the <xref:System.Security.Cryptography.HashAlgorithm.TransformBlock%2A> method to hash a string.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/HashAlgorithm/TransformBlock/sample.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/HashAlgorithm/TransformBlock/sample.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/HashAlgorithm/TransformBlock/sample.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Security.Cryptography/KeyedHashAlgorithm.xml
+++ b/xml/System.Security.Cryptography/KeyedHashAlgorithm.xml
@@ -76,7 +76,7 @@
 ## Examples
  The following code example demonstrates how to derive from the <xref:System.Security.Cryptography.KeyedHashAlgorithm> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/KeyedHashAlgorithm/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/KeyedHashAlgorithm/Overview/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/KeyedHashAlgorithm/Overview/program.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Security.Cryptography/Oid.xml
+++ b/xml/System.Security.Cryptography/Oid.xml
@@ -65,7 +65,7 @@
 ## Examples
  The following code example shows how to use the <xref:System.Security.Cryptography.Oid> class.
   
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/Oid/Overview/cryptography.oid.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/Oid/Overview/cryptography.oid.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/Oid/Overview/cryptography.oid.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Security.Cryptography/RC2CryptoServiceProvider.xml
+++ b/xml/System.Security.Cryptography/RC2CryptoServiceProvider.xml
@@ -87,7 +87,7 @@
 ## Examples
  The following code example encrypts and then decrypts a string.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RC2CryptoServiceProvider/Overview/class1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RC2CryptoServiceProvider/Overview/class1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/RC2CryptoServiceProvider/Overview/class1.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Security.Cryptography/RNGCryptoServiceProvider.xml
+++ b/xml/System.Security.Cryptography/RNGCryptoServiceProvider.xml
@@ -82,7 +82,7 @@
 ## Examples
  The following code example shows how to create a random number with the <xref:System.Security.Cryptography.RNGCryptoServiceProvider> class.
  
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RNGCryptoServiceProvider/Overview/rngcsp.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RNGCryptoServiceProvider/Overview/rngcsp.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/RNGCryptoServiceProvider/Overview/rngcsp.vb" id="Snippet1":::
 
  ]]></format>
@@ -150,7 +150,7 @@
 ## Examples
  The following code example shows how to create a random number with the <xref:System.Security.Cryptography.RNGCryptoServiceProvider> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RNGCryptoServiceProvider/Overview/rngcsp.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RNGCryptoServiceProvider/Overview/rngcsp.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/RNGCryptoServiceProvider/Overview/rngcsp.vb" id="Snippet1":::
 
  ]]></format>
@@ -471,7 +471,7 @@
 ## Examples
  The following code example shows how to create a random number with the <xref:System.Security.Cryptography.RNGCryptoServiceProvider> class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RNGCryptoServiceProvider/Overview/rngcsp.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RNGCryptoServiceProvider/Overview/rngcsp.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/RNGCryptoServiceProvider/Overview/rngcsp.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Security.Cryptography/RSACryptoServiceProvider.xml
+++ b/xml/System.Security.Cryptography/RSACryptoServiceProvider.xml
@@ -1716,7 +1716,7 @@ The supported RSA key sizes depend on the available cryptographic service provid
 ## Examples
  The following code example creates an <xref:System.Security.Cryptography.RSACryptoServiceProvider> object and persists the key to a key container.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RSACryptoServiceProvider/PersistKeyInCsp/example.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RSACryptoServiceProvider/PersistKeyInCsp/example.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/RSACryptoServiceProvider/PersistKeyInCsp/example.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Security.Cryptography/RSAPKCS1KeyExchangeFormatter.xml
+++ b/xml/System.Security.Cryptography/RSAPKCS1KeyExchangeFormatter.xml
@@ -80,7 +80,7 @@
 ## Examples  
  The following example shows how to use the <xref:System.Security.Cryptography.RSAPKCS1KeyExchangeFormatter> class to create an exchange key for a message recipient.  
   
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RSAOAEPKeyExchangeFormatter/CreateKeyExchange/program.cs"  interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RSAOAEPKeyExchangeFormatter/CreateKeyExchange/program.cs"  id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/RSAOAEPKeyExchangeFormatter/CreateKeyExchange/program.vb" id="Snippet1":::  
   
  ]]></format>

--- a/xml/System.Security.Cryptography/RSAPKCS1SignatureDeformatter.xml
+++ b/xml/System.Security.Cryptography/RSAPKCS1SignatureDeformatter.xml
@@ -374,7 +374,7 @@
 ## Examples  
  The following example demonstrates how to use the <xref:System.Security.Cryptography.RSAPKCS1SignatureDeformatter.VerifySignature%2A> method to verify a signature.  
   
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RSAPKCS1SignatureDeformatter/Overview/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RSAPKCS1SignatureDeformatter/Overview/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/RSAPKCS1SignatureDeformatter/Overview/program.vb" id="Snippet1":::  
   
  ]]></format>

--- a/xml/System.Security.Cryptography/RijndaelManaged.xml
+++ b/xml/System.Security.Cryptography/RijndaelManaged.xml
@@ -84,7 +84,7 @@
 ## Examples
  The following example demonstrates how to encrypt and decrypt sample data using the `RijndaelManaged` class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RijndaelManaged/Overview/class1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RijndaelManaged/Overview/class1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/RijndaelManaged/Overview/class1.vb" id="Snippet1":::
 
  ]]></format>
@@ -135,7 +135,7 @@
 ## Examples
  The following example creates a new instance of the `RijndaelManaged` class.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RijndaelManaged/Overview/class1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RijndaelManaged/Overview/class1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/RijndaelManaged/Overview/class1.vb" id="Snippet1":::
 
  ]]></format>
@@ -435,7 +435,7 @@
 ## Examples
  The following code examples demonstrates how to encrypt a message using the `CreateEncryptor` method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RijndaelManaged/Overview/class1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RijndaelManaged/Overview/class1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/RijndaelManaged/Overview/class1.vb" id="Snippet1":::
 
  ]]></format>
@@ -578,7 +578,7 @@
 
 
 ## Examples
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RijndaelManaged/Overview/class1.cs"  interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RijndaelManaged/Overview/class1.cs"  id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/RijndaelManaged/Overview/class1.vb" id="Snippet1":::
 
  ]]></format>
@@ -636,7 +636,7 @@
 
 
 ## Examples
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RijndaelManaged/Overview/class1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/RijndaelManaged/Overview/class1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/RijndaelManaged/Overview/class1.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Security.Cryptography/SymmetricAlgorithm.xml
+++ b/xml/System.Security.Cryptography/SymmetricAlgorithm.xml
@@ -653,7 +653,7 @@ We recommend that you specify the algorithm by calling the <xref:System.Security
 ## Examples
  The following example encrypts a string using the transform object returned from the <xref:System.Security.Cryptography.SymmetricAlgorithm.CreateEncryptor%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/SymmetricAlgorithm/CreateEncryptor/encryptor.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/SymmetricAlgorithm/CreateEncryptor/encryptor.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/SymmetricAlgorithm/CreateEncryptor/encryptor.vb" id="Snippet1":::
 
  ]]></format>
@@ -2860,7 +2860,7 @@ Allows an <see cref="T:System.Object" /> to attempt to free resources and perfor
 ## Examples
  The following example shows the value of <xref:System.Security.Cryptography.SymmetricAlgorithm.LegalKeySizes%2A> for the AES symmetric algorithm.
 
- :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/SymmetricAlgorithm/LegalBlockSizes/program.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Security.Cryptography/SymmetricAlgorithm/LegalBlockSizes/program.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Security.Cryptography/SymmetricAlgorithm/LegalBlockSizes/program.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Text.RegularExpressions/Capture.xml
+++ b/xml/System.Text.RegularExpressions/Capture.xml
@@ -68,7 +68,7 @@
 ## Examples  
  The following example defines a regular expression that matches sentences that contain no punctuation except for a period (".").  
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Capture/Overview/example1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Capture/Overview/example1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Capture/Overview/example1.vb" id="Snippet1"::: 
   
  The regular expression pattern `((\w+)[\s.])+` is defined as shown in the following table. Note that in this regular expression, a quantifier (+) is applied to the entire regular expression.  
@@ -307,7 +307,7 @@
 ## Examples  
  The following example defines a regular expression that matches sentences that contain no punctuation except for a period ("."). The `Match.Value` property displays the result string, which consists of a matched sentence, for each match. The `Group.Value` property displays the result string for each capturing group; it consists of the last string captured by that capturing group. The <xref:System.Text.RegularExpressions.Capture.Value%2A?displayProperty=nameWithType> property displays the result string for each capture.  
  
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Capture/Overview/example1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Capture/Overview/example1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Capture/Overview/example1.vb" id="Snippet1":::  
   
  The regular expression pattern `((\w+)[\s.])+` is defined as shown in the following table. Note that in this regular expression, a quantifier (+) is applied to the entire regular expression.  
@@ -323,7 +323,7 @@
   
  The following example uses a regular expression pattern, `^([a-z]+)(\d+)*\.([a-z]+(\d)*)$`, to match a product number that consists of two parts separated by a period. Both parts consist of alphabetic characters followed by optional numbers. Because the first input string does not match the pattern, the value of the returned <xref:System.Text.RegularExpressions.Match?displayProperty=nameWithType> object's `Value` property is <xref:System.String.Empty?displayProperty=nameWithType>. Similarly, when the regular expression pattern is unable to match a capturing group, the value of the corresponding <xref:System.Text.RegularExpressions.Group> object's `Value` property is <xref:System.String.Empty?displayProperty=nameWithType>.  
   
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Capture/Value/value1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Capture/Value/value1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Capture/Value/value1.vb" id="Snippet1":::  
   
  The regular expression pattern is defined as shown in the following table:  

--- a/xml/System.Text.RegularExpressions/CaptureCollection.xml
+++ b/xml/System.Text.RegularExpressions/CaptureCollection.xml
@@ -126,7 +126,7 @@
 
      This regular expression pattern identifies the words in a sentence. The pattern defines a single capturing group that consists of one or more word characters followed by one or two non-word characters. The regular expression pattern uses the `+` quantifier to match one or more occurrences of this group. The output from this example shows that the <xref:System.Text.RegularExpressions.Match> object and the <xref:System.Text.RegularExpressions.CaptureCollection> object returned by the `Match.Captures` property contain information about the same match. The second <xref:System.Text.RegularExpressions.Group> object, which corresponds to the only capturing group in the regular expression, identifies only the last captured string, whereas the <xref:System.Text.RegularExpressions.CaptureCollection> object returned by the first capturing group's <xref:System.Text.RegularExpressions.Group.Captures%2A?displayProperty=nameWithType> property includes all captured substrings.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/CaptureCollection/Overview/capturecollectionex1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/CaptureCollection/Overview/capturecollectionex1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/CaptureCollection/Overview/capturecollectionex1.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Text.RegularExpressions/Group.xml
+++ b/xml/System.Text.RegularExpressions/Group.xml
@@ -78,7 +78,7 @@
 
  In this regular expression pattern, the subpattern `(\w+?)` is designed to match multiple words within a sentence. However, the value of the <xref:System.Text.RegularExpressions.Group> object represents only the last match that `(\w+?)` captures, whereas the <xref:System.Text.RegularExpressions.Group.Captures%2A> property returns a <xref:System.Text.RegularExpressions.CaptureCollection> that represents all captured text. As the output shows, the <xref:System.Text.RegularExpressions.CaptureCollection> for the second capturing group contains four objects. The last of these corresponds to the <xref:System.Text.RegularExpressions.Group> object.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Group/Overview/groupandcaptures1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Group/Overview/groupandcaptures1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Group/Overview/groupandcaptures1.vb" id="Snippet1":::
 
  ]]></format>
@@ -133,12 +133,12 @@
 ## Remarks
  If a quantifier is not applied to a capturing group, the collection returned by the <xref:System.Text.RegularExpressions.Group.Captures%2A> property contains a single <xref:System.Text.RegularExpressions.Capture> object that provides information about the same substring as the <xref:System.Text.RegularExpressions.Group> object. This is illustrated in the following example. It defines a regular expression, `\b(\w+)\b`, that extracts a single word from a sentence. The <xref:System.Text.RegularExpressions.Group> object captures the word "This", and the single object in the <xref:System.Text.RegularExpressions.CaptureCollection> contains information about the same capture.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Group/Captures/captures1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Group/Captures/captures1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Group/Captures/captures1.vb" id="Snippet1":::
 
  The real utility of the <xref:System.Text.RegularExpressions.Group.Captures%2A> property occurs when a quantifier is applied to a capturing group so that the group captures multiple substrings in a single regular expression. In this case, the <xref:System.Text.RegularExpressions.Group> object contains information about the last captured substring, whereas the <xref:System.Text.RegularExpressions.Group.Captures%2A> property contains information about all the substrings captured by the group. In the following example, the regular expression `\b(\w+\s*)+\.` matches an entire sentence that ends in a period. The group `(\w+\s*)+` captures the individual words in the collection. Because the <xref:System.Text.RegularExpressions.Group> collection contains information only about the last captured substring, it captures the last word in the sentence, "sentence". However, each word captured by the group is available from the collection returned by the <xref:System.Text.RegularExpressions.Group.Captures%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Group/Captures/captures2.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Group/Captures/captures2.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Group/Captures/captures2.vb" id="Snippet2":::
 
  ]]></format>

--- a/xml/System.Text.RegularExpressions/GroupCollection.xml
+++ b/xml/System.Text.RegularExpressions/GroupCollection.xml
@@ -142,7 +142,7 @@
 
  For each match, the <xref:System.Text.RegularExpressions.GroupCollection> contains three <xref:System.Text.RegularExpressions.Group> objects. The first object contains the string that matches the entire regular expression. The second object, which represents the first captured group, contains the product name. The third object, which represents the second captured group, contains the trademark or registered trademark symbol.
 
-  :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/GroupCollection/Overview/Example1.cs" interactive="try-dotnet" id="Snippet1":::
+  :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/GroupCollection/Overview/Example1.cs" id="Snippet1":::
   :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/GroupCollection/Overview/Example1.vb" id="Snippet1":::
 
  ]]></format>
@@ -252,7 +252,7 @@
 ## Examples
  The following example extracts each word from a sentence and captures it in a capturing group, The <xref:System.Text.RegularExpressions.GroupCollection.CopyTo%2A> method is then used to copy the elements in each match's <xref:System.Text.RegularExpressions.GroupCollection> object to an array that contains the capturing groups from all matches. The individual captured words are then displayed to the console.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/GroupCollection/CopyTo/copyto1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/GroupCollection/CopyTo/copyto1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/GroupCollection/CopyTo/copyto1.vb" id="Snippet1":::
 
  The regular expression is defined as follows:
@@ -643,7 +643,7 @@ A collection that is read-only does not allow the addition or removal of element
 |`(\w)`|This is the second capturing group.|
 |`\k`|Match the string captured by the second capturing group.|
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/GroupCollection/Item/item3.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/GroupCollection/Item/item3.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/GroupCollection/Item/item3.vb" id="Snippet2":::
 
  ]]></format>
@@ -721,7 +721,7 @@ A collection that is read-only does not allow the addition or removal of element
 |`(?<letter>\w)`|Match a single word character. Name this the `letter` capturing group.|
 |`\k<letter>`|Match the string captured by the `letter` capturing group.|
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/GroupCollection/Item/item2.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/GroupCollection/Item/item2.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/GroupCollection/Item/item2.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Text.RegularExpressions/Match.xml
+++ b/xml/System.Text.RegularExpressions/Match.xml
@@ -95,14 +95,14 @@ The following examples use the regular expression `Console\.Write(Line)?`. The r
 
  The following example calls the <xref:System.Text.RegularExpressions.Regex.Matches%28System.String%2CSystem.String%29?displayProperty=nameWithType> method to retrieve all pattern matches in an input string. It then iterates the <xref:System.Text.RegularExpressions.Match> objects in the returned <xref:System.Text.RegularExpressions.MatchCollection> object to display information about each match.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Overview/Match2.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Overview/Match2.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Match/Overview/Match2.vb" id="Snippet2":::
 
  **Example 2**
 
  The following example calls the <xref:System.Text.RegularExpressions.Regex.Match%28System.String%2CSystem.String%29> and <xref:System.Text.RegularExpressions.Match.NextMatch%2A> methods to retrieve one match at a time.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Overview/Match3.cs" interactive="try-dotnet" id="Snippet3":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Overview/Match3.cs" id="Snippet3":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Match/Overview/Match3.vb" id="Snippet3":::
 
  ]]></format>
@@ -217,7 +217,7 @@ The following examples use the regular expression `Console\.Write(Line)?`. The r
 ## Remarks
  A regular expression pattern can include subexpressions, which are defined by enclosing a portion of the regular expression pattern in parentheses. Every such subexpression forms a group. The <xref:System.Text.RegularExpressions.Match.Groups%2A> property provides access to information about those subexpression matches. For example, the regular expression pattern `(\d{3})-(\d{3}-\d{4})`, which matches North American telephone numbers, has two subexpressions. The first consists of the area code, which composes the first three digits of the telephone number. This group is captured by the first portion of the regular expression, `(\d{3})`. The second consists of the individual telephone number, which composes the last seven digits of the telephone number. This group is captured by the second portion of the regular expression, `(\d{3}-\d{4})`. These two groups can then be retrieved from the <xref:System.Text.RegularExpressions.GroupCollection> object that is returned by the <xref:System.Text.RegularExpressions.Match.Groups%2A> property, as the following example shows.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Groups/groups1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Groups/groups1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Match/Groups/groups1.vb" id="Snippet1":::
 
  The <xref:System.Text.RegularExpressions.GroupCollection> object returned by the <xref:System.Text.RegularExpressions.Match.Groups%2A?displayProperty=nameWithType> property is a zero-based collection object that always has at least one member. If the regular expression engine cannot find any matches in a particular input string, the <xref:System.Text.RegularExpressions.Group.Success%2A?displayProperty=nameWithType> property of the single <xref:System.Text.RegularExpressions.Group> object in the collection (the object at index 0) is set to `false` and the <xref:System.Text.RegularExpressions.Group> object's <xref:System.Text.RegularExpressions.Capture.Value%2A> property is set to <xref:System.String.Empty?displayProperty=nameWithType>. If the regular expression engine can find a match, the first element of the <xref:System.Text.RegularExpressions.GroupCollection> object (the element at index 0) returned by the <xref:System.Text.RegularExpressions.Match.Groups%2A> property contains a string that matches the entire regular expression pattern. Each subsequent element, from index one upward, represents a captured group, if the regular expression includes capturing groups. For more information, see the "Grouping Constructs and Regular Expression Objects" section of the [Grouping Constructs](/dotnet/standard/base-types/grouping-constructs-in-regular-expressions) article.
@@ -227,7 +227,7 @@ The following examples use the regular expression `Console\.Write(Line)?`. The r
 ## Examples
  The following example attempts to match a regular expression pattern against a sample string. The example uses the <xref:System.Text.RegularExpressions.Match.Groups%2A> property to store information that is retrieved by the match for display to the console.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Groups/snippet8.cs" interactive="try-dotnet" id="Snippet8":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Groups/snippet8.cs" id="Snippet8":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Match/Groups/snippet8.vb" id="Snippet8":::
 
  ]]></format>
@@ -293,7 +293,7 @@ The following examples use the regular expression `Console\.Write(Line)?`. The r
 ## Examples
  The following example uses the <xref:System.Text.RegularExpressions.Match.NextMatch%2A> method to capture regular expression matches beyond the first match.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Groups/snippet8.cs" interactive="try-dotnet" id="Snippet8":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Groups/snippet8.cs" id="Snippet8":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Match/Groups/snippet8.vb" id="Snippet8":::
 
  ]]></format>
@@ -304,7 +304,7 @@ The following examples use the regular expression `Console\.Write(Line)?`. The r
 
  The following example provides an illustration. The regular expression pattern <c>a*</c> searches for zero or more occurrences of the letter "a" in the string "abaabb". As the output from the example shows, the search finds six matches. The first match attempt finds the first "a". The second match starts exactly where the first match ends, before the first b; it finds zero occurrences of "a" and returns an empty string. The third match does not begin exactly where the second match ended, because the second match returned an empty string. Instead, it begins one character later, after the first "b". The third match finds two occurrences of "a" and returns "aa". The fourth match attempt begins where the third match ended, before the second "b", and returns an empty string. The fifth match attempt again advances one character so that it begins before the third "b" and returns an empty string. The sixth match begins after the last "b" and returns an empty string again.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/NextMatch/nextmatch1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/NextMatch/nextmatch1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Match/NextMatch/nextmatch1.vb" id="Snippet1":::</para>
         </block>
       </Docs>
@@ -368,7 +368,7 @@ The following examples use the regular expression `Console\.Write(Line)?`. The r
 ## Examples
  The following example replaces the hyphens that begin and end a parenthetical expression with parentheses.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Result/result1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Result/result1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Match/Result/result1.vb" id="Snippet1":::
 
  The regular expression pattern `--(.+?)--` is interpreted as shown in the following table.

--- a/xml/System.Text.RegularExpressions/MatchCollection.xml
+++ b/xml/System.Text.RegularExpressions/MatchCollection.xml
@@ -124,7 +124,7 @@
 ## Examples
  The following example illustrates the use of the <xref:System.Text.RegularExpressions.MatchCollection> class to interrogate a set of <xref:System.Text.RegularExpressions.Match> instances.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/MatchCollection/Overview/words.cs" interactive="try-dotnet" id="Snippet0":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/MatchCollection/Overview/words.cs" id="Snippet0":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/MatchCollection/Overview/words.vb" id="Snippet0":::
 
  ]]></format>
@@ -305,7 +305,7 @@
 ## Examples
  The following example uses the <xref:System.Text.RegularExpressions.MatchCollection.Count%2A> property to determine whether the call to the <xref:System.Text.RegularExpressions.Regex.Matches%28System.String%2CSystem.String%29?displayProperty=nameWithType> method found any matches. If not, it indicates that no matches were found. Otherwise, it enumerates the matches and displays their value and the position in the input string at which they were found.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/MatchCollection/Count/countex1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/MatchCollection/Count/countex1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/MatchCollection/Count/countex1.vb" id="Snippet1":::
 
  The regular expression pattern `\d+` matches one or more decimal characters in an input string.
@@ -549,7 +549,7 @@ A collection that is read-only does not allow the addition or removal of element
 ## Examples
  The following example parses the first sentence of Nathaniel Hawthorne's *House of the Seven Gables* and returns a <xref:System.Text.RegularExpressions.MatchCollection> object that contains all words that begin with either an uppercase or lowercase "h". The <xref:System.Text.RegularExpressions.MatchCollection.Item%2A> property is then used to retrieve each word and display it to the console.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/MatchCollection/Item/RegEx_24804.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/MatchCollection/Item/RegEx_24804.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/MatchCollection/Item/RegEx_24804.vb" id="Snippet1":::
 
  The example produces the following output:

--- a/xml/System.Text.RegularExpressions/MatchEvaluator.xml
+++ b/xml/System.Text.RegularExpressions/MatchEvaluator.xml
@@ -73,7 +73,7 @@
 ## Examples
  The following code example uses the <xref:System.Text.RegularExpressions.MatchEvaluator> delegate to replace every matched group of characters with the number of the match occurrence.
   
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/MatchEvaluator/Overview/regexreplace.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/MatchEvaluator/Overview/regexreplace.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/MatchEvaluator/Overview/regexreplace.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Text.RegularExpressions/Regex.xml
+++ b/xml/System.Text.RegularExpressions/Regex.xml
@@ -221,7 +221,7 @@
 ## Examples
  The following example illustrates how to use this constructor to instantiate a regular expression that matches any word that begins with the letters "a" or "t".
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/.ctor/constructors1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/.ctor/constructors1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/.ctor/constructors1.vb" id="Snippet1":::
 
  Note that the regular expression pattern cannot match the word "The" at the beginning of the text, because comparisons are case-sensitive by default. For an example of case-insensitive comparison, see the <xref:System.Text.RegularExpressions.Regex.%23ctor(System.String,System.Text.RegularExpressions.RegexOptions)> constructor.
@@ -367,7 +367,7 @@
 ## Examples
  The following example illustrates how to use this constructor to instantiate a regular expression that matches any word that begins with the letters "a" or "t".
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/.ctor/Constructors2.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/.ctor/Constructors2.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/.ctor/Constructors2.vb" id="Snippet2":::
 
  Note that the match collection includes the word "The" that begins the text because the `options` parameter has defined case-insensitive comparisons.
@@ -469,7 +469,7 @@
 ## Examples
  The following example calls the <xref:System.Text.RegularExpressions.Regex.%23ctor(System.String,System.Text.RegularExpressions.RegexOptions,System.TimeSpan)> constructor to instantiate a <xref:System.Text.RegularExpressions.Regex> object with a time-out value of one second. The regular expression pattern `(a+)+$`, which matches one or more sequences of one or more "a" characters at the end of a line, is subject to excessive backtracking. If a <xref:System.Text.RegularExpressions.RegexMatchTimeoutException> is thrown, the example increases the time-out value up to the maximum value of three seconds. Otherwise, it abandons the attempt to match the pattern.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/.ctor/ctor1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/.ctor/ctor1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/.ctor/ctor1.vb" id="Snippet1":::
 
  ]]></format>
@@ -2453,7 +2453,7 @@ Allows an <see cref="T:System.Object" /> to attempt to free resources and perfor
 ## Examples
  The following example defines a general-purpose `ShowMatches` method that displays the names of regular expression groups and their matched text.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/GetGroupNames/getgroupnames1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/GetGroupNames/getgroupnames1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/GetGroupNames/getgroupnames1.vb" id="Snippet1":::
 
  In this case, the regular expression pattern `\b(?<FirstWord>\w+)\s?((\w+)\s)*(?<LastWord>\w+)?(?<Punctuation>\p{Po})` is intended to parse a simple sentence, and to identify its first word, last word, and ending punctuation mark. The following table shows how the regular expression pattern is interpreted:
@@ -2531,7 +2531,7 @@ Allows an <see cref="T:System.Object" /> to attempt to free resources and perfor
 ## Examples
  The following example defines a regular expression, `\b((?<word>\w+)\s*)+(?<end>[.?!])`, that matches a sentence. The regular expression includes three capturing groups: an unnamed group that captures an individual word along with a space character that may follow it; a group named `word` that captures the individual words in the sentence; and a group named `end` that captures the punctuation that ends the sentence. The example calls the <xref:System.Text.RegularExpressions.Regex.GetGroupNumbers%2A> method to get the numbers of all capturing groups, and then displays their captured string. In addition, the <xref:System.Text.RegularExpressions.Regex.GroupNameFromNumber%2A> method is used to indicate whether a particular numbered group corresponds to a named group.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/GetGroupNumbers/getgroupnumbers1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/GetGroupNumbers/getgroupnumbers1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/GetGroupNumbers/getgroupnumbers1.vb" id="Snippet1":::
 
  The regular expression pattern is interpreted as shown in the following table.
@@ -2612,7 +2612,7 @@ Allows an <see cref="T:System.Object" /> to attempt to free resources and perfor
 ## Examples
  The following example defines a regular expression pattern that matches an address line containing a U.S. city name, state name, and zip code. The example uses the <xref:System.Text.RegularExpressions.Regex.GroupNameFromNumber%2A> method to retrieve the names of capturing groups. It then uses these names to retrieve the corresponding captured groups for matches.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/GroupNameFromNumber/groupnamefromnumberex.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/GroupNameFromNumber/groupnamefromnumberex.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/GroupNameFromNumber/groupnamefromnumberex.vb" id="Snippet1":::
 
  The regular expression pattern is defined by the following expression:
@@ -2981,7 +2981,7 @@ Allows an <see cref="T:System.Object" /> to attempt to free resources and perfor
 ## Examples
  The following example illustrates the use of the <xref:System.Text.RegularExpressions.Regex.IsMatch(System.String)> method to determine whether a string is a valid part number. The regular expression assumes that the part number has a specific format that consists of three sets of characters separated by hyphens. The first set, which contains four characters, must consist of an alphanumeric character followed by two numeric characters followed by an alphanumeric character. The second set, which consists of three characters, must be numeric. The third set, which consists of four characters, must have three numeric characters followed by an alphanumeric character.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/IsMatch/ismatch2.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/IsMatch/ismatch2.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/IsMatch/ismatch2.vb" id="Snippet2":::
 
  The regular expression pattern is:
@@ -3164,7 +3164,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example illustrates the use of the <xref:System.Text.RegularExpressions.Regex.IsMatch(System.String,System.Int32)> method to determine whether a string is a valid part number. It searches for a part number that follows a colon (:) character in a string. The <xref:System.String.IndexOf(System.Char)> method is used to determine the position of the colon character, which is then passed to the <xref:System.Text.RegularExpressions.Regex.IsMatch(System.String,System.Int32)> method. The regular expression assumes that the part number has a specific format that consists of three sets of characters separated by hyphens. The first set, which contains four characters, must consist of an alphanumeric character followed by two numeric characters followed by an alphanumeric character. The second set, which consists of three characters, must be numeric. The third set, which consists of four characters, must have three numeric characters followed by an alphanumeric character.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/IsMatch/ismatch3.cs" interactive="try-dotnet" id="Snippet3":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/IsMatch/ismatch3.cs" id="Snippet3":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/IsMatch/ismatch3.vb" id="Snippet3":::
 
  The regular expression pattern is:
@@ -3269,7 +3269,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example illustrates the use of the <xref:System.Text.RegularExpressions.Regex.IsMatch(System.String,System.String)> method to determine whether a string is a valid part number. The regular expression assumes that the part number has a specific format that consists of three sets of characters separated by hyphens. The first set, which contains four characters, must consist of an alphanumeric character followed by two numeric characters followed by an alphanumeric character. The second set, which consists of three characters, must be numeric. The third set, which consists of four characters, must have three numeric characters followed by an alphanumeric character.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/IsMatch/ismatch1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/IsMatch/ismatch1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/IsMatch/ismatch1.vb" id="Snippet1":::
 
  The regular expression pattern is:
@@ -3435,7 +3435,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example illustrates the use of the <xref:System.Text.RegularExpressions.Regex.IsMatch(System.String,System.String)> method to determine whether a string is a valid part number. The regular expression assumes that the part number has a specific format that consists of three sets of characters separated by hyphens. The first set, which contains four characters, must consist of an alphanumeric character followed by two numeric characters followed by an alphanumeric character. The second set, which consists of three characters, must be numeric. The third set, which consists of four characters, must have three numeric characters followed by an alphanumeric character.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/IsMatch/ismatch4.cs" interactive="try-dotnet" id="Snippet4":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/IsMatch/ismatch4.cs" id="Snippet4":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/IsMatch/ismatch4.vb" id="Snippet4":::
 
  The regular expression pattern is:
@@ -3614,7 +3614,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example illustrates the use of the <xref:System.Text.RegularExpressions.Regex.IsMatch(System.String,System.String,System.Text.RegularExpressions.RegexOptions,System.TimeSpan)> method to determine whether a string is a valid part number. The regular expression assumes that the part number has a specific format that consists of three sets of characters separated by hyphens. The first set, which contains four characters, must consist of an alphanumeric character followed by two numeric characters followed by an alphanumeric character. The second set, which consists of three characters, must be numeric. The third set, which consists of four characters, must have three numeric characters followed by an alphanumeric character. Matching the regular expression pattern should involve minimal searching through the input string, so the method sets a time-out interval of 500 milliseconds.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/IsMatch/ismatch5.cs" interactive="try-dotnet" id="Snippet5":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/IsMatch/ismatch5.cs" id="Snippet5":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/IsMatch/ismatch5.vb" id="Snippet5":::
 
  The regular expression pattern is:
@@ -3746,7 +3746,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example finds regular expression pattern matches in a string, then lists the matched groups, captures, and capture positions.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Groups/snippet8.cs" interactive="try-dotnet" id="Snippet8":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Match/Groups/snippet8.cs" id="Snippet8":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Match/Groups/snippet8.vb" id="Snippet8":::
 
  The regular expression pattern `(\w+)\s+(car)` matches occurrences of the word "car" along with the word that precedes it. It is interpreted as shown in the following table.
@@ -3900,7 +3900,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example calls the <xref:System.Text.RegularExpressions.Regex.Match(System.String,System.String)> method to find the first word that contains at least one `z` character, and then calls the <xref:System.Text.RegularExpressions.Match.NextMatch%2A?displayProperty=nameWithType> method to find any additional matches.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Match/match1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Match/match1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Match/match1.vb" id="Snippet1":::
 
  The regular expression pattern `\b\w*z+\w*\b` is interpreted as shown in the following table.
@@ -4091,7 +4091,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example defines a regular expression that matches words beginning with the letter "a". It uses the <xref:System.Text.RegularExpressions.RegexOptions.IgnoreCase?displayProperty=nameWithType> option to ensure that the regular expression locates words beginning with both an uppercase "a" and a lowercase "a".
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Match/match2.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Match/match2.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Match/match2.vb" id="Snippet2":::
 
  The regular expression pattern `\ba\w*\b` is interpreted as shown in the following table.
@@ -4303,7 +4303,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example uses the <xref:System.Text.RegularExpressions.Regex.Matches(System.String)> method to identify any words in a sentence that end in "es".
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Matches/matches1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Matches/matches1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Matches/matches1.vb" id="Snippet1":::
 
  The regular expression pattern `\b\w+es\b` is defined as shown in the following table.
@@ -4392,7 +4392,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example uses the <xref:System.Text.RegularExpressions.Regex.Match(System.String)> method to find the first word in a sentence that ends in "es", and then calls the <xref:System.Text.RegularExpressions.Regex.Matches(System.String,System.Int32)> method to identify any additional words that end in "es".
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Matches/matches3.cs" interactive="try-dotnet" id="Snippet3":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Matches/matches3.cs" id="Snippet3":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Matches/matches3.vb" id="Snippet3":::
 
  The regular expression pattern `\b\w+es\b` is defined as shown in the following table.
@@ -4490,7 +4490,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example uses the <xref:System.Text.RegularExpressions.Regex.Matches(System.String,System.String)> method to identify any word in a sentence that ends in "es".
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Matches/matches2.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Matches/matches2.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Matches/matches2.vb" id="Snippet2":::
 
  The regular expression pattern `\b\w+es\b` is defined as shown in the following table.
@@ -4592,7 +4592,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example calls the <xref:System.Text.RegularExpressions.Regex.Matches(System.String,System.String)> method to identify any word in a sentence that ends in "es", and then calls the <xref:System.Text.RegularExpressions.Regex.Matches(System.String,System.String,System.Text.RegularExpressions.RegexOptions)> method to perform a case-insensitive comparison of the pattern with the input string. As the output shows, the two methods return different results.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Matches/matches4.cs" interactive="try-dotnet" id="Snippet4":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Matches/matches4.cs" id="Snippet4":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Matches/matches4.vb" id="Snippet4":::
 
  The regular expression pattern `\b\w+es\b` is defined as shown in the following table.
@@ -4696,7 +4696,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example calls the <xref:System.Text.RegularExpressions.Regex.Matches(System.String,System.String,System.Text.RegularExpressions.RegexOptions,System.TimeSpan)> method to perform a case-sensitive comparison that matches any word in a sentence that ends in "es". It then calls the <xref:System.Text.RegularExpressions.Regex.Matches(System.String,System.String,System.Text.RegularExpressions.RegexOptions,System.TimeSpan)> method to perform a case-insensitive comparison of the pattern with the input string. In both cases, the time-out interval is set to one second. As the output shows, the two methods return different results.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Matches/matches5.cs" interactive="try-dotnet" id="Snippet11":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Matches/matches5.cs" id="Snippet11":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Matches/matches5.vb" id="Snippet11":::
 
  The regular expression pattern `\b\w+es\b` is defined as shown in the following table.
@@ -4779,7 +4779,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 
  This property is read-only. You can set its value explicitly for an individual <xref:System.Text.RegularExpressions.Regex> object by calling the <xref:System.Text.RegularExpressions.Regex.%23ctor(System.String,System.Text.RegularExpressions.RegexOptions,System.TimeSpan)?displayProperty=nameWithType> constructor; and you can set its value for all <xref:System.Text.RegularExpressions.Regex> matching operations in an application domain by calling the <xref:System.AppDomain.SetData%2A?displayProperty=nameWithType> method and providing a <xref:System.TimeSpan> value for the "REGEX_DEFAULT_MATCH_TIMEOUT" property, as the following example illustrates.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/MatchTimeout/regexmatchtimeout1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/MatchTimeout/regexmatchtimeout1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/MatchTimeout/regexmatchtimeout1.vb" id="Snippet1":::
 
  If you do not explicitly set a time-out interval, the default value <xref:System.Text.RegularExpressions.Regex.InfiniteMatchTimeout?displayProperty=nameWithType> is used, and matching operations do not time out.
@@ -4990,12 +4990,12 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example defines a regular expression, `\s+`, that matches one or more white-space characters. The replacement string, " ", replaces them with a single space character.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replaceexample5.cs" interactive="try-dotnet" id="Snippet5":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replaceexample5.cs" id="Snippet5":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/replaceexample5.vb" id="Snippet5":::
 
  The following example defines a regular expression, `(\p{Sc}\s?)?(\d+\.?((?<=\.)\d+)?)(?(1)|\s?\p{Sc})?`, and a replacement pattern, `$2`, that removes either a leading or a trailing currency symbol from a numeric value.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replaceexample7.cs" interactive="try-dotnet" id="Snippet7":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replaceexample7.cs" id="Snippet7":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/replaceexample7.vb" id="Snippet7":::
 
  The regular expression is interpreted as shown in the following table.
@@ -5100,7 +5100,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following code example displays an original string, matches each word in the original string, converts the first character of each match to uppercase, then displays the converted string.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/sample.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/sample.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/sample.vb" id="Snippet1":::
 
  ]]></format>
@@ -5183,7 +5183,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example replaces the first five occurrences of duplicated characters with a single character. The regular expression pattern `(\w)\1` matches consecutive occurrences of a single character and assigns the first occurrence to the first capturing group. The replacement pattern `$1` replaces the entire match with the first captured group.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replaceexample8.cs" interactive="try-dotnet" id="Snippet8":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replaceexample8.cs" id="Snippet8":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/replaceexample8.vb" id="Snippet8":::
 
  ]]></format>
@@ -5274,12 +5274,12 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example defines a regular expression, `\s+`, that matches one or more white-space characters. The replacement string, " ", replaces them with a single space character.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replaceexample6.cs" interactive="try-dotnet" id="Snippet6":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replaceexample6.cs" id="Snippet6":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/replaceexample6.vb" id="Snippet6":::
 
  The following example uses the <xref:System.Text.RegularExpressions.Regex.Replace(System.String,System.String,System.String)> method to replace the local machine and drive names in a UNC path with a local file path. The regular expression uses the <xref:System.Environment.MachineName%2A?displayProperty=nameWithType> property to include the name of the local computer, and the <xref:System.Environment.GetLogicalDrives%2A?displayProperty=nameWithType> method to include the names of the logical drives. To run the example successfully, you should replace the literal string "MyMachine" with your local machine name.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace3.cs" interactive="try-dotnet" id="Snippet3":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace3.cs" id="Snippet3":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/replace3.vb" id="Snippet3":::
 
  The regular expression pattern is defined by the following expression:
@@ -5401,7 +5401,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example uses a regular expression to extract the individual words from a string, and then uses a <xref:System.Text.RegularExpressions.MatchEvaluator> delegate to call a method named `WordScramble` that scrambles the individual letters in the word. To do this, the `WordScramble` method creates an array that contains the characters in the match. It also creates a parallel array that it populates with random floating-point numbers. The arrays are sorted by calling the <xref:System.Array.Sort%60%602(%60%600%5B%5D,%60%601%5B%5D,System.Collections.Generic.IComparer%7B%60%600%7D)?displayProperty=nameWithType> method, and the sorted array is provided as an argument to a <xref:System.String> class constructor. This newly created string is then returned by the `WordScramble` method. The regular expression pattern `\w+` matches one or more word characters; the regular expression engine will continue to add characters to the match until it encounters a non-word character, such as a white-space character.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace5.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace5.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/replace5.vb" id="Snippet2":::
 
  ]]></format>
@@ -5500,7 +5500,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example uses a regular expression to deliberately misspell half of the words in a list. It uses the regular expression `\w*(ie|ei)\w*` to match words that include the characters "ie" or "ei". It passes the first half of the matching words to the `ReverseLetter` method, which, in turn, uses the <xref:System.Text.RegularExpressions.Regex.Replace(System.String,System.String,System.String,System.Text.RegularExpressions.RegexOptions)> method to reverse "i" and "e" in the matched string. The remaining words remain unchanged.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace7.cs" interactive="try-dotnet" id="Snippet11":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace7.cs" id="Snippet11":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/replace7.vb" id="Snippet11":::
 
  The regular expression `\w*(ie|ei)\w*` is defined as shown in the following table.
@@ -5597,7 +5597,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example double-spaces all but the first line of a string. It defines a regular expression pattern, `^.*$`, that matches a line of text, calls the <xref:System.Text.RegularExpressions.Regex.Match(System.String)> method to match the first line of the string, and uses the `Match.Index` and `Match.Count` properties to determine the starting position of the second line.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replaceexample9.cs" interactive="try-dotnet" id="Snippet9":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replaceexample9.cs" id="Snippet9":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/replaceexample9.vb" id="Snippet9":::
 
  The regular expression pattern `^.*$` is defined as shown in the following table.
@@ -5702,7 +5702,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example uses the <xref:System.Text.RegularExpressions.Regex.Replace(System.String,System.String,System.String,System.Text.RegularExpressions.RegexOptions)> method to replace the local machine and drive names in a UNC path with a local file path. The regular expression uses the <xref:System.Environment.MachineName%2A?displayProperty=nameWithType> property to include the name of the local computer, and the <xref:System.Environment.GetLogicalDrives%2A?displayProperty=nameWithType> method to include the names of the logical drives. All regular expression string comparisons are case-insensitive. To run the example successfully, you should replace the literal string "MyMachine" with your local machine name.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace4.cs" interactive="try-dotnet" id="Snippet4":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace4.cs" id="Snippet4":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/replace4.vb" id="Snippet4":::
 
  The regular expression pattern is defined by the following expression:
@@ -5831,7 +5831,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example uses a regular expression to extract the individual words from a string, and then uses a <xref:System.Text.RegularExpressions.MatchEvaluator> delegate to call a method named `WordScramble` that scrambles the individual letters in the word. To do this, the `WordScramble` method creates an array that contains the characters in the match. It also creates a parallel array that it populates with random floating-point numbers. The arrays are sorted by calling the <xref:System.Array.Sort%60%602(%60%600%5B%5D,%60%601%5B%5D,System.Collections.Generic.IComparer%7B%60%600%7D)?displayProperty=nameWithType> method, and the sorted array is provided as an argument to a <xref:System.String> class constructor. This newly created string is then returned by the `WordScramble` method. The regular expression pattern `\w+` matches one or more word characters; the regular expression engine will continue to add characters to the match until it encounters a non-word character, such as a white-space character. The call to the <xref:System.Text.RegularExpressions.Regex.Replace(System.String,System.String,System.Text.RegularExpressions.MatchEvaluator,System.Text.RegularExpressions.RegexOptions)> method includes the <xref:System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace?displayProperty=nameWithType> option so that the comment in the regular expression pattern `\w+  # Matches all the characters in a word.` is ignored by the regular expression engine.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace6.cs" interactive="try-dotnet" id="Snippet10":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace6.cs" id="Snippet10":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/replace6.vb" id="Snippet10":::
 
  ]]></format>
@@ -6020,7 +6020,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example uses the <xref:System.Text.RegularExpressions.Regex.Replace(System.String,System.String,System.String,System.Text.RegularExpressions.RegexOptions,System.TimeSpan)> method to replace the local machine and drive names in a UNC path with a local file path. The regular expression uses the <xref:System.Environment.MachineName%2A?displayProperty=nameWithType> property to include the name of the local computer and the <xref:System.Environment.GetLogicalDrives%2A?displayProperty=nameWithType> method to include the names of the logical drives. All regular expression string comparisons are case-insensitive, and any single replacement operation times out if a match cannot be found in 0.5 second. To run the example successfully, you should replace the literal string "MyMachine" with your local machine name.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace12.cs" interactive="try-dotnet" id="Snippet12":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace12.cs" id="Snippet12":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/replace12.vb" id="Snippet12":::
 
  The regular expression pattern is defined by the following expression:
@@ -6161,7 +6161,7 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 ## Examples
  The following example uses a regular expression to extract the individual words from a string, and then uses a <xref:System.Text.RegularExpressions.MatchEvaluator> delegate to call a method named `WordScramble` that scrambles the individual letters in the word. To do this, the `WordScramble` method creates an array that contains the characters in the match. It also creates a parallel array that it populates with random floating-point numbers. The arrays are sorted by calling the <xref:System.Array.Sort%60%602(%60%600%5B%5D,%60%601%5B%5D,System.Collections.Generic.IComparer%7B%60%600%7D)?displayProperty=nameWithType> method, and the sorted array is provided as an argument to a <xref:System.String> class constructor. This newly created string is then returned by the `WordScramble` method. The regular expression pattern `\w+` matches one or more word characters; the regular expression engine will continue to add characters to the match until it encounters a non-word character, such as a white-space character. The call to the <xref:System.Text.RegularExpressions.Regex.Replace(System.String,System.String,System.Text.RegularExpressions.MatchEvaluator,System.Text.RegularExpressions.RegexOptions)> method includes the <xref:System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace?displayProperty=nameWithType> option so that the comment in the regular expression pattern `\w+  # Matches all the characters in a word.` is ignored by the regular expression engine.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace13.cs" interactive="try-dotnet" id="Snippet13":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Replace/replace13.cs" id="Snippet13":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Replace/replace13.vb" id="Snippet13":::
 
  ]]></format>
@@ -6361,24 +6361,24 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 
  If multiple matches are adjacent to one another, an empty string is inserted into the array. For example, splitting a string on a single hyphen causes the returned array to include an empty string in the position where two adjacent hyphens are found, as the following code shows.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split1.vb" id="Snippet1":::
 
  If a match is found at the beginning or the end of the input string, an empty string is included at the beginning or the end of the returned array. The following example uses the regular expression pattern `\d+` to split an input string on numeric characters. Because the string begins and ends with matching numeric characters, the value of the first and last element of the returned array is <xref:System.String.Empty?displayProperty=nameWithType>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split21.cs" interactive="try-dotnet" id="Snippet21":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split21.cs" id="Snippet21":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split21.vb" id="Snippet21":::
 
  If capturing parentheses are used in a <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=nameWithType> expression, any captured text is included in the resulting string array. For example, if you split the string "plum-pear" on a hyphen placed within capturing parentheses, the returned array includes a string element that contains the hyphen.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split2.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split2.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split2.vb" id="Snippet2":::
 
 If the regular expression pattern includes multiple sets of capturing parentheses, and a match isn't found within the first set of capturing parentheses, captured text from additional capturing parentheses is included in the returned array.
 
  If the regular expression can match the empty string, <xref:System.Text.RegularExpressions.Regex.Split(System.String)> splits the string into an array of single-character strings because the empty string delimiter can be found at every location. For example:
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split11.cs" interactive="try-dotnet" id="Snippet11":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split11.cs" id="Snippet11":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split11.vb" id="Snippet11":::
 
  Note that the returned array also includes an empty string at the beginning and end of the array.
@@ -6449,17 +6449,17 @@ If the regular expression pattern includes multiple sets of capturing parenthese
 
  If multiple matches are adjacent to one another or if a match is found at the beginning or end of `input`, and the number of matches found is at least two less than `count`, an empty string is inserted into the array. That is, empty strings that result from adjacent matches or from matches at the beginning or end of the input string are counted in determining whether the number of matched substrings equals `count`. In the following example, the regular expression `/d+` is used to split an input string that includes one or more decimal digits into a maximum of three substrings. Because the beginning of the input string matches the regular expression pattern, the first array element contains <xref:System.String.Empty?displayProperty=nameWithType>, the second contains the first set of alphabetic characters in the input string, and the third contains the remainder of the string that follows the third match.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split25.cs" interactive="try-dotnet" id="Snippet25":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split25.cs" id="Snippet25":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split25.vb" id="Snippet25":::
 
  If capturing parentheses are used in a regular expression, any captured text is included in the array of split strings. However, any array elements that contain captured text are not counted in determining whether the number of matches has reached `count`. For example, splitting the string "apple-apricot-plum-pear-banana" into a maximum of four substrings results in a seven-element array, as the following code shows.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split4.cs" interactive="try-dotnet" id="Snippet4":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split4.cs" id="Snippet4":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split4.vb" id="Snippet4":::
 
 If the regular expression pattern includes multiple sets of capturing parentheses, and a match isn't found within the first set of capturing parentheses, captured text from additional capturing parentheses is included in the returned array. However, elements in the returned array that contain captured text are not counted in determining whether the number of matched substrings equals `count`. For example, in the following code, a regular expression uses two sets of capturing parentheses to extract the elements of a date from a date string. The first set of capturing parentheses captures the hyphen, and the second set captures the forward slash. The call to the <xref:System.Text.RegularExpressions.Regex.Split(System.String,System.Int32)> method then specifies a maximum of two elements in the returned array. The method returns a three-element string array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split5.cs" interactive="try-dotnet" id="Snippet5":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split5.cs" id="Snippet5":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split5.vb" id="Snippet5":::
 
  If the regular expression can match the empty string, <xref:System.Text.RegularExpressions.Regex.Split(System.String,System.Int32)> will split the string into an array of single-character strings because the empty string delimiter can be found at every location. The following example splits the string "characters" into as many elements as there are in the input string. Because the null string matches the beginning of the input string, a null string is inserted at the beginning of the returned array. This causes the tenth element to consist of the two characters at the end of the input string.
@@ -6544,24 +6544,24 @@ If the regular expression pattern includes multiple sets of capturing parenthese
 
  If multiple matches are adjacent to one another, an empty string is inserted into the array. For example, splitting a string on a single hyphen causes the returned array to include an empty string in the position where two adjacent hyphens are found, as the following code shows.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split8.cs" interactive="try-dotnet" id="Snippet8":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split8.cs" id="Snippet8":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split8.vb" id="Snippet8":::
 
  If a match is found at the beginning or the end of the input string, an empty string is included at the beginning or the end of the returned array. The following example uses the regular expression pattern `\d+` to split an input string on numeric characters. Because the string begins and ends with matching numeric characters, the value of the first and last element of the returned array is <xref:System.String.Empty?displayProperty=nameWithType>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split22.cs" interactive="try-dotnet" id="Snippet22":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split22.cs" id="Snippet22":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split22.vb" id="Snippet22":::
 
  If capturing parentheses are used in a <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=nameWithType> expression, any captured text is included in the resulting string array. For example, if you split the string "plum-pear" on a hyphen placed within capturing parentheses, the returned array includes a string element that contains the hyphen.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split9.cs" interactive="try-dotnet" id="Snippet9":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split9.cs" id="Snippet9":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split9.vb" id="Snippet9":::
 
 If the regular expression pattern includes multiple sets of capturing parentheses, and a match isn't found within the first set of capturing parentheses, captured text from additional capturing parentheses is included in the returned array.
 
  If the regular expression can match the empty string, <xref:System.Text.RegularExpressions.Regex.Split%2A> will split the string into an array of single-character strings because the empty string delimiter can be found at every location. For example:
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split13.cs" interactive="try-dotnet" id="Snippet13":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split13.cs" id="Snippet13":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split13.vb" id="Snippet13":::
 
  Note that the returned array also includes an empty string at the beginning and end of the array.
@@ -6642,19 +6642,19 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 
  If multiple matches are adjacent to one another and the number of matches found is at least two less than `count`, an empty string is inserted into the array. Similarly, if a match is found at `startat`, which is the first character in the string, the first element of the returned array is an empty string. That is, empty strings that result from adjacent matches are counted in determining whether the number of matched substrings equals `count`. In the following example, the regular expression `\d+` is used to find the starting position of the first substring of numeric characters in a string, and then to split the string a maximum of three times starting at that position. Because the regular expression pattern matches the beginning of the input string, the returned string array consists of an empty string, a five-character alphabetic string, and the remainder of the string,
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split26.cs" interactive="try-dotnet" id="Snippet26":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split26.cs" id="Snippet26":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split26.vb" id="Snippet26":::
 
  If capturing parentheses are used in a regular expression, any captured text is included in the array of split strings. However, any array elements that contain captured text are not counted in determining whether the number of matches has reached `count`. For example, splitting the string '"apple-apricot-plum-pear-pomegranate-pineapple-peach" into a maximum of four substrings beginning at character 15 in the string results in a seven-element array, as the following code shows.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split6.cs" interactive="try-dotnet" id="Snippet6":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split6.cs" id="Snippet6":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split6.vb" id="Snippet6":::
 
  However, when the regular expression pattern includes multiple sets of capturing parentheses and a match isn't found within the first set of capturing parentheses, captured text from additional capturing parentheses is included in the returned array.
 
  If the regular expression can match the empty string, <xref:System.Text.RegularExpressions.Regex.Split%2A> splits the string into an array of single-character strings because the empty string delimiter can be found at every location. The following example splits the string "characters" into as many elements as the input string contains, starting with the character "a". Because the null string matches the end of the input string, a null string is inserted at the end of the returned array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split14.cs" interactive="try-dotnet" id="Snippet14":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split14.cs" id="Snippet14":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split14.vb" id="Snippet14":::
 
  The <xref:System.Text.RegularExpressions.RegexMatchTimeoutException> exception is thrown if the execution time of the split operation exceeds the time-out interval specified by the <xref:System.Text.RegularExpressions.Regex.%23ctor(System.String,System.Text.RegularExpressions.RegexOptions,System.TimeSpan)?displayProperty=nameWithType> constructor. If you do not set a time-out interval when you call the constructor, the exception is thrown if the operation exceeds any time-out value established for the application domain in which the <xref:System.Text.RegularExpressions.Regex> object is created. If no time-out is defined in the <xref:System.Text.RegularExpressions.Regex> constructor call or in the application domain's properties, or if the time-out value is <xref:System.Text.RegularExpressions.Regex.InfiniteMatchTimeout?displayProperty=nameWithType>, no exception is thrown
@@ -6741,12 +6741,12 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 
  If a match is found at the beginning or the end of the input string, an empty string is included at the beginning or the end of the returned array. The following example uses the regular expression pattern `[a-z]+` to split an input string on any uppercase or lowercase alphabetic character. Because the string begins and ends with matching alphabetic characters, the value of the first and last element of the returned array is <xref:System.String.Empty?displayProperty=nameWithType>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split24.cs" interactive="try-dotnet" id="Snippet24":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split24.cs" id="Snippet24":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split24.vb" id="Snippet24":::
 
  If capturing parentheses are used in a <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=nameWithType> expression, any captured text is included in the resulting string array. For example, if you split the string "plum-pear" on a hyphen placed within capturing parentheses, the returned array includes a string element that contains the hyphen.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split9.cs" interactive="try-dotnet" id="Snippet9":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split9.cs" id="Snippet9":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split9.vb" id="Snippet9":::
 
  However, when the regular expression pattern includes multiple sets of capturing parentheses, and a match is not found within the first set of capturing parentheses, captured text from additional capturing parentheses is included in the returned array.
@@ -6841,12 +6841,12 @@ For more details about `startat`, see the Remarks section of <xref:System.Text.R
 
  If a match is found at the beginning or the end of the input string, an empty string is included at the beginning or the end of the returned array. The following example uses the regular expression pattern `[a-z]+` to split an input string on any uppercase or lowercase alphabetic character. Because the string begins and ends with matching alphabetic characters, the value of the first and last element of the returned array is <xref:System.String.Empty?displayProperty=nameWithType>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split23.cs" interactive="try-dotnet" id="Snippet23":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split23.cs" id="Snippet23":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split23.vb" id="Snippet23":::
 
  If capturing parentheses are used in a <xref:System.Text.RegularExpressions.Regex.Split%2A?displayProperty=nameWithType> expression, any captured text is included in the resulting string array. For example, if you split the string "plum-pear" on a hyphen placed within capturing parentheses, the returned array includes a string element that contains the hyphen.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split9.cs" interactive="try-dotnet" id="Snippet9":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/Regex/Split/split9.cs" id="Snippet9":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/Regex/Split/split9.vb" id="Snippet9":::
 
  However, when the regular expression pattern includes multiple sets of capturing parentheses, and a match is not found within the first set of capturing parentheses, captured text from additional capturing parentheses is included in the returned array.

--- a/xml/System.Text.RegularExpressions/RegexOptions.xml
+++ b/xml/System.Text.RegularExpressions/RegexOptions.xml
@@ -80,7 +80,7 @@
 ## Examples
  The following example defines two regular expressions that identify repeated words in text but that are instantiated using different `RegexOptions` values. The first regular expression is case-insensitive; case is ignored when determining whether a word is identical to the preceding word. The second regular expression is case-sensitive; a word must match the case of the preceding word exactly to be considered a duplicate.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/RegexOptions/Overview/RegexOptions.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text.RegularExpressions/RegexOptions/Overview/RegexOptions.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text.RegularExpressions/RegexOptions/Overview/RegexOptions.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Text/ASCIIEncoding.xml
+++ b/xml/System.Text/ASCIIEncoding.xml
@@ -81,7 +81,7 @@
 ## Examples
  The following example demonstrates how to encode Unicode characters into ASCII. Notice the loss of data that occurs when your application uses <xref:System.Text.ASCIIEncoding> to encode Unicode characters outside of the ASCII range.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/ASCIIEncoding/Overview/snippet.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/ASCIIEncoding/Overview/snippet.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/ASCIIEncoding/Overview/snippet.vb" id="Snippet1":::
 
  ]]></format>
@@ -696,7 +696,7 @@
 ## Examples
  The following example demonstrates how to use the <xref:System.Text.ASCIIEncoding.GetBytes%2A> method to encode a range of characters from a string and store the encoded characters in a range of elements in a byte array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/ASCIIEncoding/GetBytes/getbytes-string-int32-int32-byte[]-int32.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/ASCIIEncoding/GetBytes/getbytes-string-int32-int32-byte[]-int32.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/ASCIIEncoding/GetBytes/getbytes-string-int32-int32-byte[]-int32.vb" id="Snippet1":::
 
  ]]></format>
@@ -802,7 +802,7 @@
 ## Examples
  The following example demonstrates how to use the <xref:System.Text.ASCIIEncoding.GetBytes%2A> method to encode a range of elements from a Unicode character array and store the encoded bytes in a range of elements in a byte array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/ASCIIEncoding/GetBytes/getbytes-char[]-int32-int32-byte[]-int32.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/ASCIIEncoding/GetBytes/getbytes-char[]-int32-int32-byte[]-int32.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/ASCIIEncoding/GetBytes/getbytes-char[]-int32-int32-byte[]-int32.vb" id="Snippet1":::
 
  ]]></format>
@@ -1708,7 +1708,7 @@
 ## Examples
  The following example demonstrates how to use the <xref:System.Text.ASCIIEncoding.GetString%2A> method to convert a byte array into a <xref:System.String>.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/ASCIIEncoding/GetString/getstring-byte[].cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/ASCIIEncoding/GetString/getstring-byte[].cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/ASCIIEncoding/GetString/getstring-byte[].vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Text/Decoder.xml
+++ b/xml/System.Text/Decoder.xml
@@ -83,7 +83,7 @@ The <xref:System.Text.Decoder.GetCharCount%2A> method determines how many charac
       <format type="text/markdown"><![CDATA[
 The following example demonstrates the use of a <xref:System.Text.Decoder> to convert two different byte arrays into a character array. One of the character's bytes spans the arrays. This is similar to what a <xref:System.IO.StreamReader> object does internally when reading a stream.
 
-:::code language="csharp" source="~/snippets/csharp/System.Text/Decoder/Overview/source.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Text/Decoder/Overview/source.cs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Text/Decoder/Overview/source.vb" id="Snippet1":::
       ]]></format>
     </example>

--- a/xml/System.Text/Encoder.xml
+++ b/xml/System.Text/Encoder.xml
@@ -85,7 +85,7 @@ A <xref:System.Text.Encoder> object maintains state information between successi
       <format type="text/markdown"><![CDATA[
 The following example demonstrates how to convert an array of Unicode characters into blocks of bytes using a specified encoding. For comparison, the array of characters is first encoded using <xref:System.Text.UTF7Encoding>. Next, the array of characters is encoded using an <xref:System.Text.Encoder>.
 
-:::code language="csharp" source="~/snippets/csharp/System.Text/Encoder/Overview/snippet.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Text/Encoder/Overview/snippet.cs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoder/Overview/snippet.vb" id="Snippet1":::
       ]]></format>
     </example>

--- a/xml/System.Text/Encoding.xml
+++ b/xml/System.Text/Encoding.xml
@@ -91,7 +91,7 @@ The following example converts a string from one encoding to another.
 > [!NOTE]
 > The `byte[]` array is the only type in this example that contains the encoded data. The .NET `Char` and `String` types are themselves Unicode, so the <xref:System.Text.Encoding.GetChars%2A> call decodes the data back to Unicode.
 
-:::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Overview/convert.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Overview/convert.cs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/Overview/convert.vb" id="Snippet1":::
       ]]></format>
     </example>
@@ -352,14 +352,14 @@ The following example converts a string from one encoding to another.
 
  The <xref:System.Text.ASCIIEncoding> object that is returned by this property might not have the appropriate behavior for your app. It uses replacement fallback to replace each string that it cannot encode and each byte that it cannot decode with a question mark ("?") character. Instead, you can call the <xref:System.Text.Encoding.GetEncoding%28System.String%2CSystem.Text.EncoderFallback%2CSystem.Text.DecoderFallback%29> method to instantiate an <xref:System.Text.ASCIIEncoding> object whose fallback is either an <xref:System.Text.EncoderFallbackException> or a <xref:System.Text.DecoderFallbackException>, as the following example illustrates.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/ASCII/encoding.ascii2.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/ASCII/encoding.ascii2.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/ASCII/encoding.ascii2.vb" id="Snippet1":::
 
 ## Examples
 
 The following example demonstrates the effect of the ASCII encoding on characters that are outside the ASCII range.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/ASCII/ascii.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/ASCII/ascii.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/ASCII/ascii.vb" id="Snippet1":::
 
  ]]></format>
@@ -420,7 +420,7 @@ The following example demonstrates the effect of the ASCII encoding on character
 ## Remarks
  The <xref:System.Text.UnicodeEncoding> object that is returned by this property may not have the appropriate behavior for your app. It uses replacement fallback to replace each string that it cannot encode and each byte that it cannot decode with a question mark ("?") character. Instead, you can call the <xref:System.Text.UnicodeEncoding.%23ctor%28System.Boolean%2CSystem.Boolean%2CSystem.Boolean%29?displayProperty=nameWithType> constructor to instantiate a big endian <xref:System.Text.UnicodeEncoding> object whose fallback is either an <xref:System.Text.EncoderFallbackException> or a <xref:System.Text.DecoderFallbackException>, as the following example illustrates.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/bigendianunicode1.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/bigendianunicode1.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/BigEndianUnicode/bigendianunicode1.vb" id="Snippet2":::
 
  The returned <xref:System.Text.UnicodeEncoding> object has <xref:System.Text.Encoding.BodyName%2A>, <xref:System.Text.Encoding.HeaderName%2A>, and <xref:System.Text.Encoding.WebName%2A> properties, which yield the name "unicodeFFFE". Although the UTF-16 big endian byte order mark is hexadecimal FEFF, the name "unicodeFFFE" was chosen because the byte order mark appears as hexadecimal FFFE on little endian Windows computers.
@@ -433,7 +433,7 @@ The following example demonstrates the effect of the ASCII encoding on character
 
  The following example determines the number of bytes required to encode a character array, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.vb" id="Snippet1":::
 
  ]]></format>
@@ -702,7 +702,7 @@ The following example demonstrates the effect of the ASCII encoding on character
 ## Examples
  The following example converts a Unicode-encoded string to an ASCII-encoded string. Because the ASCII encoding object returned by the <xref:System.Text.Encoding.ASCII%2A> property uses replacement fallback and the Pi character is not part of the ASCII character set, the Pi character is replaced with a question mark, as the output from the example shows.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Overview/convert.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Overview/convert.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/Overview/convert.vb" id="Snippet1":::
 
  ]]></format>
@@ -1203,7 +1203,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example gets two instances of the same encoding (one by codepage and another by name), and checks their equality.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Equals/equals.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Equals/equals.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/Equals/equals.vb" id="Snippet1":::
 
  ]]></format>
@@ -1292,7 +1292,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example determines the number of bytes required to encode a character array, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.vb" id="Snippet1":::
 
  ]]></format>
@@ -1438,7 +1438,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example determines the number of bytes required to encode a string or a range in the string, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_string.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_string.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetByteCount/getbytes_string.vb" id="Snippet1":::
 
  ]]></format>
@@ -1625,7 +1625,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example determines the number of bytes required to encode three characters from a character array, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_chararric.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_chararric.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetByteCount/getbytes_chararric.vb" id="Snippet1":::
 
  ]]></format>
@@ -1715,7 +1715,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example determines the number of bytes required to encode three characters from a character array, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_chararric.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_chararric.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetByteCount/getbytes_chararric.vb" id="Snippet1":::
 
  ]]></format>
@@ -1802,7 +1802,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example determines the number of bytes required to encode a character array, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.vb" id="Snippet1":::
 
  ]]></format>
@@ -1889,7 +1889,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example determines the number of bytes required to encode a string or a range in the string, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_string.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_string.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetByteCount/getbytes_string.vb" id="Snippet1":::
 
  ]]></format>
@@ -2049,7 +2049,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example determines the number of bytes required to encode three characters from a character array, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_chararric.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_chararric.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetByteCount/getbytes_chararric.vb" id="Snippet1":::
 
  ]]></format>
@@ -2139,7 +2139,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example determines the number of bytes required to encode a string or a range in the string, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_string.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_string.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetByteCount/getbytes_string.vb" id="Snippet1":::
 
  ]]></format>
@@ -2334,7 +2334,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example determines the number of bytes required to encode three characters from a character array, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_chararric.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_chararric.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetByteCount/getbytes_chararric.vb" id="Snippet1":::
 
  ]]></format>
@@ -2447,7 +2447,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example determines the number of bytes required to encode a string or a range in the string, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_string.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetByteCount/getbytes_string.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetByteCount/getbytes_string.vb" id="Snippet1":::
 
  ]]></format>
@@ -2560,7 +2560,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example encodes a string into an array of bytes, and then decodes the bytes into an array of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetCharCount/getchars.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetCharCount/getchars.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetCharCount/getchars.vb" id="Snippet1":::
 
  ]]></format>
@@ -2808,12 +2808,12 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example converts a string from one encoding to another.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Overview/convert.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Overview/convert.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/Overview/convert.vb" id="Snippet1":::
 
  The following example encodes a string into an array of bytes, and then decodes a range of the bytes into an array of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetCharCount/getcharsic.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetCharCount/getcharsic.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetCharCount/getcharsic.vb" id="Snippet1":::
 
  ]]></format>
@@ -2921,7 +2921,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example encodes a string into an array of bytes, and then decodes the bytes into an array of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetCharCount/getchars.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetCharCount/getchars.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetCharCount/getchars.vb" id="Snippet1":::
 
  ]]></format>
@@ -3085,7 +3085,7 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example encodes a string into an array of bytes, and then decodes a range of the bytes into an array of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetCharCount/getcharsic.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetCharCount/getcharsic.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetCharCount/getcharsic.vb" id="Snippet1":::
 
  ]]></format>
@@ -3308,12 +3308,12 @@ For more information about this API, see <see href="/dotnet/fundamentals/runtime
 ## Examples
  The following example converts a string from one encoding to another.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Overview/convert.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Overview/convert.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/Overview/convert.vb" id="Snippet1":::
 
  The following example encodes a string into an array of bytes, and then decodes a range of the bytes into an array of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetCharCount/getcharsic.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetCharCount/getcharsic.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetCharCount/getcharsic.vb" id="Snippet1":::
 
  ]]></format>
@@ -3573,7 +3573,7 @@ You can also supply a value of 0 for the `codepage` argument. The behavior varie
 ## Examples
  The following example gets two instances of the same encoding (one by code page and another by name), and checks their equality.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Equals/equals.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Equals/equals.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/Equals/equals.vb" id="Snippet1":::
 
  ]]></format>
@@ -3664,7 +3664,7 @@ In .NET 5 and later versions, the code page name `utf-7` is not supported.
 ## Examples
  The following example gets two instances of the same encoding (one by code page and another by name), and checks their equality.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Equals/equals.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Equals/equals.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/Equals/equals.vb" id="Snippet1":::
 
  ]]></format>
@@ -3777,7 +3777,7 @@ You can also supply a value of 0 for the `codepage` argument. The behavior varie
 ## Examples
  The following example demonstrates the <xref:System.Text.Encoding.GetEncoding%28System.String%2CSystem.Text.EncoderFallback%2CSystem.Text.DecoderFallback%29?displayProperty=nameWithType> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/EncoderReplacementFallback/Overview/fallEncRpl.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/EncoderReplacementFallback/Overview/fallEncRpl.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/EncoderReplacementFallback/Overview/fallEncRpl.vb" id="Snippet1":::
 
  ]]></format>
@@ -3869,7 +3869,7 @@ In .NET 5 and later versions, the code page name `utf-7` is not supported.
 ## Examples
  The following example demonstrates the <xref:System.Text.Encoding.GetEncoding%28System.String%2CSystem.Text.EncoderFallback%2CSystem.Text.DecoderFallback%29?displayProperty=nameWithType> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/EncoderReplacementFallback/Overview/fallEncRpl.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/EncoderReplacementFallback/Overview/fallEncRpl.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/EncoderReplacementFallback/Overview/fallEncRpl.vb" id="Snippet1":::
 
  ]]></format>
@@ -4077,7 +4077,7 @@ In .NET 5 and later versions, the code page name `utf-7` is not supported.
 ## Examples
  The following example determines the number of bytes required to encode a character array, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.vb" id="Snippet1":::
 
  ]]></format>
@@ -4166,7 +4166,7 @@ In .NET 5 and later versions, the code page name `utf-7` is not supported.
 ## Examples
  The following example encodes a string into an array of bytes, and then decodes the bytes into an array of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetCharCount/getchars.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetCharCount/getchars.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetCharCount/getchars.vb" id="Snippet1":::
 
  ]]></format>
@@ -4267,7 +4267,7 @@ In .NET 5 and later versions, the code page name `utf-7` is not supported.
 ## Examples
  The following example determines the byte order of the encoding based on the preamble.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetPreamble/preamble.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/GetPreamble/preamble.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/GetPreamble/preamble.vb" id="Snippet1":::
 
  ]]></format>
@@ -5487,13 +5487,13 @@ Starting with .NET Framework 4.6, .NET Framework includes one encoding provider,
 
  The <xref:System.Text.UnicodeEncoding> object that is returned by this property may not have the appropriate behavior for your app. It uses replacement fallback to replace each string that it cannot encode and each byte that it cannot decode with a question mark ("?") character. Instead, you can call the <xref:System.Text.UnicodeEncoding.%23ctor%28System.Boolean%2CSystem.Boolean%2CSystem.Boolean%29?displayProperty=nameWithType> constructor to instantiate a little endian <xref:System.Text.UnicodeEncoding> object whose fallback is either an <xref:System.Text.EncoderFallbackException> or a <xref:System.Text.DecoderFallbackException>, as the following example illustrates.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Unicode/unicode1.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/Unicode/unicode1.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/Unicode/unicode1.vb" id="Snippet2":::
 
 ## Examples
  The following example determines the number of bytes required to encode a character array, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.vb" id="Snippet1":::
 
  ]]></format>
@@ -5551,7 +5551,7 @@ Starting with .NET Framework 4.6, .NET Framework includes one encoding provider,
 ## Remarks
  The <xref:System.Text.UTF32Encoding> object that is returned by this property may not have the appropriate behavior for your app. It uses replacement fallback to replace each string that it cannot encode and each byte that it cannot decode with the Unicode REPLACEMENT CHARACTER (U+FFFE). Instead, you can call the <xref:System.Text.UTF32Encoding.%23ctor%28System.Boolean%2CSystem.Boolean%2CSystem.Boolean%29?displayProperty=nameWithType> constructor to instantiate a <xref:System.Text.UTF32Encoding> object whose fallback is either an <xref:System.Text.EncoderFallbackException> or a <xref:System.Text.DecoderFallbackException>, as the following example illustrates.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/UTF32/encoding.utf32.1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/UTF32/encoding.utf32.1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/UTF32/encoding.utf32.1.vb" id="Snippet1":::
 
  For a discussion of little endian byte order, see <xref:System.Text.Encoding>.
@@ -5561,7 +5561,7 @@ Starting with .NET Framework 4.6, .NET Framework includes one encoding provider,
 ## Examples
  The following example determines the number of bytes required to encode a character array, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.vb" id="Snippet1":::
 
  ]]></format>
@@ -5630,7 +5630,7 @@ Starting with .NET Framework 4.6, .NET Framework includes one encoding provider,
 ## Examples
  The following example determines the number of bytes required to encode a character array, encodes the characters, and displays the resulting bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/BigEndianUnicode/getbytes_chararr.vb" id="Snippet1":::
 
  ]]></format>
@@ -5701,7 +5701,7 @@ Starting with .NET Framework 4.6, .NET Framework includes one encoding provider,
 
 - It returns a <xref:System.Text.UTF8Encoding> object that uses replacement fallback to replace each string that it can't encode and each byte that it can't decode with a question mark ("?") character. Instead, you can call the <xref:System.Text.UTF8Encoding.%23ctor%28System.Boolean%2CSystem.Boolean%29?displayProperty=nameWithType> constructor to instantiate a <xref:System.Text.UTF8Encoding> object whose fallback is either an <xref:System.Text.EncoderFallbackException> or a <xref:System.Text.DecoderFallbackException>, as the following example illustrates.
 
-     :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/UTF8/encoding.utf8.1.cs" interactive="try-dotnet" id="Snippet1":::
+     :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/UTF8/encoding.utf8.1.cs" id="Snippet1":::
      :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/UTF8/encoding.utf8.1.vb" id="Snippet1":::
 
 ## Examples
@@ -5721,7 +5721,7 @@ Starting with .NET Framework 4.6, .NET Framework includes one encoding provider,
 
  It displays the UTF-16 code units of each character and determines the number of bytes required by a UTF-8 encoder to encode the character array. It then encodes the characters and displays the resulting UTF-8-encoded bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/UTF8/example1.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/Encoding/UTF8/example1.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/Encoding/UTF8/example1.vb" id="Snippet2":::
 
  ]]></format>

--- a/xml/System.Text/StringBuilder.xml
+++ b/xml/System.Text/StringBuilder.xml
@@ -78,7 +78,7 @@
       <format type="text/markdown"><![CDATA[
 The following example shows how to call many of the methods defined by the <xref:System.Text.StringBuilder> class.
 
-:::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Overview/StringBuilder.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Overview/StringBuilder.cs" id="Snippet1":::
 :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/Overview/StringBuilder.fs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/Overview/StringBuilder.vb" id="Snippet1":::
       ]]></format>
@@ -1258,7 +1258,7 @@ The following example shows how to call many of the methods defined by the <xref
 ## Remarks
  The <xref:System.Text.StringBuilder.Append%28System.Object%29> method modifies the existing instance of this class; it does not return a new class instance. Because of this, you can call a method or property on the existing reference and you do not have to assign the return value to a <xref:System.Text.StringBuilder> object, as the following example illustrates. It defines a `Dog` class, creates a `Dog` object, and makes three calls to the <xref:System.Text.StringBuilder.Append%2A> method to create a string that contains the dog's name and breed.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Append/append4.cs" interactive="try-dotnet" id="Snippet18":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Append/append4.cs" id="Snippet18":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/Append/append4.fs" id="Snippet18":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/Append/append4.vb" id="Snippet18":::
 
@@ -2489,7 +2489,7 @@ The following example shows how to call many of the methods defined by the <xref
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.AppendFormat%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appfmt.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appfmt.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/AppendFormat/appfmt.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/AppendFormat/appfmt.vb" id="Snippet1":::
 
@@ -2617,7 +2617,7 @@ The following example shows how to call many of the methods defined by the <xref
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.AppendFormat%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appfmt.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appfmt.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/AppendFormat/appfmt.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/AppendFormat/appfmt.vb" id="Snippet1":::
 
@@ -2974,13 +2974,13 @@ The index of a format item is less than 0 (zero), or greater than or equal to th
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.AppendFormat%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appfmt.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appfmt.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/AppendFormat/appfmt.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/AppendFormat/appfmt.vb" id="Snippet1":::
 
  The following example defines a custom <xref:System.IFormatProvider> implementation named `CustomerFormatter` that formats a 10-digit customer number with hyphens after the fourth and seventh digits. It is passed to the <xref:System.Text.StringBuilder.AppendFormat%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29?displayProperty=nameWithType> method to create a string that includes the formatted customer number and customer name.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/customernumberformatter1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/customernumberformatter1.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/AppendFormat/customernumberformatter1.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/AppendFormat/customernumberformatter1.vb" id="Snippet1":::
 
@@ -3310,7 +3310,7 @@ The index of a format item is less than 0 (zero), or greater than or equal to th
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.AppendFormat%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appfmt.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appfmt.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/AppendFormat/appfmt.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/AppendFormat/appfmt.vb" id="Snippet1":::
 
@@ -3441,7 +3441,7 @@ The index of a format item is less than 0 (zero), or greater than or equal to th
 ## Examples
  The following example uses the <xref:System.Text.StringBuilder.AppendFormat%28System.IFormatProvider%2CSystem.String%2CSystem.Object%2CSystem.Object%29> method to display time and temperature data stored in a generic <xref:System.Collections.Generic.Dictionary%602> object. Note that the format string has three format items, although there are only to objects to format. This is because the first object in the list (a date and time value) is used by two format items: The first format item displays the time, and the second displays the date.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appendformat2.cs" interactive="try-dotnet" id="Snippet3":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appendformat2.cs" id="Snippet3":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/AppendFormat/appendformat2.fs" id="Snippet3":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/AppendFormat/appendformat2.vb" id="Snippet3":::
 
@@ -3565,7 +3565,7 @@ The index of a format item is less than 0 (zero), or greater than or equal to th
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.AppendFormat%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appfmt.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appfmt.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/AppendFormat/appfmt.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/AppendFormat/appfmt.vb" id="Snippet1":::
 
@@ -3698,7 +3698,7 @@ The index of a format item is less than 0 (zero), or greater than or equal to th
 ## Examples
  The following example uses the <xref:System.Text.StringBuilder.AppendFormat%28System.IFormatProvider%2CSystem.String%2CSystem.Object%2CSystem.Object%2CSystem.Object%29> method to illustrate the result of a Boolean `And` operation with integer values. Note that the format string includes six format items, but the method has only three items in its argument list, because each item is formatted in two different ways.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appendformat3.cs" interactive="try-dotnet" id="Snippet4":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendFormat/appendformat3.cs" id="Snippet4":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/AppendFormat/appendformat3.fs" id="Snippet4":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/AppendFormat/appendformat3.vb" id="Snippet4":::
 
@@ -4566,7 +4566,7 @@ The index of a format item is less than 0 (zero), or greater than or equal to th
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.AppendLine%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendLine/al.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/AppendLine/al.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/AppendLine/al.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/AppendLine/al.vb" id="Snippet1":::
 
@@ -4809,7 +4809,7 @@ The index of a format item is less than 0 (zero), or greater than or equal to th
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.Capacity%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Capacity/cap.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Capacity/cap.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/Capacity/cap.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/Capacity/cap.vb" id="Snippet1":::
 
@@ -4874,7 +4874,7 @@ The `index` parameter is the position of a character within the <xref:System.Tex
 
 <xref:System.Text.StringBuilder.Chars(System.Int32)> is the default property of the <xref:System.Text.StringBuilder> class. In C#, it is an indexer. This means that individual characters can be retrieved from the <xref:System.Text.StringBuilder.Chars(System.Int32)> property as shown in the following example, which counts the number of alphabetic, white-space, and punctuation characters in a string.
 
-:::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Chars/chars1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Chars/chars1.cs" id="Snippet1":::
 :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/Chars/chars1.fs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/Chars/chars1.vb" id="Snippet1":::
 
@@ -4940,7 +4940,7 @@ The `index` parameter is the position of a character within the <xref:System.Tex
 
 The following example instantiates a <xref:System.Text.StringBuilder> object with a string, calls the <xref:System.Text.StringBuilder.Clear%2A> method, and then appends a new string.
 
-:::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Clear/clear1.cs" interactive="try-dotnet" id="Snippet1":::
+:::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Clear/clear1.cs" id="Snippet1":::
 :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/Clear/clear1.fs" id="Snippet1":::
 :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/Clear/clear1.vb" id="Snippet1":::
 
@@ -5072,7 +5072,7 @@ The following example instantiates a <xref:System.Text.StringBuilder> object wit
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.CopyTo%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/CopyTo/ct2.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/CopyTo/ct2.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/CopyTo/ct2.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/CopyTo/ct2.vb" id="Snippet1":::
 
@@ -5151,7 +5151,7 @@ The following example instantiates a <xref:System.Text.StringBuilder> object wit
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.EnsureCapacity%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Capacity/cap.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Capacity/cap.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/Capacity/cap.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/Capacity/cap.vb" id="Snippet1":::
 
@@ -5280,7 +5280,7 @@ The `Equals` method performs an ordinal comparison to determine whether the char
 ## Examples
  The following code uses the <xref:System.Text.StringBuilder.Equals%2A> method to check whether two <xref:System.Text.StringBuilder> objects are equal. The method is called repeatedly after small changes are made to each object, and the results are displayed to the console.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Capacity/cap.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Capacity/cap.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/Capacity/cap.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/Capacity/cap.vb" id="Snippet1":::
 
@@ -5371,7 +5371,7 @@ foreach (ReadOnlyMemory<char> chunk in sb.GetChunks())
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.Insert%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Insert/insert.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Insert/insert.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/Insert/insert.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/Insert/insert.vb" id="Snippet1":::
 
@@ -6785,7 +6785,7 @@ The existing characters are shifted to make room for the character sequence in t
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.Length%2A> property.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Capacity/cap.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Capacity/cap.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/Capacity/cap.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/Capacity/cap.vb" id="Snippet1":::
 
@@ -6916,7 +6916,7 @@ In .NET Core and in the .NET Framework 4.0 and later versions, when you instanti
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.Remove%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Remove/remove.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Remove/remove.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/Remove/remove.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/Remove/remove.vb" id="Snippet1":::
 
@@ -6943,7 +6943,7 @@ In .NET Core and in the .NET Framework 4.0 and later versions, when you instanti
 ## Examples
  The following example demonstrates the <xref:System.Text.StringBuilder.Replace%2A> method.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Replace/replace.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/StringBuilder/Replace/replace.cs" id="Snippet1":::
  :::code language="fsharp" source="~/snippets/fsharp/System.Text/StringBuilder/Replace/replace.fs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/StringBuilder/Replace/replace.vb" id="Snippet1":::
 

--- a/xml/System.Text/UTF32Encoding.xml
+++ b/xml/System.Text/UTF32Encoding.xml
@@ -105,12 +105,12 @@
 ## Examples
  The following example demonstrates the behavior of <xref:System.Text.UTF32Encoding> objects with and without error detection enabled. It creates a byte array whose last four bytes represent an invalid surrogate pair; the high surrogate U+D8FF is followed by an U+01FF, which is outside the range of low surrogates (0xDC00 through 0xDFFF). Without error detection, the UTF32 decoder uses replacement fallback to replace the invalid surrogate pair with REPLACEMENT CHARACTER (U+FFFD).
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF32Encoding/Overview/errordetection.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF32Encoding/Overview/errordetection.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF32Encoding/Overview/ErrorDetection.vb" id="Snippet1":::
 
  The following example encodes a string of Unicode characters into a byte array by using a <xref:System.Text.UTF32Encoding> object. The byte array is then decoded into a string to demonstrate that there is no loss of data.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF32Encoding/Overview/snippet.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF32Encoding/Overview/snippet.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF32Encoding/Overview/snippet.vb" id="Snippet1":::
 
  The following example uses the same string as the previous one, except that it writes the encoded bytes to a file and prefixes the byte stream with a byte order mark (BOM). It then reads the file in two different ways: as a text file by using a <xref:System.IO.StreamReader> object; and as a binary file. As you would expect, neither newly-read string includes the BOM.

--- a/xml/System.Text/UTF7Encoding.xml
+++ b/xml/System.Text/UTF7Encoding.xml
@@ -86,7 +86,7 @@
 ## Examples
  The following code example demonstrates how to use a <xref:System.Text.UTF7Encoding> to encode a string of Unicode characters and store them in a byte array. Notice that when the byte array is decoded back to a string, no data is lost.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF7Encoding/Overview/snippet.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF7Encoding/Overview/snippet.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF7Encoding/Overview/snippet.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Text/UTF8Encoding.xml
+++ b/xml/System.Text/UTF8Encoding.xml
@@ -95,12 +95,12 @@
 ## Examples
  The following example uses a <xref:System.Text.UTF8Encoding> object to encode a string of Unicode characters and store them in a byte array. The Unicode string includes two characters, Pi (U+03A0) and Sigma (U+03A3), that are outside the ASCII character range. When the encoded byte array is decoded back to a string, the Pi and Sigma characters are still present.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/Overview/snippet.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/Overview/snippet.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/Overview/snippet.vb" id="Snippet1":::
 
  The following example uses the same string as the previous example, except that it writes the encoded bytes to a file and prefixes the byte stream with a byte order mark (BOM). It then reads the file in two different ways: as a text file by using a <xref:System.IO.StreamReader> object; and as a binary file. As you would expect, neither newly-read string includes the BOM.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/Overview/bom1.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/Overview/bom1.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/Overview/bom1.vb" id="Snippet2":::
 
  ]]></format>
@@ -171,7 +171,7 @@
 ## Examples
  The following example creates a new <xref:System.Text.UTF8Encoding> instance and displays its name.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/.ctor/ctor.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/.ctor/ctor.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/.ctor/ctor.vb" id="Snippet1":::
 
  ]]></format>
@@ -236,7 +236,7 @@
 ## Examples
  The following example creates a new <xref:System.Text.UTF8Encoding> instance and specifies that a Unicode byte order mark prefix should be emitted by the <xref:System.Text.UTF8Encoding.GetPreamble%2A> method. The <xref:System.Text.UTF8Encoding.GetPreamble%2A> method then returns the Unicode byte order mark prefix.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/.ctor/ctor-boolean.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/.ctor/ctor-boolean.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/.ctor/ctor-boolean.vb" id="Snippet1":::
 
  ]]></format>
@@ -304,7 +304,7 @@
 ## Examples
  The following example creates a new <xref:System.Text.UTF8Encoding> instance, specifying that the <xref:System.Text.UTF8Encoding.GetPreamble%2A> method should not emit a Unicode byte order mark prefix, and an exception should be thrown when an invalid encoding is detected. The behavior of this constructor is compared to the default <xref:System.Text.UTF8Encoding.%23ctor> constructor, which does not throw an exception when an invalid encoding is detected. The two <xref:System.Text.UTF8Encoding> instances encode a character array that contains two high surrogates (U+D801 and U+D802) in a row, which is an invalid character sequence; a high surrogate should always be followed by a low surrogate.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/.ctor/ctor-boolean-boolean.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/.ctor/ctor-boolean-boolean.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/.ctor/ctor-boolean-boolean.vb" id="Snippet1":::
 
  ]]></format>
@@ -382,7 +382,7 @@
 ## Examples
  The following example uses the <xref:System.Text.UTF8Encoding.Equals%2A> method to test whether the current <xref:System.Text.UTF8Encoding> object is equal to a different <xref:System.Text.UTF8Encoding> object. Four <xref:System.Text.UTF8Encoding> objects are created and compared and the results of the comparisons are displayed.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/Equals/equals-object.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/Equals/equals-object.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/Equals/equals-object.vb" id="Snippet1":::
 
  ]]></format>
@@ -522,7 +522,7 @@
 ## Examples
  The following example calls the <xref:System.Text.UTF8Encoding.GetMaxByteCount%2A> and <xref:System.Text.UTF8Encoding.GetByteCount%28System.String%29> methods to calculate the maximum and actual number of bytes required to encode a string. It also displays the actual number of bytes required to store a byte stream with a byte order mark.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetByteCount/getbytecount1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetByteCount/getbytecount1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/GetByteCount/getbytecount1.vb" id="Snippet1":::
 
  ]]></format>
@@ -698,7 +698,7 @@
 ## Examples
  The following example populates an array with a Latin uppercase and lowercase characters and calls the <xref:System.Text.UTF8Encoding.GetByteCount%28System.Char%5B%5D%2CSystem.Int32%2CSystem.Int32%29> method to determine the number of bytes needed to encode the Latin lowercase characters. It then displays this information along with the total number of bytes needed if a byte order mark is added. It compares this number with the value returned by the <xref:System.Text.UTF8Encoding.GetMaxByteCount%2A> method, which indicates maximum number of bytes needed to encode the Latin lowercase characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetByteCount/getbytecount2.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetByteCount/getbytecount2.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/GetByteCount/getbytecount2.vb" id="Snippet2":::
 
  ]]></format>
@@ -993,7 +993,7 @@
 ## Examples
  The following example uses the <xref:System.Text.UTF8Encoding.GetBytes%2A> method to encode a range of characters from a string and stores the encoded bytes in a range of elements in a byte array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetBytes/getbytes-string-int32-int32-byte[]-int32.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetBytes/getbytes-string-int32-int32-byte[]-int32.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/GetBytes/getbytes-string-int32-int32-byte[]-int32.vb" id="Snippet1":::
 
  ]]></format>
@@ -1104,7 +1104,7 @@
 ## Examples
  The following example uses the <xref:System.Text.UTF8Encoding.GetBytes%2A> method to encode a range of elements from a Unicode character array and store the encoded bytes in a range of elements in a byte array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetBytes/getbytes-char[]-int32-int32-byte[]-int32.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetBytes/getbytes-char[]-int32-int32-byte[]-int32.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/GetBytes/getbytes-char[]-int32-int32-byte[]-int32.vb" id="Snippet1":::
 
  ]]></format>
@@ -1350,7 +1350,7 @@
 ## Examples
  The following example uses the <xref:System.Text.UTF8Encoding.GetCharCount%2A> method to return the number of characters produced by decoding a range of elements in a byte array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetCharCount/getcharcount-byte[]-int32-int32.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetCharCount/getcharcount-byte[]-int32-int32.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/GetCharCount/getcharcount-byte[]-int32-int32.vb" id="Snippet1":::
 
  ]]></format>
@@ -1615,7 +1615,7 @@
 ## Examples
  The following example uses the <xref:System.Text.UTF8Encoding.GetChars%2A> method to decode a range of elements in a byte array and store the result in a character array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetChars/getchars-byte[]-int32-int32-char[]-int32.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetChars/getchars-byte[]-int32-int32-char[]-int32.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/GetChars/getchars-byte[]-int32-int32-char[]-int32.vb" id="Snippet1":::
 
  ]]></format>
@@ -1706,7 +1706,7 @@
 ## Examples
  The following example uses the <xref:System.Text.UTF8Encoding.GetDecoder%2A> method to obtain a UTF-8 decoder. The decoder converts a sequence of bytes into a sequence of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetDecoder/getdecoder-.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetDecoder/getdecoder-.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/GetDecoder/getdecoder-.vb" id="Snippet1":::
 
  ]]></format>
@@ -1773,7 +1773,7 @@
 ## Examples
  The following example uses the <xref:System.Text.UTF8Encoding.GetEncoder%2A> method to obtain an encoder to convert a sequence of characters into a UTF-8 encoded sequence of bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetEncoder/getencoder-.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetEncoder/getencoder-.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/GetEncoder/getencoder-.vb" id="Snippet1":::
 
  ]]></format>
@@ -1904,7 +1904,7 @@
 ## Examples
  The following example uses the <xref:System.Text.UTF8Encoding.GetMaxByteCount%2A> method to return the maximum number of bytes required to encode a specified number of characters.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetMaxByteCount/getmaxbytecount-int32.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetMaxByteCount/getmaxbytecount-int32.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/GetMaxByteCount/getmaxbytecount-int32.vb" id="Snippet1":::
 
  ]]></format>
@@ -1989,7 +1989,7 @@
 ## Examples
  The following example uses the <xref:System.Text.UTF8Encoding.GetMaxCharCount%2A> method to return the maximum number of characters produced by decoding a specified number of bytes.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetMaxCharCount/getmaxcharcount-int32.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetMaxCharCount/getmaxcharcount-int32.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/GetMaxCharCount/getmaxcharcount-int32.vb" id="Snippet1":::
 
  ]]></format>
@@ -2080,12 +2080,12 @@
 ## Examples
  The following example uses the <xref:System.Text.UTF8Encoding.GetPreamble%2A> method to return the Unicode byte order mark encoded in UTF-8 format. Notice that the parameterless constructor for <xref:System.Text.UTF8Encoding> does not provide a preamble.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetPreamble/getpreamble-.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetPreamble/getpreamble-.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/GetPreamble/getpreamble-.vb" id="Snippet1":::
 
  The following example instantiates two <xref:System.Text.UTF8Encoding> objects, the first by calling the parameterless <xref:System.Text.UTF8Encoding.%23ctor> constructor, which does not provide a BOM, and the second by calling the <xref:System.Text.UTF8Encoding.%23ctor%28System.Boolean%29> constructor with its `encoderShouldEmitUTF8Identifier` argument set to `true`. It then calls the <xref:System.Text.UTF8Encoding.GetPreamble%2A> method to write the BOM to a file before writing a UF8-encoded string. As the console output from the example shows, the file that saves the bytes from the second encoder has three more bytes than the first.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetPreamble/getpreamble1.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UTF8Encoding/GetPreamble/getpreamble1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UTF8Encoding/GetPreamble/getpreamble1.vb" id="Snippet1":::
 
  You can also compare the files by using the `fc` command in a console window, or you can inspect the files in a text editor that includes a Hex View mode. Note that when the file is opened in an editor that supports UTF-8, the BOM is not displayed.

--- a/xml/System.Text/UnicodeEncoding.xml
+++ b/xml/System.Text/UnicodeEncoding.xml
@@ -113,12 +113,12 @@
 ## Examples
  The following example demonstrates how to encode a string of Unicode characters into a byte array by using a <xref:System.Text.UnicodeEncoding> object. The byte array is decoded into a string to demonstrate that there is no loss of data.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/Overview/snippet.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/Overview/snippet.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UnicodeEncoding/Overview/snippet.vb" id="Snippet1":::
 
  The following example uses the same string as the previous one, except that it writes the encoded bytes to a file and prefixes the byte stream with a byte order mark (BOM). It then reads the file in two different ways: as a text file by using a <xref:System.IO.StreamReader> object; and as a binary file. As you would expect, neither newly-read string includes the BOM.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/Overview/bom1.cs" interactive="try-dotnet" id="Snippet2":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/Overview/bom1.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UnicodeEncoding/Overview/bom1.vb" id="Snippet2":::
 
  ]]></format>
@@ -194,7 +194,7 @@
 ## Examples
  The following example demonstrates how to create a new <xref:System.Text.UnicodeEncoding> instance and display the name of the encoding.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/.ctor/ctor.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/.ctor/ctor.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UnicodeEncoding/.ctor/ctor.vb" id="Snippet1":::
 
  ]]></format>
@@ -261,7 +261,7 @@
 ## Examples
  The following example demonstrates how to create a new <xref:System.Text.UnicodeEncoding> instance specifying whether to support little endian or big endian byte ordering and the Unicode byte order mark.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/.ctor/ctor-boolean-boolean.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/.ctor/ctor-boolean-boolean.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UnicodeEncoding/.ctor/ctor-boolean-boolean.vb" id="Snippet1":::
 
  ]]></format>
@@ -329,7 +329,7 @@
 ## Examples
  The following example demonstrates the behavior of <xref:System.Text.UnicodeEncoding>, both with error detection enabled and without.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/.ctor/errordetection.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/.ctor/errordetection.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UnicodeEncoding/.ctor/errordetection.vb" id="Snippet1":::
 
  ]]></format>
@@ -970,7 +970,7 @@
 ## Examples
  The following example demonstrates how to use the <xref:System.Text.UnicodeEncoding.GetBytes%2A> method to encode a range of characters from a <xref:System.String> and store the encoded bytes in a range of elements in a byte array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/GetBytes/getbytes-string-int32-int32-byte[]-int32.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/GetBytes/getbytes-string-int32-int32-byte[]-int32.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UnicodeEncoding/GetBytes/getbytes-string-int32-int32-byte[]-int32.vb" id="Snippet1":::
 
  ]]></format>
@@ -1080,7 +1080,7 @@
 ## Examples
  The following example demonstrates how to encode a range of elements from a Unicode character array and store the encoded bytes in a range of elements in a byte array.
 
- :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/GetBytes/getbytes-char[]-int32-int32-byte[]-int32.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/System.Text/UnicodeEncoding/GetBytes/getbytes-char[]-int32-int32-byte[]-int32.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Text/UnicodeEncoding/GetBytes/getbytes-char[]-int32-int32-byte[]-int32.vb" id="Snippet1":::
 
  ]]></format>

--- a/xml/System.Web/HttpUtility.xml
+++ b/xml/System.Web/HttpUtility.xml
@@ -845,7 +845,7 @@
 ## Examples
  The following code example demonstrates how to use the <xref:System.Web.HttpUtility.ParseQueryString%2A> method. Multiple occurrences of the same query string variable are consolidated in one entry of the returned <xref:System.Collections.Specialized.NameValueCollection>.
 
- :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WebNet/HttpUtility_ParseQueryString/cs/httputility_parsequerystring.cs" interactive="try-dotnet" id="Snippet1":::
+ :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WebNet/HttpUtility_ParseQueryString/cs/httputility_parsequerystring.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/VS_Snippets_WebNet/HttpUtility_ParseQueryString/vb/httputility_parsequerystring.vb" id="Snippet1":::
 
  ]]></format>


### PR DESCRIPTION
This PR removes interactive snippets from every namespace except `System`.

Contributes to dotnet/docs#50331

Notes for reviewers:

1. The diff looks a bit weird because the diff algorithm doesn't prefer words, so the `i` from "interactive" is outside of the diff, and the diff shows I removed the `i` from the following `id=` node.
1. I looked at several of the XML files, and I didn't find any remarks about using the interactive capability. Nor did I find other instances of include files with explanations.
