### PR TITLE
Add AggregateBy examples

### DIFF
--- a/snippets/csharp/System.Linq/Enumerable/AggregateTSource/Enumerable.csproj
+++ b/snippets/csharp/System.Linq/Enumerable/AggregateTSource/Enumerable.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
+++ b/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
@@ -3209,22 +3209,15 @@ namespace SequenceExamples
         static class AggregateBy
         {
             // <Snippet205>
-            class Employee
-            {
-                public string Name { get; set; }
-                public string Department { get; set; }
-                public decimal Salary { get; set; }
-            }
-
             public static void AggregateBySeedSelectorExample()
             {
-                Employee[] employees =
+                (string Name, string Department, decimal Salary)[] employees =
                 {
-                    new Employee { Name = "Ali", Department = "HR", Salary = 45000 },
-                    new Employee { Name = "Samer", Department = "Technology", Salary = 50000 },
-                    new Employee { Name = "Hamed", Department = "Sales", Salary = 75000 },
-                    new Employee { Name = "Lina", Department = "Technology", Salary = 65000 },
-                    new Employee { Name = "Omar", Department = "HR", Salary = 40000 }
+                    ("Ali", "HR", 45000),
+                    ("Samer", "Technology", 50000),
+                    ("Hamed", "Sales", 75000),
+                    ("Lina", "Technology", 65000),
+                    ("Omar", "HR", 40000)
                 };
 
                 var result =

--- a/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
+++ b/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
@@ -3204,5 +3204,85 @@ namespace SequenceExamples
 #endif
         }
         #endregion
+
+        #region AggregateBy
+        static class AggregateBy
+        {
+            // <Snippet205>
+            class Employee
+            {
+                public string Name { get; set; }
+                public string Department { get; set; }
+                public decimal Salary { get; set; }
+            }
+
+            public static void AggregateBySeedSelectorExample()
+            {
+                Employee[] employees =
+                {
+                    new Employee { Name = "Ali", Department = "HR", Salary = 45000 },
+                    new Employee { Name = "Samer", Department = "Technology", Salary = 50000 },
+                    new Employee { Name = "Hamed", Department = "Sales", Salary = 75000 },
+                    new Employee { Name = "Lina", Department = "Technology", Salary = 65000 },
+                    new Employee { Name = "Omar", Department = "HR", Salary = 40000 }
+                };
+
+                var result =
+                    employees.AggregateBy(
+                        e => e.Department,
+                        dept => (Total: 0m, Count: 0),
+                        (acc, e) => (acc.Total + e.Salary, acc.Count + 1)
+                    );
+
+                foreach (var item in result)
+                {
+                    Console.WriteLine($"{item.Key}: Total={item.Value.Total}, Count={item.Value.Count}");
+                }
+
+                /*
+                 This code produces the following output:
+
+                 HR: Total=85000, Count=2
+                 Technology: Total=115000, Count=2
+                 Sales: Total=75000, Count=1
+                */
+            }
+            // </Snippet205>
+
+            // <Snippet206>
+            public static void AggregateBySeedExample()
+            {
+                Employee[] employees =
+                {
+                    new Employee { Name = "Ali", Department = "HR", Salary = 45000 },
+                    new Employee { Name = "Samer", Department = "Technology", Salary = 50000 },
+                    new Employee { Name = "Hamed", Department = "Sales", Salary = 75000 },
+                    new Employee { Name = "Lina", Department = "Technology", Salary = 65000 },
+                    new Employee { Name = "Omar", Department = "HR", Salary = 40000 }
+                };
+
+                var totals =
+                    employees.AggregateBy(
+                        e => e.Department,
+                        0m,
+                        (total, e) => total + e.Salary
+                    );
+
+                foreach (var item in totals)
+                {
+                    Console.WriteLine($"{item.Key}: {item.Value}");
+                }
+
+                /*
+                 This code produces the following output:
+
+                 HR: 85000
+                 Technology: 115000
+                 Sales: 75000
+                */
+            }
+            // </Snippet206>
+        }
+        #endregion
     }
 }

