### PR TITLE
Add RegexOptions.AnyNewLine documentation

### DIFF
--- a/xml/System.Text.RegularExpressions/RegexOptions.xml
+++ b/xml/System.Text.RegularExpressions/RegexOptions.xml
@@ -108,7 +108,7 @@
       </ReturnValue>
       <MemberValue>2048</MemberValue>
       <Docs>
-        <summary>Make <c>^</c>, <c>$</c>, <c>\Z</c>, and <c>.</c> recognize all common newline sequences (<c>\r\n</c>, <c>\r</c>, <c>\n</c>, and the Unicode newlines <c>\u0085</c>, <c>\u2028</c>, <c>\u2029</c>) instead of only <c>\n</c>. This option cannot be combined with <see cref="F:System.Text.RegularExpressions.RegexOptions.NonBacktracking" /> or <see cref="F:System.Text.RegularExpressions.RegexOptions.ECMAScript" />. For more information, see the "AnyNewLine Mode" section in the <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">Regular Expression Options</see> article.</summary>
+        <summary>Makes <c>^</c>, <c>$</c>, <c>\Z</c>, and <c>.</c> recognize all common newline sequences (<c>\r\n</c>, <c>\r</c>, <c>\n</c>, and the Unicode newlines <c>\u0085</c>, <c>\u2028</c>, and <c>\u2029</c>) instead of only <c>\n</c>. This option cannot be combined with <see cref="F:System.Text.RegularExpressions.RegexOptions.NonBacktracking" /> or <see cref="F:System.Text.RegularExpressions.RegexOptions.ECMAScript" />. For more information, see the "AnyNewLine Mode" section in the <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">Regular Expression Options</see> article.</summary>
       </Docs>
     </Member>
     <Member MemberName="Compiled">


### PR DESCRIPTION
Add API documentation for the new `RegexOptions.AnyNewLine` enum member (value `2048`), shipping in .NET 11 Preview 3.

`AnyNewLine` makes `^`, `$`, `\Z`, and `.` recognize all Unicode newline sequences (`\r\n`, `\r`, `\n`, `\u0085`, `\u2028`, `\u2029`) instead of only `\n`. This addresses one of the most common pitfalls with `System.Text.RegularExpressions` -- that `$` doesn't match before `\r\n` and `.` matches `\r`.

Related:
- Runtime implementation: dotnet/runtime#124701
- API approval: dotnet/runtime#25598
- Conceptual docs PR: dotnet/docs#52328
