### PR TITLE
Fix formatting issues in Path.GetRelativePath remarks

### DIFF
--- a/xml/System.IO/Path.xml
+++ b/xml/System.IO/Path.xml
@@ -2049,7 +2049,7 @@ Unlike <xref:System.IO.Path.GetTempFileName%2A>, <xref:System.IO.Path.GetRandomF
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-Paths are resolved by calling the <xref:System.IO.Path.GetFullPath%2A> method before calculating the difference. The method uses the default file path comparison for the current platform (<xref:System.StringComparison.OrdinalIgnoreCase?displayProperty=nameWithType> for Windows and MacOS, <xref:System.StringComparison.Ordinal?displayProperty=nameWithType> for Linux).
+Paths are resolved by calling the <xref:System.IO.Path.GetFullPath%2A> method before calculating the difference. The method uses the default file path comparison for the current platform (<xref:System.StringComparison.OrdinalIgnoreCase?displayProperty=nameWithType> for Windows and macOS, <xref:System.StringComparison.Ordinal?displayProperty=nameWithType> for Linux).
 
 ## Examples
  The following code shows how to call the <xref:System.IO.Path.GetRelativePath%2A> method.


### PR DESCRIPTION
I found a few issues in the "Remarks" section of the docs for [Path.GetRelativePath](https://learn.microsoft.com/en-us/dotnet/api/system.io.path.getrelativepath?view=net-10.0#remarks).

* "MacOS" is mistakenly spelled "MacOs".
* A left parenthesis was opened but never closed.

This PR fixes both issues.

<img width="1562" height="286" alt="image" src="https://github.com/user-attachments/assets/4eed1f98-f460-4cbb-90af-edd0d3d6d1d4" />


https://xkcd.com/859/

