### PR TITLE
Update AuthenticablePrincipal.xml

### DIFF
--- a/xml/System.DirectoryServices.AccountManagement/AuthenticablePrincipal.xml
+++ b/xml/System.DirectoryServices.AccountManagement/AuthenticablePrincipal.xml
@@ -383,7 +383,7 @@
       <Docs>
         <summary>Gets or sets a Nullable Boolean value that specifies whether this account is enabled for authentication.</summary>
         <value>
-          <see langword="true" /> if the principal is enabled, or null if the account has not been persisted; otherwise <see langword="false" />.</value>
+          <see langword="true" /> if the principal is enabled, and if the context is allowed to read the principals attributes (when using active directory), or null if the account has not been persisted; otherwise <see langword="false" />.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 


### PR DESCRIPTION
I was looking up a principal in AD where the calling context had been denied to read any attribute. The Enabled property returned false, which I found a bit confusing... To reflect the permissions effect on the value when using active directory, I updated the documentation.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