--- a/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
+++ b/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
@@ -3245,13 +3245,13 @@ namespace SequenceExamples
             // <Snippet206>
             public static void AggregateBySeedExample()
             {
-                Employee[] employees =
+                (string Name, string Department, decimal Salary)[] employees =
                 {
-                    new Employee { Name = "Ali", Department = "HR", Salary = 45000 },
-                    new Employee { Name = "Samer", Department = "Technology", Salary = 50000 },
-                    new Employee { Name = "Hamed", Department = "Sales", Salary = 75000 },
-                    new Employee { Name = "Lina", Department = "Technology", Salary = 65000 },
-                    new Employee { Name = "Omar", Department = "HR", Salary = 40000 }
+                    ("Ali", "HR", 45000),
+                    ("Samer", "Technology", 50000),
+                    ("Hamed", "Sales", 75000),
+                    ("Lina", "Technology", 65000),
+                    ("Omar", "HR", 40000)
                 };
 
                 var totals =

--- a/xml/System.Linq/Enumerable.xml
+++ b/xml/System.Linq/Enumerable.xml
@@ -414,7 +414,52 @@
         <remarks>
           This method is comparable to the <see cref="M:System.Linq.Enumerable.GroupBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})" /> methods where each grouping is being aggregated into a single value as opposed to allocating a collection for each group.
         </remarks>
-      </Docs>
+        <example>
+          <para>
+            The following example demonstrates how to use AggregateBy with a seed selector to compute multiple values per key.
+          </para>
+          <code language="csharp">
+        class Employee
+        {
+            public string Name { get; set; }
+            public string Department { get; set; }
+            public decimal Salary { get; set; }
+        }
+
+        public static void AggregateBySeedSelectorExample()
+        {
+            Employee[] employees =
+            {
+                new Employee { Name = "Ali", Department = "HR", Salary = 45000 },
+                new Employee { Name = "Samer", Department = "Technology", Salary = 50000 },
+                new Employee { Name = "Hamed", Department = "Sales", Salary = 75000 },
+                new Employee { Name = "Lina", Department = "Technology", Salary = 65000 },
+                new Employee { Name = "Omar", Department = "HR", Salary = 40000 }
+            };
+
+            var result =
+                employees.AggregateBy(
+                    e => e.Department,
+                    dept => (Total: 0m, Count: 0),
+                    (acc, e) => (acc.Total + e.Salary, acc.Count + 1)
+                );
+
+            foreach (var item in result)
+            {
+                Console.WriteLine($"{item.Key}: Total={item.Value.Total}, Count={item.Value.Count}");
+            }
+        }
+
+        /*
+        This code produces the following output:
+
+        HR: Total=85000, Count=2
+        Technology: Total=115000, Count=2
+        Sales: Total=75000, Count=1
+        */
+          </code>
+        </example>
+        </Docs>
     </Member>
     <Member MemberName="AggregateBy&lt;TSource,TKey,TAccumulate&gt;">
       <MemberSignature Language="C#" Value="public static System.Collections.Generic.IEnumerable&lt;System.Collections.Generic.KeyValuePair&lt;TKey,TAccumulate&gt;&gt; AggregateBy&lt;TSource,TKey,TAccumulate&gt; (this System.Collections.Generic.IEnumerable&lt;TSource&gt; source, Func&lt;TSource,TKey&gt; keySelector, TAccumulate seed, Func&lt;TAccumulate,TSource,TAccumulate&gt; func, System.Collections.Generic.IEqualityComparer&lt;TKey&gt;? keyComparer = default);" />
@@ -491,6 +536,52 @@
         <remarks>
           This method is comparable to the <see cref="M:System.Linq.Enumerable.GroupBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})" /> methods where each grouping is being aggregated into a single value as opposed to allocating a collection for each group.
         </remarks>
+        <example>
+          <para>
+            The following example demonstrates how to use AggregateBy with a constant seed value to compute totals per key.
+          </para>
+          <code language="csharp">
+        class Employee
+        {
+            public string Name { get; set; }
+            public string Department { get; set; }
+            public decimal Salary { get; set; }
+        }
+
+        public static void AggregateBySeedExample()
+        {
+            Employee[] employees =
+            {
+                new Employee { Name = "Ali", Department = "HR", Salary = 45000 },
+                new Employee { Name = "Samer", Department = "Technology", Salary = 50000 },
+                new Employee { Name = "Hamed", Department = "Sales", Salary = 75000 },
+                new Employee { Name = "Lina", Department = "Technology", Salary = 65000 },
+                new Employee { Name = "Omar", Department = "HR", Salary = 40000 }
+            };
+
+            // Compute total salary per department using a constant seed
+            var totals =
+                employees.AggregateBy(
+                    e => e.Department,
+                    0m,
+                    (total, e) => total + e.Salary
+                );
+
+            foreach (var item in totals)
+            {
+                Console.WriteLine($"{item.Key}: {item.Value}");
+            }
+        }
+
+        /*
+        This code produces the following output:
+
+        HR: 85000
+        Technology: 115000
+        Sales: 75000
+        */
+        </code>
+        </example>
       </Docs>
     </Member>
     <Member MemberName="All&lt;TSource&gt;">

--- a/xml/System.Linq/Enumerable.xml
+++ b/xml/System.Linq/Enumerable.xml
@@ -400,65 +400,32 @@
           </Attributes>
         </Parameter>
       </Parameters>
-      <Docs>
-        <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
-        <typeparam name="TKey">The type of the key returned by <paramref name="keySelector" />.</typeparam>
-        <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        <param name="source">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> to aggregate over.</param>
-        <param name="keySelector">A function to extract the key for each element.</param>
-        <param name="seedSelector">A factory for the initial accumulator value.</param>
-        <param name="func">An accumulator function to be invoked on each element.</param>
-        <param name="keyComparer">An <see cref="T:System.Collections.Generic.IEqualityComparer`1" /> to compare keys with.</param>
-        <summary>Applies an accumulator function over a sequence, grouping results by key.</summary>
-        <returns>An enumerable containing the aggregates corresponding to each key deriving from <paramref name="source" />.</returns>
-        <remarks>
-          This method is comparable to the <see cref="M:System.Linq.Enumerable.GroupBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})" /> methods where each grouping is being aggregated into a single value as opposed to allocating a collection for each group.
-        </remarks>
-        <example>
-          <para>
-            The following example demonstrates how to use AggregateBy with a seed selector to compute multiple values per key.
-          </para>
-          <code language="csharp">
-        class Employee
-        {
-            public string Name { get; set; }
-            public string Department { get; set; }
-            public decimal Salary { get; set; }
-        }
+     <Docs>
+          <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+          <typeparam name="TKey">The type of the key returned by <paramref name="keySelector" />.</typeparam>
+          <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+          <param name="source">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> to aggregate over.</param>
+          <param name="keySelector">A function to extract the key for each element.</param>
+          <param name="seedSelector">A factory for the initial accumulator value.</param>
+          <param name="func">An accumulator function to be invoked on each element.</param>
+          <param name="keyComparer">An <see cref="T:System.Collections.Generic.IEqualityComparer`1" /> to compare keys with.</param>
+          <summary>Applies an accumulator function over a sequence, grouping results by key.</summary>
+          <returns>An enumerable containing the aggregates corresponding to each key deriving from <paramref name="source" />.</returns>
+          <remarks>
+            <format type="text/markdown"><![CDATA[
 
-        public static void AggregateBySeedSelectorExample()
-        {
-            Employee[] employees =
-            {
-                new Employee { Name = "Ali", Department = "HR", Salary = 45000 },
-                new Employee { Name = "Samer", Department = "Technology", Salary = 50000 },
-                new Employee { Name = "Hamed", Department = "Sales", Salary = 75000 },
-                new Employee { Name = "Lina", Department = "Technology", Salary = 65000 },
-                new Employee { Name = "Omar", Department = "HR", Salary = 40000 }
-            };
+## Remarks
 
-            var result =
-                employees.AggregateBy(
-                    e => e.Department,
-                    dept => (Total: 0m, Count: 0),
-                    (acc, e) => (acc.Total + e.Salary, acc.Count + 1)
-                );
+This method is comparable to the <xref:System.Linq.Enumerable.GroupBy%2A> methods where each grouping is being aggregated into a single value as opposed to allocating a collection for each group.
 
-            foreach (var item in result)
-            {
-                Console.WriteLine($"{item.Key}: Total={item.Value.Total}, Count={item.Value.Count}");
-            }
-        }
+## Examples
 
-        /*
-        This code produces the following output:
+The following example demonstrates how to use `AggregateBy` with a seed selector to compute multiple values per key.
 
-        HR: Total=85000, Count=2
-        Technology: Total=115000, Count=2
-        Sales: Total=75000, Count=1
-        */
-          </code>
-        </example>
+:::code language="csharp" source="~/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs" id="Snippet205":::
+
+            ]]></format>
+          </remarks>
         </Docs>
     </Member>
     <Member MemberName="AggregateBy&lt;TSource,TKey,TAccumulate&gt;">
@@ -523,66 +490,32 @@
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
-        <typeparam name="TKey">The type of the key returned by <paramref name="keySelector" />.</typeparam>
-        <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
-        <param name="source">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> to aggregate over.</param>
-        <param name="keySelector">A function to extract the key for each element.</param>
-        <param name="seed">The initial accumulator value.</param>
-        <param name="func">An accumulator function to be invoked on each element.</param>
-        <param name="keyComparer">An <see cref="T:System.Collections.Generic.IEqualityComparer`1" /> to compare keys with.</param>
-        <summary>Applies an accumulator function over a sequence, grouping results by key.</summary>
-        <returns>An enumerable containing the aggregates corresponding to each key deriving from <paramref name="source" />.</returns>
-        <remarks>
-          This method is comparable to the <see cref="M:System.Linq.Enumerable.GroupBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})" /> methods where each grouping is being aggregated into a single value as opposed to allocating a collection for each group.
-        </remarks>
-        <example>
-          <para>
-            The following example demonstrates how to use AggregateBy with a constant seed value to compute totals per key.
-          </para>
-          <code language="csharp">
-        class Employee
-        {
-            public string Name { get; set; }
-            public string Department { get; set; }
-            public decimal Salary { get; set; }
-        }
+          <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+          <typeparam name="TKey">The type of the key returned by <paramref name="keySelector" />.</typeparam>
+          <typeparam name="TAccumulate">The type of the accumulator value.</typeparam>
+          <param name="source">An <see cref="T:System.Collections.Generic.IEnumerable`1" /> to aggregate over.</param>
+          <param name="keySelector">A function to extract the key for each element.</param>
+          <param name="seed">The initial accumulator value.</param>
+          <param name="func">An accumulator function to be invoked on each element.</param>
+          <param name="keyComparer">An <see cref="T:System.Collections.Generic.IEqualityComparer`1" /> to compare keys with.</param>
+          <summary>Applies an accumulator function over a sequence, grouping results by key.</summary>
+          <returns>An enumerable containing the aggregates corresponding to each key deriving from <paramref name="source" />.</returns>
+          <remarks>
+            <format type="text/markdown"><![CDATA[
 
-        public static void AggregateBySeedExample()
-        {
-            Employee[] employees =
-            {
-                new Employee { Name = "Ali", Department = "HR", Salary = 45000 },
-                new Employee { Name = "Samer", Department = "Technology", Salary = 50000 },
-                new Employee { Name = "Hamed", Department = "Sales", Salary = 75000 },
-                new Employee { Name = "Lina", Department = "Technology", Salary = 65000 },
-                new Employee { Name = "Omar", Department = "HR", Salary = 40000 }
-            };
+## Remarks
 
-            // Compute total salary per department using a constant seed
-            var totals =
-                employees.AggregateBy(
-                    e => e.Department,
-                    0m,
-                    (total, e) => total + e.Salary
-                );
+This method is comparable to the <xref:System.Linq.Enumerable.GroupBy%2A> methods where each grouping is being aggregated into a single value as opposed to allocating a collection for each group.
 
-            foreach (var item in totals)
-            {
-                Console.WriteLine($"{item.Key}: {item.Value}");
-            }
-        }
+## Examples
 
-        /*
-        This code produces the following output:
+The following example demonstrates how to use `AggregateBy` with a constant seed value to compute totals per key.
 
-        HR: 85000
-        Technology: 115000
-        Sales: 75000
-        */
-        </code>
-        </example>
-      </Docs>
+:::code language="csharp" source="~/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs" id="Snippe":::
+
+            ]]></format>
+          </remarks>
+        </Docs>
     </Member>
     <Member MemberName="All&lt;TSource&gt;">
       <MemberSignature Language="C#" Value="public static bool All&lt;TSource&gt; (this System.Collections.Generic.IEnumerable&lt;TSource&gt; source, Func&lt;TSource,bool&gt; predicate);" />

--- a/xml/System.Linq/Enumerable.xml
+++ b/xml/System.Linq/Enumerable.xml
@@ -506,6 +506,7 @@ The following example demonstrates how to use `AggregateBy` with a seed selector
 ## Remarks
 
 This method is comparable to the <xref:System.Linq.Enumerable.GroupBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})> methods where each grouping is being aggregated into a single value as opposed to allocating a collection for each group.
