### PR TITLE
Fix mentions  of equality comparison for collections

### DIFF
--- a/xml/System.Collections.Generic/ICollection`1.xml
+++ b/xml/System.Collections.Generic/ICollection`1.xml
@@ -249,7 +249,8 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- Implementations can vary in how they determine equality of objects; for example, <xref:System.Collections.Generic.List%601> uses <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=nameWithType>, whereas <xref:System.Collections.Generic.Dictionary%602> allows the user to specify the <xref:System.Collections.Generic.IEqualityComparer%601> implementation to use for comparing keys.  
+
+Implementations can vary in how they determine equality of objects; for example, <xref:System.Collections.Generic.List%601> uses <xref:System.Collections.Generic.EqualityComparer%601.Default?displayProperty=nameWithType>, whereas <xref:System.Collections.Generic.Dictionary%602> allows the user to specify the <xref:System.Collections.Generic.IEqualityComparer%601> implementation to use for comparing keys.  
   
  ]]></format>
         </remarks>
@@ -459,7 +460,8 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- Implementations can vary in how they determine equality of objects; for example, <xref:System.Collections.Generic.List%601> uses <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=nameWithType>, whereas, <xref:System.Collections.Generic.Dictionary%602> allows the user to specify the <xref:System.Collections.Generic.IEqualityComparer%601> implementation to use for comparing keys.  
+
+Implementations can vary in how they determine equality of objects; for example, <xref:System.Collections.Generic.List%601> uses <xref:System.Collections.Generic.EqualityComparer%601.Default?displayProperty=nameWithType>, whereas, <xref:System.Collections.Generic.Dictionary%602> allows the user to specify the <xref:System.Collections.Generic.IEqualityComparer%601> implementation to use for comparing keys.  
   
  In collections of contiguous elements, such as lists, the elements that follow the removed element move up to occupy the vacated spot. If the collection is indexed, the indexes of the elements that are moved are also updated. This behavior does not apply to collections where elements are conceptually grouped into buckets, such as a hash table.  
   

--- a/xml/System.Collections.Generic/List`1.xml
+++ b/xml/System.Collections.Generic/List`1.xml
@@ -1036,7 +1036,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=nameWithType> for `T`, the type of values in the list.
+ This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default?displayProperty=nameWithType> for `T`, the type of values in the list.
 
  This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.
 
@@ -3411,7 +3411,7 @@ Public Function StartsWith(e As Employee) As Boolean
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=nameWithType> for `T`, the type of values in the list.
+ This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default?displayProperty=nameWithType> for `T`, the type of values in the list.
 
  This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.
 

--- a/xml/System/Array.xml
+++ b/xml/System/Array.xml
@@ -5574,7 +5574,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This method searches all the elements of a one-dimensional array for `value`. To determine whether `value` exists in `array`, the method performs an equality comparison by using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=nameWithType>.
+ This method searches all the elements of a one-dimensional array for `value`. To determine whether `value` exists in `array`, the method performs an equality comparison by using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default?displayProperty=nameWithType>.
 
  Because most arrays have a lower bound of zero, this method generally returns -1 if`value` isn't found. In the rare case that the lower bound of the array is equal to <xref:System.Int32.MinValue?displayProperty=nameWithType>(0x80000000) and `value` isn't found, this method returns <xref:System.Int32.MaxValue?displayProperty=nameWithType> (0x7FFFFFFF).
 
@@ -5673,7 +5673,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This method searches a one-dimensional array from the element at index `startIndex` to the last element. To determine whether `value` exists in `array`, the method performs an equality comparison by using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=nameWithType>.
+ This method searches a one-dimensional array from the element at index `startIndex` to the last element. To determine whether `value` exists in `array`, the method performs an equality comparison by using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default?displayProperty=nameWithType>.
 
  Because most arrays have a lower bound of zero, this method generally returns -1 if `value` isn't found. In the rare case that the lower bound of the array is equal to <xref:System.Int32.MinValue?displayProperty=nameWithType>(0x80000000) and `value` isn't found, this method returns <xref:System.Int32.MaxValue?displayProperty=nameWithType> (0x7FFFFFFF).
 
@@ -5783,7 +5783,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This method searches the elements of a one-dimensional array from `startIndex` to `startIndex` plus `count` minus 1, if `count` is greater than 0. To determine whether `value` exists in `array`, the method performs an equality comparison by using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=nameWithType>.
+ This method searches the elements of a one-dimensional array from `startIndex` to `startIndex` plus `count` minus 1, if `count` is greater than 0. To determine whether `value` exists in `array`, the method performs an equality comparison by using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default?displayProperty=nameWithType>.
 
  Because most arrays have a lower bound of zero, this method generally returns -1 when `value` isn't found. In the rare case that the lower bound of the array is equal to <xref:System.Int32.MinValue?displayProperty=nameWithType> (0x80000000) and `value` isn't found, this method returns <xref:System.Int32.MaxValue?displayProperty=nameWithType> (0x7FFFFFFF).
 
@@ -5889,7 +5889,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This method searches all the elements of a one-dimensional array for `value`. To determine whether `value` exists in `array`, the method performs an equality comparison by using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=nameWithType>.
+ This method searches all the elements of a one-dimensional array for `value`. To determine whether `value` exists in `array`, the method performs an equality comparison by using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default?displayProperty=nameWithType>.
 
  This method is an O(`n`) operation, where `n` is the <xref:System.Array.Length%2A> of `array`.
 
@@ -5975,7 +5975,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This method searches a one-dimensional array from the element at `startIndex` to the end of the array. To determine whether `value` exists in `array`, the method performs an equality comparison by using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=nameWithType>.
+ This method searches a one-dimensional array from the element at `startIndex` to the end of the array. To determine whether `value` exists in `array`, the method performs an equality comparison by using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default?displayProperty=nameWithType>.
 
  If `startIndex` equals <xref:System.Array.Length%2A>,the method returns -1. If `startIndex` is greater than <xref:System.Array.Length%2A?displayProperty=nameWithType>, the method throws an <xref:System.ArgumentOutOfRangeException>.
 
@@ -6067,7 +6067,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This method searches the elements of a one-dimensional array from `startIndex` to `startIndex` plus `count` minus 1, if `count` is greater than 0. To determine whether `value` exists in `array`, the method performs an equality comparison by using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=nameWithType>.
+ This method searches the elements of a one-dimensional array from `startIndex` to `startIndex` plus `count` minus 1, if `count` is greater than 0. To determine whether `value` exists in `array`, the method performs an equality comparison by using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default?displayProperty=nameWithType>.
 
  If `startIndex` equals <xref:System.Array.Length%2A?displayProperty=nameWithType>, the method returns -1.  If `startIndex` is greater than <xref:System.Array.Length%2A?displayProperty=nameWithType>, the method throws an <xref:System.ArgumentOutOfRangeException>.
 


### PR DESCRIPTION
For `ICollection<T>.Contains` and `Remove`, the relevant types are `(I)EqualityComparer<T>`, not `(I)Comparer<T>`.

For `List<T>` and `Array`, don't try to (badly) explain their behavior, instead link to `EqualityComparer<T>.Default`.