### PR TITLE
Clarify LargeChange property usage in Slider and RangeBase documentation

### DIFF
--- a/xml/System.Windows.Controls.Primitives/RangeBase.xml
+++ b/xml/System.Windows.Controls.Primitives/RangeBase.xml
@@ -120,7 +120,7 @@
 
  When the user clicks the <xref:System.Windows.Controls.Primitives.Track> of a <xref:System.Windows.Controls.Primitives.ScrollBar>, the <xref:System.Windows.Controls.Primitives.RangeBase.Value> property increases or decreases by the value of <xref:System.Windows.Controls.Primitives.RangeBase.LargeChange*>.
 
- When the user invokes the <xref:System.Windows.Controls.Slider.DecreaseLarge*> or <xref:System.Windows.Controls.Slider.IncreaseLarge*> commands on a <xref:System.Windows.Controls.Slider>, the <xref:System.Windows.Controls.Primitives.RangeBase.ValueProperty> of the slider changes by the value of <xref:System.Windows.Controls.Primitives.RangeBase.LargeChange*>.
+ When the user clicks the <xref:System.Windows.Controls.Primitives.Track> or invokes the <xref:System.Windows.Controls.Slider.DecreaseLarge*> or <xref:System.Windows.Controls.Slider.IncreaseLarge*> commands on a <xref:System.Windows.Controls.Slider>, the <xref:System.Windows.Controls.Primitives.RangeBase.ValueProperty> of the slider changes by the value of <xref:System.Windows.Controls.Primitives.RangeBase.LargeChange*>.
 
  The <xref:System.Windows.Controls.ProgressBar> does not use this property.
 

--- a/xml/System.Windows.Controls.Primitives/RangeBase.xml
+++ b/xml/System.Windows.Controls.Primitives/RangeBase.xml
@@ -120,7 +120,7 @@
 
  When the user clicks the <xref:System.Windows.Controls.Primitives.Track> of a <xref:System.Windows.Controls.Primitives.ScrollBar>, the <xref:System.Windows.Controls.Primitives.RangeBase.Value> property increases or decreases by the value of <xref:System.Windows.Controls.Primitives.RangeBase.LargeChange*>.
 
- When the user clicks the <xref:System.Windows.Controls.Primitives.Track> or invokes the <xref:System.Windows.Controls.Slider.DecreaseLarge*> or <xref:System.Windows.Controls.Slider.IncreaseLarge*> commands on a <xref:System.Windows.Controls.Slider>, the <xref:System.Windows.Controls.Primitives.RangeBase.ValueProperty> of the slider changes by the value of <xref:System.Windows.Controls.Primitives.RangeBase.LargeChange*>.
+ When the user clicks the <xref:System.Windows.Controls.Primitives.Track> of a <xref:System.Windows.Controls.Slider>, the <xref:System.Windows.Controls.Primitives.RangeBase.Value> of the slider increases or decreases by the value of <xref:System.Windows.Controls.Primitives.RangeBase.LargeChange*> if <xref:System.Windows.Controls.Slider.IsMoveToPointEnabled> is `false`. When the user invokes the <xref:System.Windows.Controls.Slider.DecreaseLarge*> or <xref:System.Windows.Controls.Slider.IncreaseLarge*> commands, the <xref:System.Windows.Controls.Primitives.RangeBase.Value> of the slider changes by the value of <xref:System.Windows.Controls.Primitives.RangeBase.LargeChange*>.
 
  The <xref:System.Windows.Controls.ProgressBar> does not use this property.
 

--- a/xml/System.Windows.Controls/Slider.xml
+++ b/xml/System.Windows.Controls/Slider.xml
@@ -874,7 +874,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- When this property is set to `false` and a mouse click occurs along the <xref:System.Windows.Controls.Slider> away from the <xref:System.Windows.Controls.Primitives.Track.Thumb*>, the <xref:System.Windows.Controls.Primitives.Track.Thumb*> moves in the direction of the mouse click. Instead of moving immediately to the mouse click location, the <xref:System.Windows.Controls.Primitives.Track.Thumb*> moves a distance that is defined by the <xref:System.Windows.Controls.Primitives.RangeBase.SmallChange> property for each mouse click.
+ When this property is set to `false` and a mouse click occurs along the <xref:System.Windows.Controls.Slider> away from the <xref:System.Windows.Controls.Primitives.Track.Thumb*>, the <xref:System.Windows.Controls.Primitives.Track.Thumb*> moves in the direction of the mouse click. Instead of moving immediately to the mouse click location, the <xref:System.Windows.Controls.Primitives.Track.Thumb*> moves a distance that is defined by the <xref:System.Windows.Controls.Primitives.RangeBase.LargeChange> property for each mouse click.
 
  The effect of multiple mouse clicks can be emulated by pressing and holding the left mouse button until the <xref:System.Windows.Controls.Primitives.Track.Thumb*> is repositioned to the desired location.
 


### PR DESCRIPTION
## Summary

* Corrects `Slider.IsMoveToPointEnabled` track click remark reference from SmallChange to LargeChange
* Clarifies slider behavior for the `RangeBase.LargeChange` property

<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

