### PR TITLE
Add UnionBy documentation examples

### DIFF
--- a/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
+++ b/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
@@ -3293,7 +3293,7 @@ namespace SequenceExamples
 
                 (int ProductId, string Name, decimal Price)[] warehouseProducts =
                 {
-                    (102, "Mouse", 120m),      // Duplicate ProductId (already in local)
+                    (102, "Mouse", 100m),      // Duplicate ProductId (already in local)
                     (104, "Monitor", 800m),
                     (101, "Laptop", 1000m)     // Duplicate ProductId (already in local)
                 };

--- a/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
+++ b/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
@@ -3284,56 +3284,55 @@ namespace SequenceExamples
             // <Snippet207>
             public static void UnionByKeySelectorExample()
             {
-                (int ProductId, string Name, int Stock)[] localInventory =
+                (int ProductId, string Name , decimal Price)[] localProducts =
                 {
-                    (101, "Laptop", 15),
-                    (102, "Mouse", 50),
-                    (103, "Keyboard", 20)
-                };
+                                (101, "Laptop", 1000m),                 
+                                (102, "Mouse", 100m),
+                                (103, "Keyboard", 120m)
+                            };
 
-                (int ProductId, string Name, int Stock)[] warehouseInventory =
+                (int ProductId, string Name, decimal Price)[] warehouseProducts =
                 {
-                    (102, "Mouse", 200),      // Duplicate ProductId (already in local)
-                    (104, "Monitor", 30),
-                    (101, "Laptop", 50)       // Duplicate ProductId (already in local)
-                };
-
-                var combinedInventoryProducts =
-                    localInventory.UnionBy(
-                        warehouseInventory,
-                        item => item.ProductId
+                                (102, "Mouse", 120m),      // Duplicate ProductId (already in local)
+                                (104, "Monitor", 800m),
+                                (101, "Laptop", 1000m)     // Duplicate ProductId (already in local)
+                            };
+                var combinedProducts =
+                    localProducts.UnionBy(
+                        warehouseProducts,
+                        product => product.ProductId
                     );
 
-                foreach (var item in combinedInventoryProducts)
+                foreach (var product in combinedProducts)
                 {
-                    Console.WriteLine($"{item.ProductId}: {item.Name}");
+                    Console.WriteLine($"{product.ProductId}: {product.Name} - ${product.Price}");
                 }
 
                 /*
                 This code produces the following output:
 
-                101: Laptop
-                102: Mouse
-                103: Keyboard
-                104: Monitor
+                101: Laptop - $1000
+                102: Mouse - $100
+                103: Keyboard - $120
+                104: Monitor - $800
                 */
             }
             // </Snippet207>
 
-            // <Snippet208>
+        // <Snippet208>
             public static void UnionByComparerExample()
             {
                 (string Email, string FullName)[] marketingList =
                 {
-                    ("Mahmoud.Doe@example.com", "Mahmoud Doe"),
-                    ("alice.smith@example.com", "Alice Smith")
-                };
+                                ("Mahmoud.Doe@example.com", "Mahmoud Doe"),
+                                ("alice.smith@example.com", "Alice Smith")
+                            };
 
                 (string Email, string FullName)[] salesList =
                 {
-                    ("ALICE.SMITH@EXAMPLE.COM", "Alice S."), // Duplicate email, different casing
-                    ("Sara.jones@example.com", "Sara Jones") // Fixed the capital J here
-                };
+                                ("ALICE.SMITH@EXAMPLE.COM", "Alice S."), // Duplicate email, different casing
+                                ("Sara.jones@example.com", "Sara Jones")
+                            };
 
                 var combinedList =
                     marketingList.UnionBy(

--- a/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
+++ b/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
@@ -3286,17 +3286,17 @@ namespace SequenceExamples
             {
                 (int ProductId, string Name , decimal Price)[] localProducts =
                 {
-                                (101, "Laptop", 1000m),                 
-                                (102, "Mouse", 100m),
-                                (103, "Keyboard", 120m)
-                            };
+                    (101, "Laptop", 1000m),                 
+                    (102, "Mouse", 100m),
+                    (103, "Keyboard", 120m)
+                };
 
                 (int ProductId, string Name, decimal Price)[] warehouseProducts =
                 {
-                                (102, "Mouse", 120m),      // Duplicate ProductId (already in local)
-                                (104, "Monitor", 800m),
-                                (101, "Laptop", 1000m)     // Duplicate ProductId (already in local)
-                            };
+                    (102, "Mouse", 120m),      // Duplicate ProductId (already in local)
+                    (104, "Monitor", 800m),
+                    (101, "Laptop", 1000m)     // Duplicate ProductId (already in local)
+                };
                 var combinedProducts =
                     localProducts.UnionBy(
                         warehouseProducts,
@@ -3319,20 +3319,20 @@ namespace SequenceExamples
             }
             // </Snippet207>
 
