### PR TITLE
DO NOT SIMPLY MERGE READ DESCRIPTION - InstallUtil doesn't work with net core executables?

### DIFF
--- a/xml/System.ServiceProcess/ServiceBase.xml
+++ b/xml/System.ServiceProcess/ServiceBase.xml
@@ -73,9 +73,7 @@
 
  You do not have to implement <xref:System.ServiceProcess.ServiceBase.OnStart%2A>, <xref:System.ServiceProcess.ServiceBase.OnStop%2A>, or any other method in <xref:System.ServiceProcess.ServiceBase>. However, the service's behavior is described in <xref:System.ServiceProcess.ServiceBase.OnStart%2A>, so at minimum, this member should be overridden. The `main()` function of the executable registers the service in the executable with the Service Control Manager by calling the <xref:System.ServiceProcess.ServiceBase.Run%2A> method. The <xref:System.ServiceProcess.ServiceBase.ServiceName%2A> property of the <xref:System.ServiceProcess.ServiceBase> object passed to the <xref:System.ServiceProcess.ServiceBase.Run%2A> method must match the <xref:System.ServiceProcess.ServiceInstaller.ServiceName%2A> property of the service installer for that service.
 
- You can use `sc create` to install services on your system.
-
-        
+ You can use the `sc create` command to install services that target modern .NET, or use `InstallUtil.exe` to install services that target .NET Framework.
 
 > [!NOTE]
 >  You can specify a log other than the Application event log to receive notification of service calls, but neither the <xref:System.ServiceProcess.ServiceBase.AutoLog%2A> nor the <xref:System.ServiceProcess.ServiceBase.EventLog%2A> property can write to a custom log. Set <xref:System.ServiceProcess.ServiceBase.AutoLog%2A> to `false` if you do not want to use automatic logging.


### PR DESCRIPTION
We tried installing a service executable converted from .net framework 4.8 to net10 using installUtil, as suggested here, but that errored because of a BadImageFormatException:

> Beim Initialisieren der Installation ist eine Ausnahme aufgetreten:
System.BadImageFormatException: Die Datei oder Assembly "file:///D:\Publish\NexusCbfcLite\Nexus.BackgroundService.exe" oder eine Abhängigkeit davon wurde nicht gefunden. Im Modul wurde ein Assemblymanifest erwartet.

I kinda expected that since ServiceUtil is a .net framework process.

using `sc create` worked, though. documentation shoud reflect this (after this is cleared to be correct, of course)

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

