### PR TITLE
Clarify MarshalMode docs: naming convention, return values

### DIFF
--- a/xml/System.Runtime.InteropServices.Marshalling/MarshalMode.xml
+++ b/xml/System.Runtime.InteropServices.Marshalling/MarshalMode.xml
@@ -21,8 +21,8 @@
     <remarks>
       <para>Each member name follows the pattern <c>{CallDirection}{DataFlow}</c>:</para>
       <list type="bullet">
-        <item><description><b>Call direction</b> (<c>ManagedToUnmanaged</c> or <c>UnmanagedToManaged</c>) indicates which side initiates the call. <c>ManagedToUnmanaged</c> applies to P/Invoke calls. <c>UnmanagedToManaged</c> applies to Reverse P/Invoke or COM scenarios where native code calls into managed code.</description></item>
-        <item><description><b>Data flow</b> (<c>In</c>, <c>Out</c>, or <c>Ref</c>) indicates how data moves relative to the call. <c>In</c> means data flows from caller to callee. <c>Out</c> means data flows from callee to caller, which includes both <c>out</c> parameters and return values. <c>Ref</c> means data flows in both directions.</description></item>
+        <item><b>Call direction</b> (<c>ManagedToUnmanaged</c> or <c>UnmanagedToManaged</c>) indicates which side initiates the call. <c>ManagedToUnmanaged</c> applies to P/Invoke calls. <c>UnmanagedToManaged</c> applies to Reverse P/Invoke or COM scenarios where native code calls into managed code.</item>
+        <item><b>Data flow</b> (<c>In</c>, <c>Out</c>, or <c>Ref</c>) indicates how data moves relative to the call. <c>In</c> means data flows from caller to callee. <c>Out</c> means data flows from callee to caller, which includes both <c>out</c> parameters and return values. <c>Ref</c> means data flows in both directions.</item>
       </list>
       <para>For example, <c>ManagedToUnmanagedOut</c> applies when managed code calls unmanaged code (P/Invoke) and data flows back to the caller — this covers <c>out</c> parameters and return values. The marshaller for this mode converts from the unmanaged type to the managed type.</para>
     </remarks>


### PR DESCRIPTION
## Summary

Fill in the placeholder `<remarks>` for the `MarshalMode` enum with an explanation of the `{CallDirection}{DataFlow}` naming convention. Update `ManagedToUnmanagedOut` and `UnmanagedToManagedOut` summaries to explicitly mention that they apply to **return values** in addition to `out` parameters.

## Motivation

Addresses [dotnet/runtime#124726](https://github.com/dotnet/runtime/issues/124726) — a community user was confused about which `MarshalMode` to use for a custom marshaller that only handles return values from P/Invoke calls. The existing docs only mentioned `out` parameters, and the `<remarks>` section was the original placeholder text (`To be added.`) since .NET 7.

## Changes

- **Type-level `<remarks>`**: Replaced `To be added.` with a structured explanation of the naming convention:
  - Call direction (`ManagedToUnmanaged` vs `UnmanagedToManaged`)
  - Data flow (`In`, `Out`, `Ref`)
  - Concrete example using `ManagedToUnmanagedOut`
- **`ManagedToUnmanagedOut` summary**: Added `and return values` and clarified marshalling direction
- **`UnmanagedToManagedOut` summary**: Same treatment for symmetry

/cc @jkoritzinsky