-        // <Snippet208>
+            // <Snippet208>
             public static void UnionByComparerExample()
             {
                 (string Email, string FullName)[] marketingList =
                 {
-                                ("Mahmoud.Doe@example.com", "Mahmoud Doe"),
-                                ("alice.smith@example.com", "Alice Smith")
-                            };
+                    ("Mahmoud.Doe@example.com", "Mahmoud Doe"),
+                    ("alice.smith@example.com", "Alice Smith")
+                };
 
                 (string Email, string FullName)[] salesList =
                 {
-                                ("ALICE.SMITH@EXAMPLE.COM", "Alice S."), // Duplicate email, different casing
-                                ("Sara.jones@example.com", "Sara Jones")
-                            };
+                    ("ALICE.SMITH@EXAMPLE.COM", "Alice S."), // Duplicate email, different casing
+                    ("Sara.jones@example.com", "Sara Jones")
+                };
 
                 var combinedList =
                     marketingList.UnionBy(

--- a/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
+++ b/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs
@@ -3277,5 +3277,86 @@ namespace SequenceExamples
             // </Snippet206>
         }
         #endregion
+
+        #region UnionBy
+        static class UnionBy
+        {
+            // <Snippet207>
+            public static void UnionByKeySelectorExample()
+            {
+                (int ProductId, string Name, int Stock)[] localInventory =
+                {
+                    (101, "Laptop", 15),
+                    (102, "Mouse", 50),
+                    (103, "Keyboard", 20)
+                };
+
+                (int ProductId, string Name, int Stock)[] warehouseInventory =
+                {
+                    (102, "Mouse", 200),      // Duplicate ProductId (already in local)
+                    (104, "Monitor", 30),
+                    (101, "Laptop", 50)       // Duplicate ProductId (already in local)
+                };
+
+                var combinedInventoryProducts =
+                    localInventory.UnionBy(
+                        warehouseInventory,
+                        item => item.ProductId
+                    );
+
+                foreach (var item in combinedInventoryProducts)
+                {
+                    Console.WriteLine($"{item.ProductId}: {item.Name}");
+                }
+
+                /*
+                This code produces the following output:
+
+                101: Laptop
+                102: Mouse
+                103: Keyboard
+                104: Monitor
+                */
+            }
+            // </Snippet207>
+
+            // <Snippet208>
+            public static void UnionByComparerExample()
+            {
+                (string Email, string FullName)[] marketingList =
+                {
+                    ("Mahmoud.Doe@example.com", "Mahmoud Doe"),
+                    ("alice.smith@example.com", "Alice Smith")
+                };
+
+                (string Email, string FullName)[] salesList =
+                {
+                    ("ALICE.SMITH@EXAMPLE.COM", "Alice S."), // Duplicate email, different casing
+                    ("Sara.jones@example.com", "Sara Jones") // Fixed the capital J here
+                };
+
+                var combinedList =
+                    marketingList.UnionBy(
+                        salesList,
+                        contact => contact.Email,
+                        StringComparer.OrdinalIgnoreCase
+                    );
+
+                foreach (var contact in combinedList)
+                {
+                    Console.WriteLine($"{contact.FullName} ({contact.Email})");
+                }
+
+                /*
+                This code produces the following output:
+
+                Mahmoud Doe (Mahmoud.Doe@example.com)
+                Alice Smith (alice.smith@example.com)
+                Sara Jones (Sara.jones@example.com)
+                */
+            }
+            // </Snippet208>
+        }
+        #endregion
     }
 }

--- a/xml/System.Linq/Enumerable.xml
+++ b/xml/System.Linq/Enumerable.xml
@@ -17924,6 +17924,12 @@ The default equality comparer, <xref:System.Collections.Generic.EqualityComparer
 
 When the object returned by this method is enumerated, <xref:System.Linq.Enumerable.UnionBy*> enumerates `first` and `second` in that order and yields each element that has not already been yielded.
 
+## Examples
+
+The following example demonstrates how to use `UnionBy` to merge two collections of objects while excluding duplicates based on a specific property.
+
+:::code language="csharp" source="~/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs" id="Snippet207":::
+
           ]]></format>
         </remarks>
         <related type="Article" href="/dotnet/csharp/programming-guide/concepts/linq/set-operations?branch=main#union-and-unionby">Union and UnionBy examples</related>
@@ -18007,6 +18013,12 @@ This method is implemented by using deferred execution. The immediate return val
 If `comparer` is `null`, the default equality comparer, <xref:System.Collections.Generic.EqualityComparer`1.Default>, is used to compare values.
 
 When the object returned by this method is enumerated, <xref:System.Linq.Enumerable.UnionBy*> enumerates `first` and `second` in that order and yields each element that has not already been yielded.
+
+## Examples
+
+The following example demonstrates how to use `UnionBy` to merge two collections while using a custom comparer to ignore case sensitivity when checking for duplicate keys.
+
+:::code language="csharp" source="~/snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs" id="Snippet208":::
 
           ]]></format>
         </remarks>


### PR DESCRIPTION
## Summary

This PR adds two comprehensive code examples to the `Enumerable.UnionBy` documentation to illustrate its behavior and practical use cases. 

The added examples demonstrate:
1. `UnionByKeySelectorExample`: Merging two collections while excluding duplicates based on a specific property (e.g., merging inventory arrays by `ProductId`).
2. `UnionByComparerExample`: Merging two collections using a custom comparer to ignore case sensitivity when checking for duplicate keys (e.g., merging email lists).

These examples have been added to the `<remarks>` section in `Enumerable.xml` and the corresponding C# code has been added to `snippets/csharp/System.Linq/Enumerable/AggregateTSource/enumerable.cs`. 
