### PR TITLE
Remove <altmember> references to .NET Framework APIs

### DIFF
--- a/xml/System.CodeDom.Compiler/CodeDomProvider.xml
+++ b/xml/System.CodeDom.Compiler/CodeDomProvider.xml
@@ -77,7 +77,6 @@
     <altmember cref="T:System.CodeDom.Compiler.CompilerInfo" />
     <altmember cref="T:Microsoft.CSharp.CSharpCodeProvider" />
     <altmember cref="T:Microsoft.VisualBasic.VBCodeProvider" />
-    <altmember cref="T:Microsoft.JScript.JScriptCodeProvider" />
     <related type="Article" href="/dotnet/framework/configure-apps/file-schema/compiler/">Compiler and Language Provider Settings Schema</related>
   </Docs>
   <Members>

--- a/xml/System.ComponentModel.Design/DesignerActionListCollection.xml
+++ b/xml/System.ComponentModel.Design/DesignerActionListCollection.xml
@@ -576,7 +576,6 @@
         <altmember cref="M:System.ComponentModel.Design.DesignerActionListCollection.IndexOf(System.ComponentModel.Design.DesignerActionList)" />
         <altmember cref="M:System.ComponentModel.Design.DesignerActionListCollection.Add(System.ComponentModel.Design.DesignerActionList)" />
         <altmember cref="M:System.ComponentModel.Design.DesignerActionListCollection.Remove(System.ComponentModel.Design.DesignerActionList)" />
-        <altmember cref="M:System.ComponentModel.Design.DesignerActionListCollection.OnInsert(System.Int32,System.Object)" />
       </Docs>
     </Member>
     <Member MemberName="Item">

--- a/xml/System.ComponentModel.Design/DesignerActionService.xml
+++ b/xml/System.ComponentModel.Design/DesignerActionService.xml
@@ -663,7 +663,6 @@
         <altmember cref="M:System.ComponentModel.Design.DesignerActionService.GetComponentServiceActions(System.ComponentModel.IComponent,System.ComponentModel.Design.DesignerActionListCollection)" />
         <altmember cref="T:System.ComponentModel.Design.DesignerActionListCollection" />
         <altmember cref="T:System.ComponentModel.Design.DesignerVerb" />
-        <altmember cref="T:System.ComponentModel.Design.ComponentActionsType" />
       </Docs>
     </Member>
     <Member MemberName="GetComponentActions">

--- a/xml/System.ComponentModel/RunInstallerAttribute.xml
+++ b/xml/System.ComponentModel/RunInstallerAttribute.xml
@@ -84,7 +84,6 @@
  ]]></format>
     </remarks>
     <altmember cref="T:System.Attribute" />
-    <altmember cref="T:System.Configuration.Install.Installer" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Configuration/AppSettingsSection.xml
+++ b/xml/System.Configuration/AppSettingsSection.xml
@@ -53,7 +53,6 @@
  ]]></format>
     </remarks>
     <altmember cref="T:System.Configuration.ConfigurationManager" />
-    <altmember cref="T:System.Web.Configuration.WebConfigurationManager" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Configuration/Configuration.xml
+++ b/xml/System.Configuration/Configuration.xml
@@ -92,7 +92,6 @@ Note: If you use a static <see langword="GetSection" /> method that takes a path
     </block>
     <altmember cref="T:System.Configuration.ConfigurationSection" />
     <altmember cref="T:System.Configuration.ConfigurationManager" />
-    <altmember cref="T:System.Web.Configuration.WebConfigurationManager" />
     <related type="Article" href="/dotnet/framework/configure-apps/">Configuration Files</related>
   </Docs>
   <Members>

--- a/xml/System.Configuration/ConfigurationElement.xml
+++ b/xml/System.Configuration/ConfigurationElement.xml
@@ -97,7 +97,6 @@
 - The simpler declarative model, also called the attributed model, allows you to define an element attribute by using a property and then decorate it with attributes. These attributes instruct the ASP.NET configuration system about the property types and their default values. With this information, obtained through reflection, the ASP.NET configuration system creates the element property objects for you and performs the required initialization. The example shown later in this topic shows how to use this model.</para>
     </block>
     <altmember cref="T:System.Configuration.ConfigurationManager" />
-    <altmember cref="T:System.Web.Configuration.WebConfigurationManager" />
     <altmember cref="T:System.Configuration.ConfigurationSection" />
     <altmember cref="T:System.Configuration.ElementInformation" />
     <altmember cref="T:System.Configuration.ConfigurationElementCollection" />

--- a/xml/System.Configuration/ConfigurationFileMap.xml
+++ b/xml/System.Configuration/ConfigurationFileMap.xml
@@ -44,7 +44,6 @@
   
  ]]></format>
     </remarks>
-    <altmember cref="T:System.Web.Configuration.WebConfigurationFileMap" />
     <altmember cref="T:System.Configuration.ExeConfigurationFileMap" />
   </Docs>
   <Members>

--- a/xml/System.Configuration/ConfigurationManager.xml
+++ b/xml/System.Configuration/ConfigurationManager.xml
@@ -300,7 +300,6 @@ End Module
 - Read permissions on all the configuration files.</para>
     </block>
     <altmember cref="T:System.Configuration.Configuration" />
-    <altmember cref="T:System.Web.Configuration.WebConfigurationManager" />
     <related type="Article" href="/dotnet/framework/configure-apps/">Configuration Files</related>
   </Docs>
   <Members>

--- a/xml/System.Configuration/ContextInformation.xml
+++ b/xml/System.Configuration/ContextInformation.xml
@@ -93,7 +93,6 @@
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Web.Configuration.WebConfigurationManager.OpenWebConfiguration(System.String)" />
       </Docs>
     </Member>
     <Member MemberName="HostingContext">
@@ -143,7 +142,6 @@
 
  ]]></format>
         </remarks>
-        <altmember cref="T:System.Web.Configuration.WebContext" />
         <altmember cref="T:System.Configuration.ExeContext" />
       </Docs>
     </Member>

--- a/xml/System.Configuration/ExeConfigurationFileMap.xml
+++ b/xml/System.Configuration/ExeConfigurationFileMap.xml
@@ -46,7 +46,6 @@
  ]]></format>
     </remarks>
     <altmember cref="T:System.Configuration.ConfigurationFileMap" />
-    <altmember cref="T:System.Web.Configuration.WebConfigurationFileMap" />
     <related type="Article" href="/dotnet/framework/configure-apps/">Configuration Files</related>
   </Docs>
   <Members>

--- a/xml/System.Data.Common/DbDataSourceEnumerator.xml
+++ b/xml/System.Data.Common/DbDataSourceEnumerator.xml
@@ -52,7 +52,6 @@
   
  ]]></format>
     </remarks>
-    <altmember cref="T:System.Data.Sql.SqlDataSourceEnumerator" />
     <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
   </Docs>
   <Members>
@@ -156,7 +155,6 @@
   
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Data.Sql.SqlDataSourceEnumerator.GetDataSources" />
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
       </Docs>
     </Member>

--- a/xml/System.Data.Common/RowUpdatingEventArgs.xml
+++ b/xml/System.Data.Common/RowUpdatingEventArgs.xml
@@ -64,7 +64,6 @@
  ]]></format>
     </remarks>
     <altmember cref="T:System.Data.OleDb.OleDbRowUpdatingEventArgs" />
