### PR TITLE
US-543733: Content Update - Localization fix: <dotnet-api-docs> - two hexadecimal

### DIFF
--- a/xml/System/Convert.xml
+++ b/xml/System/Convert.xml
@@ -17764,7 +17764,7 @@
 
 
 ## Examples
- The following example converts each element in an integer array to its equivalent binary, hexadecimal, decimal, and hexadecimal string representations.
+ The following example converts each element in an integer array to its string representation in binary, octal, decimal, and hexadecimal.
 
  :::code language="csharp" source="~/snippets/csharp/System/Convert/ToString/tostring2.cs" id="Snippet11":::
  :::code language="fsharp" source="~/snippets/fsharp/System/Convert/ToString/tostring2.fs" id="Snippet11":::


### PR DESCRIPTION
Per task: https://dev.azure.com/msft-skilling/Content/_workitems/edit/543733, fixed a typo issue.