### PR TITLE
Clarify MatchCasing does not affect directory path resolution

### DIFF
--- a/xml/System.IO/EnumerationOptions.xml
+++ b/xml/System.IO/EnumerationOptions.xml
@@ -246,15 +246,15 @@ It **does not affect directory path resolution**. On case-sensitive file systems
 
 The default is to match the platform defaults, which are based on the case sensitivity of the filesystem.
 
-          ]]></format>
-	</remarks>
-	<example>
+ ]]></format>
+	    </remarks>
+	    <example>
           <format type="text/markdown"><![CDATA[
 Directory.GetFiles("/tmp/data", "*.TXT",
-    new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive });
+new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive });
 
 > Matches file names case-insensitively, but `/tmp/data` directory path must still match exact casing on Linux/macOS.
-          ]]></format>
+ ]]></format>
         </example>
       </Docs>
     </Member>


### PR DESCRIPTION
Fixes dotnet/runtime#115356

## Summary

This PR clarifies that `EnumerationOptions.MatchCasing` applies only to file name pattern matching and does **not** affect directory path resolution.

On case-sensitive file systems (e.g., Linux and macOS), directory paths must match the exact casing even if `MatchCasing = CaseInsensitive`.

## Motivation

Users may assume that `MatchCasing` affects the full path when performing searches. In reality, it only applies to **file name pattern matching**, which can be misleading on case-sensitive systems. This update improves documentation to reduce confusion.

## Changes

- Updated XML doc comment in `EnumerationOptions.cs` (runtime repo)
- Updated API XML (`EnumerationOptions.xml`) with `<remarks>` clarifying:
  - Scope is limited to file name matching
  - Directory paths are unaffected
  - Default behavior is platform-dependent
- Optional example included in API XML to illustrate Linux behavior

## Example (API docs)

```csharp
Directory.GetFiles("/tmp/data", "*.TXT",
    new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive });

