### PR TITLE
add missing whitespace after link

### DIFF
--- a/xml/System.Windows.Controls/Validation.xml
+++ b/xml/System.Windows.Controls/Validation.xml
@@ -142,7 +142,7 @@
 
 5.  If the binding has an <xref:System.Windows.Controls.ExceptionValidationRule> associated with it and an exception is thrown during step 4, the binding engine checks to see if there is a <xref:System.Windows.Data.Binding.UpdateSourceExceptionFilter%2A>. You have the option to use the <xref:System.Windows.Data.Binding.UpdateSourceExceptionFilter%2A> callback to provide a custom handler for handling exceptions. If an <xref:System.Windows.Data.Binding.UpdateSourceExceptionFilter%2A> is not specified on the <xref:System.Windows.Data.Binding>, the binding engine creates a <xref:System.Windows.Controls.ValidationError> with the exception and adds it to the <xref:System.Windows.Controls.Validation.Errors%2A?displayProperty=nameWithType> collection of the bound element.
 
- Also note that a valid value transfer in either direction (target-to-source or source-to-target) clears the <xref:System.Windows.Controls.Validation>.<xref:System.Windows.Controls.Validation.Errors%2A>attached property.
+ Also note that a valid value transfer in either direction (target-to-source or source-to-target) clears the <xref:System.Windows.Controls.Validation>.<xref:System.Windows.Controls.Validation.Errors%2A> attached property.
 
  For more information, see "Data Validation" in [Data Binding Overview](/dotnet/framework/wpf/data/data-binding-overview).
 
@@ -223,7 +223,7 @@
 
 5.  If the binding has an <xref:System.Windows.Controls.ExceptionValidationRule> associated with it and an exception is thrown during step 4, the binding engine checks to see if there is a <xref:System.Windows.Data.Binding.UpdateSourceExceptionFilter%2A>. You have the option to use the <xref:System.Windows.Data.Binding.UpdateSourceExceptionFilter%2A> callback to provide a custom handler for handling exceptions. If an <xref:System.Windows.Data.Binding.UpdateSourceExceptionFilter%2A> is not specified on the <xref:System.Windows.Data.Binding>, the binding engine creates a <xref:System.Windows.Controls.ValidationError> with the exception and adds it to the <xref:System.Windows.Controls.Validation.Errors%2A?displayProperty=fullName> collection of the bound element.
 
- Also note that a valid value transfer in either direction (target-to-source or source-to-target) clears the <xref:System.Windows.Controls.Validation>.<xref:System.Windows.Controls.Validation.Errors%2A>attached property.
+ Also note that a valid value transfer in either direction (target-to-source or source-to-target) clears the <xref:System.Windows.Controls.Validation>.<xref:System.Windows.Controls.Validation.Errors%2A> attached property.
 
  For information about the behavior of this property in <xref:System.Windows.Data.MultiBinding> scenarios, see <xref:System.Windows.Data.MultiBindingExpression.ValidationError%2A>.
 


### PR DESCRIPTION
Fixes missing whitespace at:

<img width="476" height="96" alt="image" src="https://github.com/user-attachments/assets/e91637c6-291a-4e1e-b5b8-ff373e3586f1" />

on page https://learn.microsoft.com/en-us/dotnet/api/system.windows.controls.validation.errors