### PR TITLE
Disallow edits on System.Text.RegularExpressions docs

### DIFF
--- a/.github/policies/disallow-edits.yml
+++ b/.github/policies/disallow-edits.yml
@@ -67,6 +67,9 @@ configuration:
               - filesMatchPattern:
                   matchAny: true
                   pattern: xml/System.Runtime.Serialization/XsdDataContractExporter.xml
+              - filesMatchPattern:
+                  matchAny: true
+                  pattern: xml/System.Text.RegularExpressions/*
         then:
             - addReply:
                 reply: >-

--- a/docfx.json
+++ b/docfx.json
@@ -174,6 +174,7 @@
         "api/System.Net.ServerSentEvents.**": false,
         "api/System.Numerics.Tensors.**": false,
         "api/System.Reflection.Context.**": false,
+        "api/System.Text.RegularExpressions.**": false,
 
         "api/System.Diagnostics.FileVersionInfo.yml": false,
         "api/System.Linq.AsyncEnumerable.yml": false,


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

Follow-up to https://github.com/dotnet/runtime/pull/127038, which backports `System.Text.RegularExpressions` XML docs to `///` comments in dotnet/runtime source.

> [!IMPORTANT]
> **Do not merge** until dotnet/runtime#127038 merges.

## Changes

- **`disallow-edits.yml`**: Add `xml/System.Text.RegularExpressions/*` to the GitOps policy that auto-closes PRs modifying files whose source of truth is in dotnet/runtime.
- **`docfx.json`**: Set `open_to_public_contributors` to `false` for `api/System.Text.RegularExpressions.**` to hide the Edit button on learn.microsoft.com.

## Remaining follow-up

Per https://github.com/dotnet/dotnet-api-docs/issues/10722, since `System.Text.RegularExpressions` ships as part of the shared framework, it should also be added to the docs CI pipeline for ongoing validation (the list of XML files to push to the binaries repo). That step requires access to an internal SharePoint document and should be handled separately.

Fixes part of https://github.com/dotnet/dotnet-api-docs/issues/10722
