### PR TITLE
xml/System.Threading/Timer.xml: Divides logical blocks to separate paragraphs

### DIFF
--- a/xml/System.Threading/Timer.xml
+++ b/xml/System.Threading/Timer.xml
@@ -393,7 +393,9 @@ The following example defines a `StatusChecker` class that includes a `CheckStat
 
  If `dueTime` is zero (0), `callback` is invoked immediately. If `dueTime` is <xref:System.Threading.Timeout.Infinite?displayProperty=nameWithType>, `callback` is not invoked; the timer is disabled, but can be re-enabled by calling the <xref:System.Threading.Timer.Change%2A> method.
 
- Because the <xref:System.Threading.Timer> class has the same resolution as the system clock, which is approximately 15 milliseconds on Windows 7 and Windows 8 systems, the `callback` delegate executes at intervals defined by the resolution of the system clock if `period` is less than the resolution of the system clock. If `period` is zero (0) or <xref:System.Threading.Timeout.Infinite?displayProperty=nameWithType> and `dueTime` is not <xref:System.Threading.Timeout.Infinite?displayProperty=nameWithType>, `callback` is invoked once; the periodic behavior of the timer is disabled, but can be re-enabled using the <xref:System.Threading.Timer.Change%2A> method.
+ Because the <xref:System.Threading.Timer> class has the same resolution as the system clock, which is approximately 15 milliseconds on Windows 7 and Windows 8 systems, the `callback` delegate executes at intervals defined by the resolution of the system clock if `period` is less than the resolution of the system clock. 
+            
+ If `period` is zero (0) or <xref:System.Threading.Timeout.Infinite?displayProperty=nameWithType> and `dueTime` is not <xref:System.Threading.Timeout.Infinite?displayProperty=nameWithType>, `callback` is invoked once; the periodic behavior of the timer is disabled, but can be re-enabled using the <xref:System.Threading.Timer.Change%2A> method.
 
 > [!NOTE]
 >  The system clock that is used is the same clock used by [GetTickCount](/windows/win32/api/sysinfoapi/nf-sysinfoapi-gettickcount), which is not affected by changes made with [timeBeginPeriod](/windows/win32/api/timeapi/nf-timeapi-timebeginperiod) and [timeEndPeriod](/windows/win32/api/timeapi/nf-timeapi-timeendperiod).


### PR DESCRIPTION
## Summary

I believe the sentence `If period is zero (0) or` should be in separate paragraph. It is the same kind of information as `If  dueTime is zero (0),`(which has it's own separate paragraph)


<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

