### PR TITLE
Note that DeserializingResourceReader should not be used with untrusted data

### DIFF
--- a/xml/System.Resources.Extensions/DeserializingResourceReader.xml
+++ b/xml/System.Resources.Extensions/DeserializingResourceReader.xml
@@ -41,7 +41,7 @@
 
 ## Remarks
 
-[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)].
+[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)]
 
 ]]></format>
     </remarks>

--- a/xml/System.Resources/ResourceReader.xml
+++ b/xml/System.Resources/ResourceReader.xml
@@ -107,7 +107,7 @@
 
 ## Remarks
 
-[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)].
+[!INCLUDE [untrusted-data-instance-note](~/includes/untrusted-data-instance-note.md)]
 
  ]]></format>
         </remarks>


### PR DESCRIPTION
The [ResourceReader](https://learn.microsoft.com/dotnet/api/system.resources.resourcereader.-ctor?view=net-8.0) docs cite that only trusted data should be used, but the [DeserializingResourceReader Class](https://learn.microsoft.com/dotnet/api/system.resources.extensions.deserializingresourcereader?view=net-10.0-pp) does not include this note. While it should be implied, it's a good place to call it out.