### PR TITLE
Add pattern trust guidance to Regex class Remarks

### DIFF
--- a/xml/System.Text.RegularExpressions/Regex.xml
+++ b/xml/System.Text.RegularExpressions/Regex.xml
@@ -70,7 +70,16 @@
   </Attributes>
   <Docs>
     <summary>Represents an immutable regular expression.</summary>
-    <remarks>For more information about this API, see <see href="/dotnet/fundamentals/runtime-libraries/system-text-regularexpressions-regex">Supplemental API remarks for Regex</see>.</remarks>
+    <remarks>
+      <format type="text/markdown"><![CDATA[
+
+For more information about this API, see [Supplemental API remarks for Regex](/dotnet/fundamentals/runtime-libraries/system-text-regularexpressions-regex).
+
+> [!IMPORTANT]
+> The regular expression engine assumes that patterns are trusted. For more information, see [Use trusted patterns](/dotnet/standard/base-types/best-practices-regex#use-trusted-patterns).
+
+]]></format>
+    </remarks>
     <threadsafe>The <see cref="T:System.Text.RegularExpressions.Regex" /> class is immutable (read-only) and thread safe. <see cref="T:System.Text.RegularExpressions.Regex" /> objects can be created on any thread and shared between threads. For more information, see <see href="/dotnet/standard/base-types/thread-safety-in-regular-expressions">Thread Safety</see>.</threadsafe>
     <altmember cref="T:System.Configuration.RegexStringValidator" />
     <related type="Article" href="/dotnet/standard/base-types/regular-expressions">.NET Regular Expressions</related>


### PR DESCRIPTION
Add an `[!IMPORTANT]` note to the `Regex` class-level Remarks stating that patterns are assumed to be trusted and should not come from untrusted sources. Links to the detailed best practices guidance.

- Patterns from untrusted sources can cause excessive resource consumption regardless of input text
- Applications should use a restricted search syntax or `Regex.Escape` instead of passing user input as patterns
- Links to [Best Practices - Patterns should be trusted](/dotnet/standard/base-types/best-practices-regex#patterns-should-be-trusted)

**Companion PR:** https://github.com/dotnet/docs/pull/51843 (adds the detailed guidance section to the best practices doc)