+
 ## Examples
 
 The following example demonstrates how to use `AggregateBy` with a constant seed value to compute totals per key.

--- a/xml/System.Linq/Enumerable.xml
+++ b/xml/System.Linq/Enumerable.xml
@@ -505,8 +505,7 @@ The following example demonstrates how to use `AggregateBy` with a seed selector
 
 ## Remarks
 
-This method is comparable to the <xref:System.Linq.Enumerable.GroupBy%2A> methods where each grouping is being aggregated into a single value as opposed to allocating a collection for each group.
-
+This method is comparable to the <xref:System.Linq.Enumerable.GroupBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})> methods where each grouping is being aggregated into a single value as opposed to allocating a collection for each group.
 ## Examples
 
 The following example demonstrates how to use `AggregateBy` with a constant seed value to compute totals per key.

--- a/xml/System.Linq/Enumerable.xml
+++ b/xml/System.Linq/Enumerable.xml
@@ -511,7 +511,7 @@ This method is comparable to the <xref:System.Linq.Enumerable.GroupBy%2A> method
 
 The following example demonstrates how to use `AggregateBy` with a constant seed value to compute totals per key.
 
-:::code language="csharp" source="~/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs" id="Snippe":::
+:::code language="csharp" source="~/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs" id="Snippet206":::
 
             ]]></format>
           </remarks>

