### PR TITLE
Remove inheritance restriction from summary

### DIFF
--- a/xml/System.ComponentModel.Design/ServiceContainer.xml
+++ b/xml/System.ComponentModel.Design/ServiceContainer.xml
@@ -66,7 +66,7 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>Provides a simple implementation of the <see cref="T:System.ComponentModel.Design.IServiceContainer" /> interface. This class cannot be inherited.</summary>
+    <summary>Provides a simple implementation of the <see cref="T:System.ComponentModel.Design.IServiceContainer" /> interface.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[
 


### PR DESCRIPTION
Looks like the class was sealed way back in .NET Framework 1.1. Fixes #12235.