### PR TITLE
Update MailAddress.xml with constructor details

### DIFF
--- a/xml/System.Net.Mail/MailAddress.xml
+++ b/xml/System.Net.Mail/MailAddress.xml
@@ -261,6 +261,8 @@ If `displayName` contains non-ASCII characters, the iso-8859-1 character set is 
 
 If `address` contains a display name, and `displayName` is not `null` and is not equal to <xref:System.String.Empty?displayProperty=nameWithType>, `displayName` overrides the value specified in `address`.
 
+The <xref:System.Net.Mail.MailAddress.%23ctor(System.String,System.String)> constructor does not check if the `displayName` parameter is valid. This method removes surrounding quotes not displayed by the <xref:System.Net.Mail.MailAddress.DisplayName> property. Quotes will be added before transmission. <xref:System.Text.Encoding.UTF8> encoding will be applied to the <xref:System.Net.Mail.MailAddress.DisplayName> property before transmission.
+
 ## Examples
 
 The following code example uses this constructor to create <xref:System.Net.Mail.MailAddress> instances for the sender and recipient of an email message.


### PR DESCRIPTION
Clarify behavior of MailAddress constructor regarding displayName and encoding.

Fixes https://github.com/dotnet/runtime/issues/57014
