### PR TITLE
Fix parameter reference in TensorPrimitives.Hypot

### DIFF
--- a/xml/System.Numerics.Tensors/TensorPrimitives.xml
+++ b/xml/System.Numerics.Tensors/TensorPrimitives.xml
@@ -5172,7 +5172,7 @@
         <summary>Computes the element-wise hypotenuse given values from two tensors representing the lengths of the shorter sides in a right-angled triangle.</summary>
         <remarks>
           <para>
-            This method effectively computes <c><paramref name="destination" />[i] = T.Hypot(<paramref name="x" />[i], <paramref name="x" />[i])</c>.
+            This method effectively computes <c><paramref name="destination" />[i] = T.Hypot(<paramref name="x" />[i], <paramref name="y" />[i])</c>.
             </para>
         </remarks>
         <exception cref="T:System.ArgumentException">


### PR DESCRIPTION
## Summary

The remark for `TensorPrimitives.Hypot` referred to `x` twice instead of `x` and `y`.

Before:

> This method effectively computes <code>destination[i] = T.Hypot(x[i], x[i])</code>.

After

> This method effectively computes <code>destination[i] = T.Hypot(x[i], y[i])</code>.