### PR TITLE
Fix wording in DataColumn.DataType remarks section

### DIFF
--- a/xml/System.Data/DataColumn.xml
+++ b/xml/System.Data/DataColumn.xml
@@ -1161,7 +1161,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Setting the <xref:System.Data.DataColumn.DataType%2A> value is very important to guaranteeing the correct creation and updating of data in a data source.
+ Setting the <xref:System.Data.DataColumn.DataType%2A> value is very important for guaranteeing the correct creation and updating of data in a data source.
 
  The <xref:System.Data.DataColumn.DataType%2A> property supports the following base .NET Framework data types:
 


### PR DESCRIPTION
The fragment:

> ...is very important **to** guaranteeing...

Should probably read:

> ...is very important **for** guaranteeing...