-    <altmember cref="T:System.Data.SqlClient.SqlRowUpdatingEventArgs" />
     <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
   </Docs>
   <Members>

--- a/xml/System.Data.Linq.Mapping/MetaAccessor`2.xml
+++ b/xml/System.Data.Linq.Mapping/MetaAccessor`2.xml
@@ -23,7 +23,6 @@
     <typeparam name="TMember">The type of the member of that source.</typeparam>
     <summary>A strongly typed version of the <see cref="T:System.Data.Linq.Mapping.MetaAccessor" /> class.</summary>
     <remarks>To be added.</remarks>
-    <altmember cref="T:System.Data.Linq.Mapping.MetaAccessor" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Data.Linq/Link`1.xml
+++ b/xml/System.Data.Linq/Link`1.xml
@@ -28,8 +28,6 @@
 
  ]]></format>
     </remarks>
-    <altmember cref="T:System.Data.Linq.EntityRef`1" />
-    <altmember cref="T:System.Data.Linq.EntitySet`1" />
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">

--- a/xml/System.Data.Objects/ObjectSet`1.xml
+++ b/xml/System.Data.Objects/ObjectSet`1.xml
@@ -88,7 +88,6 @@
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Data.Objects.ObjectContext.AddObject(System.String,System.Object)" />
       </Docs>
     </Member>
     <Member MemberName="ApplyCurrentValues">
@@ -121,8 +120,6 @@
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Data.Objects.ObjectStateEntry.ApplyCurrentValues(System.Object)" />
-        <altmember cref="M:System.Data.Objects.ObjectContext.ApplyCurrentValues``1(System.String,``0)" />
       </Docs>
     </Member>
     <Member MemberName="ApplyOriginalValues">
@@ -155,8 +152,6 @@
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Data.Objects.ObjectStateEntry.ApplyOriginalValues(System.Object)" />
-        <altmember cref="M:System.Data.Objects.ObjectContext.ApplyOriginalValues``1(System.String,``0)" />
       </Docs>
     </Member>
     <Member MemberName="Attach">
@@ -191,7 +186,6 @@
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Data.Objects.ObjectContext.AttachTo(System.String,System.Object)" />
       </Docs>
     </Member>
     <Member MemberName="CreateObject">
@@ -279,7 +273,6 @@
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Data.Objects.ObjectContext.DeleteObject(System.Object)" />
       </Docs>
     </Member>
     <Member MemberName="Detach">
@@ -314,7 +307,6 @@
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Data.Objects.ObjectContext.Detach(System.Object)" />
       </Docs>
     </Member>
     <Member MemberName="EntitySet">

--- a/xml/System.Diagnostics.Eventing/EventProvider+WriteEventErrorCode.xml
+++ b/xml/System.Diagnostics.Eventing/EventProvider+WriteEventErrorCode.xml
@@ -25,7 +25,6 @@
 
  ]]></format>
     </remarks>
-    <altmember cref="M:System.Diagnostics.Eventing.EventProvider.GetLastWriteEventError" />
   </Docs>
   <Members>
     <Member MemberName="EventTooBig">

--- a/xml/System.Diagnostics.SymbolStore/ISymbolWriter.xml
+++ b/xml/System.Diagnostics.SymbolStore/ISymbolWriter.xml
@@ -60,7 +60,6 @@
 
  ]]></format>
     </remarks>
-    <altmember cref="M:System.Reflection.Emit.ModuleBuilder.GetSymWriter" />
   </Docs>
   <Members>
     <Member MemberName="Close">

--- a/xml/System.Diagnostics/EventInstance.xml
+++ b/xml/System.Diagnostics/EventInstance.xml
@@ -724,7 +724,6 @@ SVC_UPDATE.EXE
         <altmember cref="Overload:System.Diagnostics.EventLog.WriteEvent" />
         <altmember cref="P:System.Diagnostics.EventLogEntry.CategoryNumber" />
         <altmember cref="P:System.Diagnostics.EventSourceCreationData.CategoryResourceFile" />
-        <altmember cref="P:System.Diagnostics.EventLogInstaller.CategoryResourceFile" />
       </Docs>
     </Member>
     <Member MemberName="EntryType">
@@ -1071,7 +1070,6 @@ SVC_UPDATE.EXE
         <altmember cref="Overload:System.Diagnostics.EventLog.WriteEvent" />
         <altmember cref="P:System.Diagnostics.EventLogEntry.InstanceId" />
         <altmember cref="P:System.Diagnostics.EventSourceCreationData.MessageResourceFile" />
-        <altmember cref="P:System.Diagnostics.EventLogInstaller.MessageResourceFile" />
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Diagnostics/EventLog.xml
+++ b/xml/System.Diagnostics/EventLog.xml
@@ -134,7 +134,6 @@
 
  ]]></format>
     </remarks>
-    <altmember cref="T:System.Diagnostics.EventLogInstaller" />
     <altmember cref="T:System.Diagnostics.EventLogEntry" />
     <altmember cref="T:System.Diagnostics.EntryWrittenEventArgs" />
     <altmember cref="T:System.ServiceProcess.ServiceBase" />
@@ -851,7 +850,6 @@ SVC_UPDATE.EXE
         <altmember cref="M:System.Diagnostics.EventLog.SourceExists(System.String)" />
         <altmember cref="M:System.Diagnostics.EventLog.DeleteEventSource(System.String)" />
         <altmember cref="P:System.Diagnostics.EventLog.Source" />
-        <altmember cref="T:System.Diagnostics.EventLogInstaller" />
       </Docs>
     </Member>
     <Member MemberName="CreateEventSource">

--- a/xml/System.Diagnostics/EventSourceCreationData.xml
+++ b/xml/System.Diagnostics/EventSourceCreationData.xml
@@ -67,7 +67,6 @@
  ]]></format>
     </remarks>
     <altmember cref="T:System.Diagnostics.EventLog" />
-    <altmember cref="T:System.Diagnostics.EventLogInstaller" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -424,7 +423,6 @@ SVC_UPDATE.EXE
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The property is set to a negative value or to a value larger than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.</exception>
         <altmember cref="P:System.Diagnostics.EventSourceCreationData.CategoryResourceFile" />
-        <altmember cref="P:System.Diagnostics.EventLogInstaller.CategoryCount" />
         <altmember cref="Overload:System.Diagnostics.EventLog.WriteEvent" />
       </Docs>
     </Member>
@@ -603,7 +601,6 @@ SVC_UPDATE.EXE
  ]]></format>
         </remarks>
         <altmember cref="P:System.Diagnostics.EventSourceCreationData.CategoryCount" />
-        <altmember cref="P:System.Diagnostics.EventLogInstaller.CategoryResourceFile" />
       </Docs>
     </Member>
     <Member MemberName="LogName">
@@ -670,7 +667,6 @@ SVC_UPDATE.EXE
 
  ]]></format>
         </remarks>
-        <altmember cref="P:System.Diagnostics.EventLogInstaller.Log" />
         <altmember cref="M:System.Diagnostics.EventLog.Exists(System.String)" />
       </Docs>
     </Member>
@@ -917,7 +913,6 @@ SVC_UPDATE.EXE
 
  ]]></format>
         </remarks>
