### PR TITLE
Remove duplicate @ prefix from issueAuthor in GitOps

### DIFF
--- a/.github/policies/author-action.yml
+++ b/.github/policies/author-action.yml
@@ -29,7 +29,7 @@ configuration:
         then:
         - addReply:
             reply: >-
-              @${issueAuthor} - This issue has been marked `needs-author-action` and might be missing some important information.
+              ${issueAuthor} - This issue has been marked `needs-author-action` and might be missing some important information.
 
       - description: PR reviews with "changes requested" applies the needs-author-action label
         if:

--- a/.github/policies/disallow-edits.yml
+++ b/.github/policies/disallow-edits.yml
@@ -70,7 +70,7 @@ configuration:
         then:
             - addReply:
                 reply: >-
-                  @${issueAuthor} - This PR edits one or more files whose 'source of truth' for documentation is not in this repo. Please make documentation updates in the /// comments in the dotnet/runtime repo (or dotnet/extensions repo) instead.
+                  ${issueAuthor} - This PR edits one or more files whose 'source of truth' for documentation is not in this repo. Please make documentation updates in the /// comments in the dotnet/runtime repo (or dotnet/extensions repo) instead.
             - if:
                 - or:
                     - activitySenderHasPermission:


### PR DESCRIPTION
## Summary

https://github.com/GitOps-microsoft/GitOps.PullRequestIssueManagement/pull/262 (internal Microsoft link) changed the `${issueAuthor}` placeholder to include the `@` character.

Remove the one we added so we don't duplicate it.
