### PR TITLE
Remove external documentation link from INotifyCollectionChanged

### DIFF
--- a/xml/System.Collections.Specialized/INotifyCollectionChanged.xml
+++ b/xml/System.Collections.Specialized/INotifyCollectionChanged.xml
@@ -84,7 +84,6 @@
 
  ]]></format>
     </remarks>
-    <related type="ExternalDocumentation" href="https://www.codeproject.com/Articles/1004644/ObservableCollection-Simply-Explained">ObservableCollection Simply Explained</related>
   </Docs>
   <Members>
     <Member MemberName="CollectionChanged">


### PR DESCRIPTION
Link didn't go anywhere useful.