-        <altmember cref="P:System.Diagnostics.EventLogInstaller.MessageResourceFile" />
       </Docs>
     </Member>
     <Member MemberName="ParameterResourceFile">
@@ -1121,7 +1116,6 @@ SVC_UPDATE.EXE
 
  ]]></format>
         </remarks>
-        <altmember cref="P:System.Diagnostics.EventLogInstaller.ParameterResourceFile" />
       </Docs>
     </Member>
     <Member MemberName="Source">
@@ -1185,7 +1179,6 @@ SVC_UPDATE.EXE
 
  ]]></format>
         </remarks>
-        <altmember cref="P:System.Diagnostics.EventLogInstaller.Source" />
         <altmember cref="M:System.Diagnostics.EventLog.SourceExists(System.String)" />
       </Docs>
     </Member>

--- a/xml/System.Diagnostics/StackTrace.xml
+++ b/xml/System.Diagnostics/StackTrace.xml
@@ -86,7 +86,6 @@
     </remarks>
     <altmember cref="P:System.Exception.StackTrace" />
     <altmember cref="P:System.Environment.StackTrace" />
-    <altmember cref="P:System.Runtime.Serialization.Formatters.ServerFault.StackTrace" />
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">

--- a/xml/System.Diagnostics/TraceSource.xml
+++ b/xml/System.Diagnostics/TraceSource.xml
@@ -1444,7 +1444,6 @@ You can refer to the trace source by using the `name` attribute in the configura
  ]]></format>
         </remarks>
         <altmember cref="T:System.Diagnostics.XmlWriterTraceListener" />
-        <altmember cref="T:System.Diagnostics.EventSchemaTraceListener" />
         <altmember cref="T:System.Diagnostics.DelimitedListTraceListener" />
       </Docs>
     </Member>

--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -105,7 +105,6 @@
 
       ]]></format>
     </remarks>
-    <altmember cref="T:System.Globalization.CultureAndRegionInfoBuilder" />
     <altmember cref="T:System.Globalization.RegionInfo" />
   </Docs>
   <Members>
@@ -2108,7 +2107,6 @@ Setting `predefinedOnly` to `true` will ensure a culture is created only if the 
           <para>.NET Framework 3.5 and earlier versions throw an <see cref="T:System.ArgumentException" /> if <paramref name="name" /> does not correspond to the name of a supported culture. Starting with .NET Framework 4, this method throws a <see cref="T:System.Globalization.CultureNotFoundException" />.</para>
         </block>
         <altmember cref="P:System.Globalization.CultureInfo.TextInfo" />
-        <altmember cref="T:System.Globalization.CultureAndRegionInfoBuilder" />
         <altmember cref="M:System.Globalization.CultureInfo.ClearCachedData" />
       </Docs>
     </Member>
@@ -2404,7 +2402,6 @@ Setting `predefinedOnly` to `true` will ensure a culture is created only if the 
  ]]></format>
         </remarks>
         <altmember cref="P:System.Globalization.CultureInfo.TextInfo" />
-        <altmember cref="T:System.Globalization.CultureAndRegionInfoBuilder" />
       </Docs>
     </Member>
     <Member MemberName="InstalledUICulture">

--- a/xml/System.Net.Mail/SmtpClient.xml
+++ b/xml/System.Net.Mail/SmtpClient.xml
@@ -542,8 +542,6 @@ The following code example demonstrates sending an email message asynchronously.
 
  ]]></format>
         </remarks>
-        <altmember cref="T:System.Net.Configuration.SmtpSection" />
-        <altmember cref="P:System.Net.Configuration.SmtpSection.DeliveryMethod" />
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">&lt;mailSettings&gt; Element (Network Settings)</related>
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings">&lt;smtp&gt; Element (Network Settings)</related>
       </Docs>
@@ -772,9 +770,6 @@ The following code example demonstrates sending an email message asynchronously.
 
  ]]></format>
         </remarks>
-        <altmember cref="T:System.Net.Configuration.SmtpSection" />
-        <altmember cref="T:System.Net.Configuration.SmtpNetworkElement" />
-        <altmember cref="P:System.Net.Configuration.SmtpNetworkElement.EnableSsl" />
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">&lt;mailSettings&gt; Element (Network Settings)</related>
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings">&lt;smtp&gt; Element (Network Settings)</related>
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/network-element-network-settings">&lt;network&gt; Element (Network Settings)</related>
@@ -845,9 +840,6 @@ The following code example demonstrates sending an email message asynchronously.
         <exception cref="T:System.ArgumentNullException">The value specified for a set operation is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The value specified for a set operation is equal to <see cref="F:System.String.Empty" /> ("").</exception>
         <exception cref="T:System.InvalidOperationException">You cannot change the value of this property when an email is being sent.</exception>
-        <altmember cref="T:System.Net.Configuration.SmtpSection" />
-        <altmember cref="T:System.Net.Configuration.SmtpNetworkElement" />
-        <altmember cref="P:System.Net.Configuration.SmtpNetworkElement.Host" />
         <altmember cref="P:System.Net.Mail.SmtpClient.Port" />
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">mailSettings for system.net</related>
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings">&lt;smtp&gt; Element (Network Settings)</related>
@@ -969,8 +961,6 @@ The following code example demonstrates sending an email message asynchronously.
 
  ]]></format>
         </remarks>
-        <altmember cref="T:System.Net.Configuration.SmtpSection" />
-        <altmember cref="P:System.Net.Configuration.SmtpSection.DeliveryMethod" />
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">&lt;mailSettings&gt; Element (Network Settings)</related>
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings">&lt;smtp&gt; Element (Network Settings)</related>
       </Docs>
@@ -1036,9 +1026,6 @@ The following code example demonstrates sending an email message asynchronously.
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The value specified for a set operation is less than or equal to zero.</exception>
         <exception cref="T:System.InvalidOperationException">You cannot change the value of this property when an email is being sent.</exception>
-        <altmember cref="T:System.Net.Configuration.SmtpSection" />
-        <altmember cref="T:System.Net.Configuration.SmtpNetworkElement" />
-        <altmember cref="P:System.Net.Configuration.SmtpNetworkElement.Port" />
         <altmember cref="P:System.Net.Mail.SmtpClient.Host" />
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">mailSettings for system.net</related>
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings">&lt;smtp&gt; Element (Network Settings)</related>
@@ -2252,9 +2239,6 @@ The following code example demonstrates sending an email message asynchronously.
 
  ]]></format>
         </remarks>
-        <altmember cref="T:System.Net.Configuration.SmtpSection" />
-        <altmember cref="T:System.Net.Configuration.SmtpNetworkElement" />
-        <altmember cref="P:System.Net.Configuration.SmtpNetworkElement.TargetName" />
         <related type="Article" href="/dotnet/framework/network-programming/integrated-windows-authentication-with-extended-protection">Integrated Windows Authentication with Extended Protection</related>
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">&lt;mailSettings&gt; Element (Network Settings)</related>
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings">&lt;smtp&gt; Element (Network Settings)</related>

--- a/xml/System.Net.PeerToPeer.Collaboration/PeerCollaborationPermissionAttribute.xml
+++ b/xml/System.Net.PeerToPeer.Collaboration/PeerCollaborationPermissionAttribute.xml
@@ -110,7 +110,6 @@
  ]]></format>
         </remarks>
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermissionAttribute.CreatePermission" />
-        <altmember cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaboration" />
       </Docs>
     </Member>
     <Member MemberName="CreatePermission">
@@ -156,8 +155,6 @@
         <block subset="none" type="overrides">
           <para>When permissions are inherited <see cref="T:System.Security.Permissions.SecurityAttribute" />, <see cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermissionAttribute.CreatePermission" /> must be overridden.</para>
         </block>
-        <altmember cref="T:System.Net.PeerToPeer.Collaboration.PeerApplication" />
-        <altmember cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaboration" />
         <altmember cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" />
       </Docs>
     </Member>

--- a/xml/System.Net.PeerToPeer/PnrpPermissionAttribute.xml
+++ b/xml/System.Net.PeerToPeer/PnrpPermissionAttribute.xml
@@ -108,8 +108,6 @@
  ]]></format>
         </remarks>
         <altmember cref="M:System.Net.PeerToPeer.PnrpPermissionAttribute.CreatePermission" />
-        <altmember cref="T:System.Net.PeerToPeer.PeerName" />
-        <altmember cref="T:System.Net.PeerToPeer.PeerNameRecord" />
         <altmember cref="T:System.Net.PeerToPeer.PnrpPermission" />
       </Docs>
     </Member>

--- a/xml/System.Net.Sockets/IPProtectionLevel.xml
+++ b/xml/System.Net.Sockets/IPProtectionLevel.xml
@@ -51,7 +51,6 @@
   
  ]]></format>
     </remarks>
-    <altmember cref="P:System.Net.Configuration.SocketElement.IPProtectionLevel" />
     <altmember cref="P:System.Net.IPAddress.IsIPv6Teredo" />
     <altmember cref="M:System.Net.Sockets.Socket.SetIPProtectionLevel(System.Net.Sockets.IPProtectionLevel)" />
     <altmember cref="M:System.Net.Sockets.TcpListener.AllowNatTraversal(System.Boolean)" />

--- a/xml/System.Net/HttpListenerRequest.xml
+++ b/xml/System.Net/HttpListenerRequest.xml
@@ -1836,7 +1836,6 @@
 
  ]]></format>
         </remarks>
-        <altmember cref="T:System.Net.Configuration.HttpListenerElement" />
         <altmember cref="T:System.Net.HttpListener" />
         <altmember cref="T:System.Net.HttpListenerContext" />
         <altmember cref="T:System.Net.HttpListenerResponse" />

--- a/xml/System.Net/HttpListenerTimeoutManager.xml
+++ b/xml/System.Net/HttpListenerTimeoutManager.xml
@@ -52,8 +52,6 @@
  ]]></format>
     </remarks>
     <altmember cref="T:System.Net.HttpListener" />
-    <altmember cref="T:System.Net.Configuration.HttpListenerElement" />
-    <altmember cref="T:System.Net.Configuration.HttpListenerTimeoutsElement" />
   </Docs>
   <Members>
     <Member MemberName="DrainEntityBody">

--- a/xml/System.Net/HttpWebRequest.xml
+++ b/xml/System.Net/HttpWebRequest.xml
@@ -1927,7 +1927,6 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <block subset="none" type="overrides">
           <para>Each connection group creates additional connections for a server. This may result in exceeding the number of connections set by the <see cref="P:System.Net.ServicePoint.ConnectionLimit" /> property for that server.</para>
         </block>
-        <altmember cref="P:System.Net.Configuration.ConnectionManagementElement.MaxConnection" />
         <altmember cref="P:System.Net.WebRequest.ConnectionGroupName" />
         <related type="Article" href="/dotnet/framework/network-programming/connection-grouping">Connection Grouping</related>
       </Docs>
@@ -2152,7 +2151,6 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
 
  ]]></format>
         </remarks>
-        <altmember cref="P:System.Net.Configuration.HttpWebRequestElement.MaximumUnauthorizedUploadLength" />
       </Docs>
     </Member>
     <Member MemberName="ContinueTimeout">
@@ -2947,7 +2945,6 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>The value for this property is stored in <see cref="T:System.Net.WebHeaderCollection" />. If WebHeaderCollection is set, the property value is lost.</remarks>
         <exception cref="T:System.ArgumentException">
           <see langword="Expect" /> is set to a string that contains "100-continue" as a substring.</exception>
-        <altmember cref="P:System.Net.Configuration.HttpWebRequestElement.MaximumUnauthorizedUploadLength" />
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings">DefaultProxy Element (Network Settings)</related>
       </Docs>
     </Member>

--- a/xml/System.Net/ServicePointManager.xml
+++ b/xml/System.Net/ServicePointManager.xml
@@ -562,7 +562,6 @@
  ]]></format>
         </remarks>
         <altmember cref="T:System.Net.ServicePoint" />
-        <altmember cref="P:System.Net.Configuration.ServicePointManagerElement.EncryptionPolicy" />
         <altmember cref="T:System.Net.Security.EncryptionPolicy" />
         <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/servicepointmanager-element-network-settings">ServicePointManager Element (Network Settings)</related>
       </Docs>

--- a/xml/System.Net/WebRequest.xml
+++ b/xml/System.Net/WebRequest.xml
@@ -706,7 +706,6 @@
         <block subset="none" type="overrides">
           <para>The <see cref="P:System.Net.WebRequest.ConnectionGroupName" /> property typically associates a group of requests that share a set of credentials with a connection to an Internet resource to avoid potential security failures.</para>
         </block>
-        <altmember cref="P:System.Net.Configuration.ConnectionManagementElement.MaxConnection" />
         <altmember cref="P:System.Net.HttpWebRequest.ConnectionGroupName" />
         <related type="Article" href="/dotnet/framework/network-programming/connection-grouping">Connection Grouping</related>
       </Docs>

--- a/xml/System.Net/WebUtility.xml
+++ b/xml/System.Net/WebUtility.xml
@@ -74,8 +74,6 @@
     </remarks>
     <altmember cref="T:System.Uri" />
     <altmember cref="T:System.Web.HttpUtility" />
-    <altmember cref="T:System.Web.HttpServerUtility" />
-    <altmember cref="P:System.Web.HttpContext.Server" />
   </Docs>
   <Members>
     <MemberGroup MemberName="HtmlDecode">

--- a/xml/System.Reflection.Emit/AssemblyBuilder.xml
+++ b/xml/System.Reflection.Emit/AssemblyBuilder.xml
@@ -3043,7 +3043,6 @@ The following code example shows how to define and use a dynamic assembly. The e
 
  ]]></format>
         </remarks>
-        <altmember cref="F:System.Reflection.Emit.AssemblyBuilderAccess.ReflectionOnly" />
         <altmember cref="M:System.Reflection.Assembly.ReflectionOnlyLoad(System.String)" />
         <related type="Article" href="/dotnet/framework/reflection-and-codedom/how-to-load-assemblies-into-the-reflection-only-context">How to: Load Assemblies into the Reflection-Only Context</related>
       </Docs>

--- a/xml/System.Reflection.Emit/ModuleBuilder.xml
+++ b/xml/System.Reflection.Emit/ModuleBuilder.xml
@@ -1103,12 +1103,7 @@
         <exception cref="T:System.ArgumentException">
           <paramref name="name" /> is a zero-length string.</exception>
         <exception cref="T:System.InvalidOperationException">The dynamic assembly that contains the current module is transient; that is, no file name was specified when <see cref="M:System.Reflection.Emit.AssemblyBuilder.DefineDynamicModule(System.String,System.String)" /> was called.</exception>
-        <altmember cref="M:System.Reflection.Emit.ModuleBuilder.DefineResource(System.String,System.String)" />
-        <altmember cref="M:System.Reflection.Emit.AssemblyBuilder.DefineResource(System.String,System.String,System.String,System.Reflection.ResourceAttributes)" />
         <altmember cref="M:System.Resources.ResourceWriter.AddResource(System.String,System.String)" />
-        <altmember cref="M:System.Reflection.Emit.AssemblyBuilder.AddResourceFile(System.String,System.String)" />
-        <altmember cref="M:System.Reflection.Emit.AssemblyBuilder.DefineUnmanagedResource(System.String)" />
-        <altmember cref="M:System.Reflection.Emit.ModuleBuilder.DefineUnmanagedResource(System.Byte[])" />
       </Docs>
     </Member>
     <MemberGroup MemberName="DefinePInvokeMethod">
@@ -1472,7 +1467,6 @@
  -or-
 
  The containing assembly is not persistable.</exception>
-        <altmember cref="M:System.Reflection.Emit.ModuleBuilder.DefineManifestResource(System.String,System.IO.Stream,System.Reflection.ResourceAttributes)" />
       </Docs>
     </Member>
     <Member MemberName="DefineResource">
@@ -1533,7 +1527,6 @@
  -or-
 
  The containing assembly is not persistable.</exception>
-        <altmember cref="M:System.Reflection.Emit.ModuleBuilder.DefineManifestResource(System.String,System.IO.Stream,System.Reflection.ResourceAttributes)" />
       </Docs>
     </Member>
     <MemberGroup MemberName="DefineType">

--- a/xml/System.Reflection/AssemblyAlgorithmIdAttribute.xml
+++ b/xml/System.Reflection/AssemblyAlgorithmIdAttribute.xml
@@ -215,7 +215,6 @@
         <summary>Gets the hash algorithm of an assembly manifest's contents.</summary>
         <value>An unsigned integer representing the assembly hash algorithm.</value>
         <remarks>To be added.</remarks>
-        <altmember cref="T:System.Configuration.Assemblies.AssemblyHash" />
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection/IReflect.xml
+++ b/xml/System.Reflection/IReflect.xml
@@ -66,7 +66,6 @@ On .NET Framework, the <xref:System.Reflection.IReflect> interface is used to in
 
  ]]></format>
     </remarks>
-    <altmember cref="T:System.Runtime.InteropServices.CustomMarshalers.ExpandoToDispatchExMarshaler" />
   </Docs>
   <Members>
     <Member MemberName="GetField">

--- a/xml/System.Runtime.InteropServices/ComRegisterFunctionAttribute.xml
+++ b/xml/System.Runtime.InteropServices/ComRegisterFunctionAttribute.xml
@@ -89,7 +89,6 @@
  ]]></format>
     </remarks>
     <altmember cref="T:System.Runtime.InteropServices.ComUnregisterFunctionAttribute" />
-    <altmember cref="M:System.Runtime.InteropServices.RegistrationServices.RegisterAssembly(System.Reflection.Assembly,System.Runtime.InteropServices.AssemblyRegistrationFlags)" />
     <related type="Article" href="/dotnet/framework/tools/regasm-exe-assembly-registration-tool">Regasm.exe (Assembly Registration Tool)</related>
   </Docs>
   <Members>

--- a/xml/System.Runtime.InteropServices/ComUnregisterFunctionAttribute.xml
+++ b/xml/System.Runtime.InteropServices/ComUnregisterFunctionAttribute.xml
@@ -77,7 +77,6 @@
  ]]></format>
     </remarks>
     <altmember cref="T:System.Runtime.InteropServices.ComRegisterFunctionAttribute" />
-    <altmember cref="M:System.Runtime.InteropServices.RegistrationServices.UnregisterAssembly(System.Reflection.Assembly)" />
     <related type="Article" href="/dotnet/framework/tools/regasm-exe-assembly-registration-tool">Regasm.exe (Assembly Registration Tool)</related>
   </Docs>
   <Members>

--- a/xml/System.Runtime.InteropServices/Marshal.xml
+++ b/xml/System.Runtime.InteropServices/Marshal.xml
@@ -3039,10 +3039,8 @@ The code retrieves a reference to an instance of Microsoft Word successfully. Ho
  -or-
 
  The <typeparamref name="T" /> parameter is <see langword="null" />.</exception>
-        <altmember cref="M:System.Runtime.InteropServices.Marshal.GetComInterfaceForObjectInContext(System.Object,System.Type)" />
         <altmember cref="T:System.Runtime.InteropServices.ComImportAttribute" />
         <altmember cref="M:System.Runtime.InteropServices.Marshal.Release(System.IntPtr)" />
-        <altmember cref="T:System.Runtime.InteropServices.UCOMIConnectionPointContainer" />
         <altmember cref="M:System.Runtime.InteropServices.Marshal.GetIDispatchForObject(System.Object)" />
       </Docs>
     </Member>
@@ -3302,7 +3300,6 @@ The code retrieves a reference to an instance of Microsoft Word successfully. Ho
         <altmember cref="M:System.Runtime.InteropServices.Marshal.GetComInterfaceForObject(System.Object,System.Type)" />
         <altmember cref="T:System.Runtime.InteropServices.ComImportAttribute" />
         <altmember cref="M:System.Runtime.InteropServices.Marshal.Release(System.IntPtr)" />
-        <altmember cref="T:System.Runtime.InteropServices.UCOMIConnectionPointContainer" />
         <altmember cref="M:System.Runtime.InteropServices.Marshal.GetIDispatchForObject(System.Object)" />
       </Docs>
     </Member>
@@ -3443,7 +3440,6 @@ The code retrieves a reference to an instance of Microsoft Word successfully. Ho
 
  The <paramref name="m" /> parameter is not an interface method.</exception>
         <altmember cref="T:System.Reflection.MemberInfo" />
-        <altmember cref="M:System.Runtime.InteropServices.Marshal.GetMethodInfoForComSlot(System.Type,System.Int32,System.Runtime.InteropServices.ComMemberType@)" />
       </Docs>
     </Member>
     <Member MemberName="GetDelegateForFunctionPointer">
@@ -3680,7 +3676,6 @@ The code retrieves a reference to an instance of Microsoft Word successfully. Ho
  ]]></format>
         </remarks>
         <altmember cref="M:System.Runtime.InteropServices.Marshal.GetStartComSlot(System.Type)" />
-        <altmember cref="M:System.Runtime.InteropServices.Marshal.GetMethodInfoForComSlot(System.Type,System.Int32,System.Runtime.InteropServices.ComMemberType@)" />
       </Docs>
     </Member>
     <Member MemberName="GetExceptionCode">
@@ -4467,7 +4462,6 @@ A P/Invoke that marshals a delegate handles the <xref:System.GC.KeepAlive*> on t
         <exception cref="T:System.InvalidCastException">
           <paramref name="o" /> does not support the requested interface.</exception>
         <altmember cref="M:System.Runtime.InteropServices.Marshal.Release(System.IntPtr)" />
-        <altmember cref="M:System.Runtime.InteropServices.Marshal.GetIDispatchForObjectInContext(System.Object)" />
       </Docs>
     </Member>
     <Member MemberName="GetIDispatchForObjectInContext">
@@ -4580,7 +4574,6 @@ A P/Invoke that marshals a delegate handles the <xref:System.GC.KeepAlive*> on t
 
  <paramref name="t" /> is a Windows Runtime type.</exception>
         <exception cref="T:System.Runtime.InteropServices.COMException">A type library is registered for the assembly that contains the type, but the type definition cannot be found.</exception>
-        <altmember cref="M:System.Runtime.InteropServices.Marshal.GetTypeForITypeInfo(System.IntPtr)" />
         <altmember cref="T:System.Runtime.InteropServices.MarshalAsAttribute" />
       </Docs>
     </Member>
@@ -5041,7 +5034,6 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
         </remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="t" /> is not visible from COM.</exception>
-        <altmember cref="M:System.Runtime.InteropServices.Marshal.GetComSlotForMethodInfo(System.Reflection.MemberInfo)" />
         <altmember cref="M:System.Runtime.InteropServices.Marshal.GetEndComSlot(System.Type)" />
         <altmember cref="M:System.Runtime.InteropServices.Marshal.GetStartComSlot(System.Type)" />
         <altmember cref="T:System.Runtime.InteropServices.ComMemberType" />
@@ -5748,7 +5740,6 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
         <exception cref="T:System.ArgumentException">
           <paramref name="t" /> is not visible from COM.</exception>
         <altmember cref="M:System.Runtime.InteropServices.Marshal.GetEndComSlot(System.Type)" />
-        <altmember cref="M:System.Runtime.InteropServices.Marshal.GetMethodInfoForComSlot(System.Type,System.Int32,System.Runtime.InteropServices.ComMemberType@)" />
       </Docs>
     </Member>
     <Member MemberName="GetThreadFromFiberCookie">
@@ -5920,7 +5911,6 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Runtime.InteropServices.Marshal.GetITypeInfoForType(System.Type)" />
         <altmember cref="T:System.Runtime.InteropServices.MarshalAsAttribute" />
       </Docs>
     </Member>
@@ -6065,7 +6055,6 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="typeInfo" /> parameter is <see langword="null" />.</exception>
-        <altmember cref="M:System.Runtime.InteropServices.UCOMITypeInfo.GetDocumentation(System.Int32,System.String@,System.String@,System.Int32@,System.String@)" />
       </Docs>
     </Member>
     <Member MemberName="GetTypeInfoName">
@@ -6116,7 +6105,6 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Runtime.InteropServices.UCOMITypeInfo.GetDocumentation(System.Int32,System.String@,System.String@,System.Int32@,System.String@)" />
       </Docs>
     </Member>
     <MemberGroup MemberName="GetTypeLibGuid">
@@ -6172,7 +6160,6 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Runtime.InteropServices.Marshal.GetTypeLibGuidForAssembly(System.Reflection.Assembly)" />
         <altmember cref="T:System.Runtime.InteropServices.ComTypes.ITypeLib" />
       </Docs>
     </Member>
@@ -6224,7 +6211,6 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Runtime.InteropServices.Marshal.GetTypeLibGuidForAssembly(System.Reflection.Assembly)" />
         <altmember cref="T:System.Runtime.InteropServices.UCOMITypeLib" />
       </Docs>
     </Member>
@@ -6275,7 +6261,6 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
         <exception cref="T:System.ArgumentNullException">
           <paramref name="asm" /> is <see langword="null" />.</exception>
         <altmember cref="T:System.Runtime.InteropServices.GuidAttribute" />
-        <altmember cref="M:System.Runtime.InteropServices.Marshal.GetTypeLibGuid(System.Runtime.InteropServices.UCOMITypeLib)" />
       </Docs>
     </Member>
     <MemberGroup MemberName="GetTypeLibLcid">
@@ -6531,9 +6516,7 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="inputAssembly" /> is <see langword="null" />.</exception>
-        <altmember cref="T:System.Runtime.InteropServices.TypeLibExporterFlags" />
         <altmember cref="T:System.Runtime.InteropServices.TypeLibVersionAttribute" />
-        <altmember cref="T:System.Runtime.InteropServices.ITypeLibConverter" />
       </Docs>
     </Member>
     <Member MemberName="GetUniqueObjectForIUnknown">
@@ -6764,7 +6747,6 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
           <paramref name="o" /> is <see langword="null" />.</exception>
         <altmember cref="T:System.Runtime.InteropServices.ComImportAttribute" />
         <altmember cref="P:System.Type.IsImport" />
-        <altmember cref="M:System.Runtime.InteropServices.RegistrationServices.TypeRepresentsComType(System.Type)" />
       </Docs>
     </Member>
     <Member MemberName="IsTypeVisibleFromCom">
@@ -8010,7 +7992,6 @@ On .NET 6 and later versions, this method is functionally equivalent to <xref:Sy
         <exception cref="T:System.ArgumentNullException">
           <paramref name="structureType" /> is <see langword="null" />.</exception>
         <exception cref="T:System.MissingMethodException">The class specified by <paramref name="structureType" /> does not have an accessible parameterless constructor.</exception>
-        <altmember cref="M:System.Runtime.InteropServices.UCOMITypeInfo.GetTypeAttr(System.IntPtr@)" />
       </Docs>
     </Member>
     <Member MemberName="PtrToStructure&lt;T&gt;">

--- a/xml/System.Runtime.Serialization.Formatters/TypeFilterLevel.xml
+++ b/xml/System.Runtime.Serialization.Formatters/TypeFilterLevel.xml
@@ -70,10 +70,6 @@
  ]]></format>
     </remarks>
     <altmember cref="P:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter.FilterLevel" />
-    <altmember cref="P:System.Runtime.Remoting.Channels.BinaryServerFormatterSink.TypeFilterLevel" />
-    <altmember cref="P:System.Runtime.Remoting.Channels.BinaryServerFormatterSinkProvider.TypeFilterLevel" />
-    <altmember cref="P:System.Runtime.Remoting.Channels.SoapServerFormatterSink.TypeFilterLevel" />
-    <altmember cref="P:System.Runtime.Remoting.Channels.SoapServerFormatterSinkProvider.TypeFilterLevel" />
   </Docs>
   <Members>
     <Member MemberName="Full">

--- a/xml/System.Runtime.Serialization/DataContractSerializer.xml
+++ b/xml/System.Runtime.Serialization/DataContractSerializer.xml
@@ -551,7 +551,6 @@
         <altmember cref="T:System.Runtime.Serialization.IExtensibleDataObject" />
         <altmember cref="T:System.Runtime.Serialization.ExtensionDataObject" />
         <altmember cref="T:System.Runtime.Serialization.KnownTypeAttribute" />
-        <altmember cref="T:System.Runtime.Serialization.IDataContractSurrogate" />
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -663,7 +662,6 @@
         <altmember cref="T:System.Runtime.Serialization.IExtensibleDataObject" />
         <altmember cref="T:System.Runtime.Serialization.ExtensionDataObject" />
         <altmember cref="T:System.Runtime.Serialization.KnownTypeAttribute" />
-        <altmember cref="T:System.Runtime.Serialization.IDataContractSurrogate" />
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -724,7 +722,6 @@
         <altmember cref="P:System.Runtime.Serialization.DataContractSerializer.IgnoreExtensionDataObject" />
         <altmember cref="T:System.Runtime.Serialization.IExtensibleDataObject" />
         <altmember cref="T:System.Runtime.Serialization.ExtensionDataObject" />
-        <altmember cref="T:System.Runtime.Serialization.IDataContractSurrogate" />
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -904,7 +901,6 @@
 
  ]]></format>
         </remarks>
-        <altmember cref="T:System.Runtime.Serialization.IDataContractSurrogate" />
       </Docs>
     </Member>
     <Member MemberName="IgnoreExtensionDataObject">

--- a/xml/System.Runtime.Serialization/ISerializable.xml
+++ b/xml/System.Runtime.Serialization/ISerializable.xml
@@ -93,7 +93,6 @@
     <block subset="none" type="overrides">
       <para>Implement this interface to allow an object to take part in its own serialization and deserialization.</para>
     </block>
-    <altmember cref="T:System.Runtime.Remoting.Messaging.RemotingSurrogateSelector" />
     <related type="Article" href="/dotnet/standard/serialization/xml-and-soap-serialization">XML and SOAP Serialization</related>
     <related type="Article" href="/dotnet/standard/serialization/custom-serialization">Custom serialization</related>
   </Docs>

--- a/xml/System.Runtime.Serialization/OnDeserializedAttribute.xml
+++ b/xml/System.Runtime.Serialization/OnDeserializedAttribute.xml
@@ -83,7 +83,6 @@
     <altmember cref="T:System.Runtime.Serialization.OnDeserializingAttribute" />
     <altmember cref="T:System.Runtime.Serialization.OnSerializedAttribute" />
     <altmember cref="T:System.Runtime.Serialization.OnSerializingAttribute" />
-    <altmember cref="T:System.Runtime.Serialization.Formatters.Soap.SoapFormatter" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Runtime.Serialization/OnDeserializingAttribute.xml
+++ b/xml/System.Runtime.Serialization/OnDeserializingAttribute.xml
@@ -83,7 +83,6 @@
     <altmember cref="T:System.Runtime.Serialization.OnDeserializedAttribute" />
     <altmember cref="T:System.Runtime.Serialization.OnSerializedAttribute" />
     <altmember cref="T:System.Runtime.Serialization.OnSerializingAttribute" />
-    <altmember cref="T:System.Runtime.Serialization.Formatters.Soap.SoapFormatter" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Runtime.Serialization/OnSerializedAttribute.xml
+++ b/xml/System.Runtime.Serialization/OnSerializedAttribute.xml
@@ -83,7 +83,6 @@
     <altmember cref="T:System.Runtime.Serialization.OnDeserializedAttribute" />
     <altmember cref="T:System.Runtime.Serialization.OnDeserializingAttribute" />
     <altmember cref="T:System.Runtime.Serialization.OnSerializingAttribute" />
-    <altmember cref="T:System.Runtime.Serialization.Formatters.Soap.SoapFormatter" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Runtime.Serialization/OnSerializingAttribute.xml
+++ b/xml/System.Runtime.Serialization/OnSerializingAttribute.xml
@@ -85,7 +85,6 @@
     <altmember cref="T:System.Runtime.Serialization.OnDeserializingAttribute" />
     <altmember cref="T:System.Runtime.Serialization.OnDeserializedAttribute" />
     <altmember cref="T:System.Runtime.Serialization.OnSerializedAttribute" />
-    <altmember cref="T:System.Runtime.Serialization.Formatters.Soap.SoapFormatter" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Runtime.Serialization/XmlObjectSerializer.xml
+++ b/xml/System.Runtime.Serialization/XmlObjectSerializer.xml
@@ -73,7 +73,6 @@
       <para>When you inherit from <see cref="T:System.Runtime.Serialization.XmlObjectSerializer" />, you must override the following members: <see cref="M:System.Runtime.Serialization.XmlObjectSerializer.WriteStartObject(System.Xml.XmlDictionaryWriter,System.Object)" />, <see cref="M:System.Runtime.Serialization.XmlObjectSerializer.WriteObjectContent(System.Xml.XmlDictionaryWriter,System.Object)" />, <see cref="M:System.Runtime.Serialization.XmlObjectSerializer.WriteEndObject(System.Xml.XmlDictionaryWriter)" />. Additionally, the <see cref="Overload:System.Runtime.Serialization.XmlObjectSerializer.IsStartObject" /> and <see cref="Overload:System.Runtime.Serialization.XmlObjectSerializer.ReadObject" /> methods must be implemented for reading and deserializing.</para>
     </block>
     <altmember cref="T:System.Runtime.Serialization.DataContractSerializer" />
-    <altmember cref="T:System.Runtime.Serialization.NetDataContractSerializer" />
     <related type="Article" href="/dotnet/framework/wcf/feature-details/using-data-contracts">Using Data Contracts</related>
     <related type="Article" href="/dotnet/framework/wcf/feature-details/data-contract-serializer">Data Contract Serializer</related>
   </Docs>

--- a/xml/System.Security.AccessControl/EventWaitHandleSecurity.xml
+++ b/xml/System.Security.AccessControl/EventWaitHandleSecurity.xml
@@ -104,8 +104,6 @@
     <altmember cref="T:System.Security.AccessControl.EventWaitHandleAccessRule" />
     <altmember cref="T:System.Security.AccessControl.EventWaitHandleAuditRule" />
     <altmember cref="T:System.Security.AccessControl.EventWaitHandleRights" />
-    <altmember cref="M:System.Threading.EventWaitHandle.GetAccessControl" />
-    <altmember cref="M:System.Threading.EventWaitHandle.SetAccessControl(System.Security.AccessControl.EventWaitHandleSecurity)" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Security.AccessControl/MutexSecurity.xml
+++ b/xml/System.Security.AccessControl/MutexSecurity.xml
@@ -102,8 +102,6 @@
     <altmember cref="T:System.Security.AccessControl.MutexAccessRule" />
     <altmember cref="T:System.Security.AccessControl.MutexAuditRule" />
     <altmember cref="T:System.Security.AccessControl.MutexRights" />
-    <altmember cref="M:System.Threading.Mutex.GetAccessControl" />
-    <altmember cref="M:System.Threading.Mutex.SetAccessControl(System.Security.AccessControl.MutexSecurity)" />
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">

--- a/xml/System.Security.AccessControl/SemaphoreSecurity.xml
+++ b/xml/System.Security.AccessControl/SemaphoreSecurity.xml
@@ -106,8 +106,6 @@
     <altmember cref="T:System.Security.AccessControl.SemaphoreAccessRule" />
     <altmember cref="T:System.Security.AccessControl.SemaphoreAuditRule" />
     <altmember cref="T:System.Security.AccessControl.SemaphoreRights" />
-    <altmember cref="M:System.Threading.Semaphore.GetAccessControl" />
-    <altmember cref="M:System.Threading.Semaphore.SetAccessControl(System.Security.AccessControl.SemaphoreSecurity)" />
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">

--- a/xml/System.Security.Claims/Claim.xml
+++ b/xml/System.Security.Claims/Claim.xml
@@ -99,7 +99,6 @@ if (null != principal)
     </remarks>
     <altmember cref="T:System.Security.Claims.ClaimsIdentity" />
     <altmember cref="T:System.Security.Claims.ClaimsPrincipal" />
-    <altmember cref="T:System.IdentityModel.Tokens.IssuerNameRegistry" />
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
@@ -895,7 +894,6 @@ if (null != principal)
           ]]></format>
         </remarks>
         <altmember cref="P:System.Security.Claims.Claim.OriginalIssuer" />
-        <altmember cref="T:System.IdentityModel.Tokens.IssuerNameRegistry" />
       </Docs>
     </Member>
     <Member MemberName="OriginalIssuer">
@@ -950,7 +948,6 @@ if (null != principal)
           ]]></format>
         </remarks>
         <altmember cref="P:System.Security.Claims.Claim.Issuer" />
-        <altmember cref="T:System.IdentityModel.Tokens.IssuerNameRegistry" />
       </Docs>
     </Member>
     <Member MemberName="Properties">
@@ -1000,7 +997,6 @@ if (null != principal)
 
           ]]></format>
         </remarks>
-        <altmember cref="T:System.Security.Claims.ClaimProperties" />
       </Docs>
     </Member>
     <Member MemberName="Subject">

--- a/xml/System.Security.Claims/ClaimsIdentity.xml
+++ b/xml/System.Security.Claims/ClaimsIdentity.xml
@@ -88,7 +88,6 @@
     <altmember cref="T:System.Security.Claims.ClaimsPrincipal" />
     <altmember cref="T:System.Security.Principal.GenericIdentity" />
     <altmember cref="T:System.Security.Principal.WindowsIdentity" />
-    <altmember cref="T:System.Web.Security.FormsIdentity" />
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">

--- a/xml/System.Security.Claims/ClaimsPrincipal.xml
+++ b/xml/System.Security.Claims/ClaimsPrincipal.xml
@@ -108,8 +108,6 @@ if (HttpContext.Current.User is ClaimsPrincipal principal)
     </remarks>
     <altmember cref="T:System.Security.Claims.Claim" />
     <altmember cref="T:System.Security.Claims.ClaimsIdentity" />
-    <altmember cref="T:System.Security.Claims.ClaimsAuthenticationManager" />
-    <altmember cref="T:System.Security.Claims.ClaimsAuthorizationManager" />
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">

--- a/xml/System.Security.Policy/PolicyLevel.xml
+++ b/xml/System.Security.Policy/PolicyLevel.xml
@@ -395,7 +395,6 @@
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.AppDomain.SetAppDomainPolicy(System.Security.Policy.PolicyLevel)" />
       </Docs>
     </Member>
     <Member MemberName="FromXml">

--- a/xml/System.Xml.Serialization/CodeGenerationOptions.xml
+++ b/xml/System.Xml.Serialization/CodeGenerationOptions.xml
@@ -57,7 +57,6 @@ The following example illustrates the use of the `CodeGenerationOptions` enumera
 :::code language="csharp" source="~/snippets/csharp/System.Web.Services.Description/ServiceDescriptionImporter/Overview/import.cs" id="Snippet4":::
       ]]></format>
     </example>
-    <altmember cref="P:System.Web.Services.Description.ServiceDescriptionImporter.CodeGenerationOptions" />
   </Docs>
   <Members>
     <Member MemberName="EnableDataBinding">

--- a/xml/System.Xml.Serialization/SoapSchemaMember.xml
+++ b/xml/System.Xml.Serialization/SoapSchemaMember.xml
@@ -63,7 +63,6 @@
     </remarks>
     <forInternalUseOnly />
     <altmember cref="T:System.Web.Services.Description.MessagePart" />
-    <altmember cref="T:System.Xml.Serialization.SoapSchemaImporter" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Xml.Serialization/XmlSchemaExporter.xml
+++ b/xml/System.Xml.Serialization/XmlSchemaExporter.xml
@@ -70,7 +70,6 @@
     <forInternalUseOnly />
     <altmember cref="T:System.Xml.Serialization.XmlSchemas" />
     <altmember cref="T:System.Xml.Schema.XmlSchema" />
-    <altmember cref="T:System.Xml.Serialization.SoapSchemaExporter" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Xml.Serialization/XmlSchemaImporter.xml
+++ b/xml/System.Xml.Serialization/XmlSchemaImporter.xml
@@ -71,9 +71,6 @@
  ]]></format>
     </remarks>
     <forInternalUseOnly />
-    <altmember cref="T:System.Xml.Serialization.XmlCodeExporter" />
-    <altmember cref="T:System.Xml.Serialization.SoapSchemaImporter" />
-    <altmember cref="T:System.Web.Services.Description.ServiceDescriptionImporter" />
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">

--- a/xml/System.Xml.Xsl/XslTransform.xml
+++ b/xml/System.Xml.Xsl/XslTransform.xml
@@ -922,7 +922,6 @@
         <altmember cref="T:System.Net.CredentialCache" />
         <altmember cref="T:System.Security.SecurityZone" />
         <altmember cref="T:System.Xml.XmlSecureResolver" />
-        <altmember cref="M:System.Xml.XmlSecureResolver.CreateEvidenceForUrl(System.String)" />
       </Docs>
     </Member>
     <Member MemberName="Load">
@@ -994,7 +993,6 @@
         <altmember cref="T:System.Net.CredentialCache" />
         <altmember cref="T:System.Security.SecurityZone" />
         <altmember cref="T:System.Xml.XmlSecureResolver" />
-        <altmember cref="M:System.Xml.XmlSecureResolver.CreateEvidenceForUrl(System.String)" />
       </Docs>
     </Member>
     <Member MemberName="Load">
@@ -1070,7 +1068,6 @@
         <altmember cref="T:System.Net.CredentialCache" />
         <altmember cref="T:System.Security.SecurityZone" />
         <altmember cref="T:System.Xml.XmlSecureResolver" />
-        <altmember cref="M:System.Xml.XmlSecureResolver.CreateEvidenceForUrl(System.String)" />
       </Docs>
     </Member>
     <MemberGroup MemberName="Transform">

--- a/xml/System.Xml/XmlDataDocument.xml
+++ b/xml/System.Xml/XmlDataDocument.xml
@@ -171,7 +171,6 @@
  ]]></format>
         </remarks>
         <altmember cref="T:System.Data.SqlClient.SqlConnection" />
-        <altmember cref="T:System.Data.SqlClient.SqlDataAdapter" />
       </Docs>
     </Member>
     <Member MemberName="CloneNode">

--- a/xml/System.Xml/XmlSecureResolver.xml
+++ b/xml/System.Xml/XmlSecureResolver.xml
@@ -133,7 +133,6 @@ See the constructor reference topics for examples of these types of restrictions
 
  ]]></format>
         </remarks>
-        <altmember cref="M:System.Xml.XmlSecureResolver.CreateEvidenceForUrl(System.String)" />
         <altmember cref="T:System.Security.Policy.Evidence" />
         <altmember cref="T:System.Net.WebPermission" />
         <altmember cref="T:System.Security.SecurityManager" />


### PR DESCRIPTION
Work done by Copilot CLI.

Contributes to #12513.