### PR TITLE
docs: Add untrusted data security warnings to System.Speech APIs

### DIFF
--- a/xml/System.Speech.Recognition.SrgsGrammar/SrgsDocument.xml
+++ b/xml/System.Speech.Recognition.SrgsGrammar/SrgsDocument.xml
@@ -31,6 +31,8 @@
     <remarks>
       <format type="text/markdown"><![CDATA[
 
+[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)]
+
 ## Remarks
  You can you construct an empty <xref:System.Speech.Recognition.SrgsGrammar.SrgsDocument> instance and build a grammar by adding instances of classes that represent SRGS elements, such as <xref:System.Speech.Recognition.SrgsGrammar.SrgsRule>, <xref:System.Speech.Recognition.SrgsGrammar.SrgsOneOf>,<xref:System.Speech.Recognition.SrgsGrammar.SrgsItem>, <xref:System.Speech.Recognition.SrgsGrammar.SrgsRuleRef>, <xref:System.Speech.Recognition.SrgsGrammar.SrgsSemanticInterpretationTag>, and <xref:System.Speech.Recognition.SrgsGrammar.SrgsToken>. You can also construct an <xref:System.Speech.Recognition.SrgsGrammar.SrgsDocument> instance from an existing SRGS-compliant XML grammar file, from an instance of <xref:System.Speech.Recognition.SrgsGrammar.SrgsRule>, or from an instance of <xref:System.Speech.Recognition.GrammarBuilder>.
 
@@ -284,6 +286,8 @@ recognizer.LoadGrammarAsync(g);
         <remarks>
           <format type="text/markdown"><![CDATA[
 
+[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)]
+
 ## Examples
  The following example creates a new <xref:System.Speech.Recognition.SrgsGrammar.SrgsDocument> from the file named "srgsDocumentFile.xml".
 
@@ -325,6 +329,8 @@ if (File.Exists(srgsDocumentFile))
         <summary>Initializes a new instance of the <see cref="T:System.Speech.Recognition.SrgsGrammar.SrgsDocument" /> class from an instance of <see cref="T:System.Xml.XmlReader" /> that references an XML-format grammar file.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
+
+[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)]
 
 ## Examples
  The following example creates a new instance of <xref:System.Speech.Recognition.SrgsGrammar.SrgsDocument> from an instance of <xref:System.Xml.XmlReader> that references the file "srgsDocumentFile.xml".

--- a/xml/System.Speech.Recognition/Grammar.xml
+++ b/xml/System.Speech.Recognition/Grammar.xml
@@ -437,6 +437,8 @@ private static Grammar CreateSrgsDocumentGrammar()
         <remarks>
           <format type="text/markdown"><![CDATA[
 
+[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)]
+
 ## Remarks
  This constructor does not pass any parameters to the initialization handler, and the description should not define an initialization handler that requires arguments.
 
@@ -539,6 +541,8 @@ private static Grammar CreateGrammarFromFile()
         <summary>Initializes a new instance of the <see cref="T:System.Speech.Recognition.Grammar" /> class from a <see cref="T:System.IO.Stream" /> and specifies a root rule.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
+
+[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)]
 
 ## Remarks
  This constructor does not pass any parameters to the initialization handler, and the description should not define an initialization handler that requires arguments.
@@ -773,6 +777,8 @@ namespace SampleRecognition
         <summary>Initializes a new instance of the <see cref="T:System.Speech.Recognition.Grammar" /> class from a file and specifies a root rule.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
+
+[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)]
 
 ## Remarks
  This constructor does not pass any parameters to the initialization handler, and the description should not define an initialization handler that requires arguments.
@@ -1222,6 +1228,8 @@ private static Grammar CreateSrgsDocumentGrammar3()
         <summary>Initializes a new instance of the <see cref="T:System.Speech.Recognition.Grammar" /> class from a file that contains a grammar definition, and specifies the name of a rule to be the entry point to the grammar.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
+
+[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)]
 
 ## Remarks
  Parameters for an initialization handler may also be specified.

--- a/xml/System.Speech.Recognition/GrammarBuilder.xml
+++ b/xml/System.Speech.Recognition/GrammarBuilder.xml
@@ -2002,6 +2002,8 @@ grammarWithDictation.Name = "Grammar with Dictation";
         <remarks>
           <format type="text/markdown"><![CDATA[
 
+[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)]
+
 ## Remarks
  The URI provided by the `path` argument may be local or remote. The application must have read access to the location of specified grammar files.
 
@@ -2088,6 +2090,8 @@ private static Grammar CreateCitiesGrammar1()
         <summary>Appends the specified rule of a grammar definition file to the current sequence of grammar elements.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
+
+[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)]
 
 ## Remarks
  The URI provided by the `path` argument may be local or remote. The application must have read access to the location of specified grammar files.

--- a/xml/System.Speech.Synthesis/PromptBuilder.xml
+++ b/xml/System.Speech.Synthesis/PromptBuilder.xml
@@ -200,7 +200,13 @@ public void MySimpleText ()
       <Docs>
         <param name="path">A fully qualified path to the audio file.</param>
         <summary>Appends the specified audio file to the <see cref="T:System.Speech.Synthesis.PromptBuilder" />.</summary>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[
+
+[!INCLUDE [untrusted-data-class-note](~/includes/untrusted-data-class-note.md)]
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="AppendAudio">
@@ -959,6 +965,8 @@ namespace SampleSynthesis
         <summary>Appends an <c>XMLReader</c> object that references an SSML prompt to the <see cref="T:System.Speech.Synthesis.PromptBuilder" /> object.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
+
+[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)]
 
 ## Remarks
  The SSML file must be an XML-format file that conforms to the [Speech Synthesis Markup Language (SSML) Version 1.0](https://www.w3.org/TR/speech-synthesis/) specification.


### PR DESCRIPTION
Add untrusted-data-instance-note to APIs that handle external XML/SRGS/SSML/audio files to warn developers about security risks when processing untrusted data.

Changes:
- SrgsDocument: Added class-level warning and warnings to constructors that accept file paths and XmlReader
- Grammar: Added warnings to constructors that accept file paths and streams
- PromptBuilder: Added warnings to AppendSsml(XmlReader) and AppendAudio(string) methods
- GrammarBuilder: Added warnings to AppendRuleReference methods that accept file paths

These APIs can load and parse external files which may contain corrupted or malicious content. The warnings direct developers to validate all inputs per OWASP guidelines.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