--- a/xml/System.Linq/Enumerable.xml
+++ b/xml/System.Linq/Enumerable.xml
@@ -416,7 +416,7 @@
 
 ## Remarks
 
-This method is comparable to the <xref:System.Linq.Enumerable.GroupBy%2A> methods where each grouping is being aggregated into a single value as opposed to allocating a collection for each group.
+This method is comparable to the <xref:System.Linq.Enumerable.GroupBy``2(System.Collections.Generic.IEnumerable{``0},System.Func{``0,``1})> methods where each grouping is aggregated into a single value as opposed to allocating a collection for each group.
 
 ## Examples
 


### PR DESCRIPTION
Summary
This PR adds comprehensive usage examples for the new .NET 9 Enumerable.AggregateBy method. These examples are designed to help developers understand the difference between using a constant seed and a seed selector for stateful aggregations.

Examples Added:
Multi-value Aggregation (seedSelector): Demonstrates using a tuple (Total, Count) to compute both the sum and the frequency of elements per group in a single pass.

Simple Summation (seed): Illustrates the use of a constant decimal seed to calculate total values (salaries) grouped by a key (department).

Technical Highlights:
Efficiency: The examples emphasize the benefit of AggregateBy over GroupBy by avoiding the allocation of intermediate grouping collections.

Real-world Context: Uses an Employee class scenario to make the utility of the API immediately clear to developers.

Each example includes input data, the LINQ implementation, and the expected console output.