### PR TITLE
Explain what "normal" is in Double.IsNormal

### DIFF
--- a/xml/System/Double.xml
+++ b/xml/System/Double.xml
@@ -2947,7 +2947,7 @@ This method correctly handles floating-point values and so `2.0` and `3.0` will 
       </Parameters>
       <Docs>
         <param name="d">A double-precision floating-point number.</param>
-        <summary>Determines whether the specified value is normal.</summary>
+        <summary>Determines whether the specified value is not NaN, not infinite, not subnormal, and not zero.</summary>
         <returns>
           <see langword="true" /> if the value is normal; <see langword="false" /> otherwise.</returns>
         <remarks>This effectively checks the value is not NaN, not infinite, not subnormal, and not zero.</remarks>


### PR DESCRIPTION
## Summary

The documentation for Double.IsNormal is wholly unhelpful. It says it checks if a number is "Normal". Only in the remarks, "normal" is explained. This changes it to make it clear what it actually checks.