### PR TITLE
Update error message for idData hexadecimal length

### DIFF
--- a/xml/System.Diagnostics/ActivityTraceId.xml
+++ b/xml/System.Diagnostics/ActivityTraceId.xml
@@ -153,7 +153,7 @@ Because an `ActivityTraceId` is a structure that contains 16 bytes, it can be pa
          ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">
-          <paramref name="idData" /> does not contain 16 hexadecimal characters.
+          <paramref name="idData" /> does not contain 32 hexadecimal characters.
 
 -or-
 


### PR DESCRIPTION
## Summary

* Updated the exception documentation in `ActivityTraceId` to state that `idData` must contain 32 hexadecimal characters, not 16, reflecting the actual string size.
