### PR TITLE
Add CreateTempSubdirectory cross-references to GetTempPath docs

### DIFF
--- a/xml/System.IO/Directory.xml
+++ b/xml/System.IO/Directory.xml
@@ -505,7 +505,15 @@ An I/O error occurred.</exception>
         <param name="prefix">An optional string to add to the beginning of the subdirectory name.</param>
         <summary>Creates a uniquely named, empty directory in the current user's temporary directory.</summary>
         <returns>An object that represents the directory that was created.</returns>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+This method creates a new directory with a unique name under the path returned by <xref:System.IO.Path.GetTempPath*>. On Unix-like operating systems, the parent temporary directory may be shared among all users, whereas the directory created by <xref:System.IO.Directory.CreateTempSubdirectory*> is created with owner-only permissions (`700`).
+
+          ]]></format>
+        </remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="prefix" /> contains a directory separator.</exception>
         <exception cref="T:System.IO.IOException">A new directory cannot be created.</exception>

--- a/xml/System.IO/Directory.xml
+++ b/xml/System.IO/Directory.xml
@@ -510,7 +510,7 @@ An I/O error occurred.</exception>
 
 ## Remarks
 
-This method creates a new directory with a unique name under the path returned by <xref:System.IO.Path.GetTempPath*>. On Unix-like operating systems, the parent temporary directory may be shared among all users, whereas the directory created by <xref:System.IO.Directory.CreateTempSubdirectory*> is created with owner-only permissions (`700`).
+This method creates a new directory with a unique name under the path returned by <xref:System.IO.Path.GetTempPath*>. On Unix-like operating systems, the parent temporary directory might be shared among all users, whereas the directory created by <xref:System.IO.Directory.CreateTempSubdirectory*> is created with owner-only permissions (`700`).
 
           ]]></format>
         </remarks>

--- a/xml/System.IO/Path.xml
+++ b/xml/System.IO/Path.xml
@@ -2203,9 +2203,9 @@ If the current Windows version exposes the [`GetTempPath2`](https://learn.micros
 
 On Windows versions that don't expose GetTempPath2, this method instead invokes the [`GetTempPath`](https://learn.microsoft.com/windows/win32/api/fileapi/nf-fileapi-gettemppathw) Win32 API and returns the resolved path. For more information on how this resolution is performed, including how to control the return value through the use of environment variables, see [the _Remarks_ section](https://learn.microsoft.com/windows/win32/api/fileapi/nf-fileapi-gettemppathw#remarks) of the GetTempPath documentation.
 
-# [MacOS](#tab/macos)
+# [macOS](#tab/macos)
 
-If the `TMPDIR` environment variable has been set, this method returns the value specified by that environment variable. MacOS sets `TMPDIR` on login to a per-user temporary directory.
+If the `TMPDIR` environment variable has been set, this method returns the value specified by that environment variable. macOS sets `TMPDIR` on login to a per-user temporary directory.
 
 Otherwise, this method returns `/tmp/`, which is shared among all users.
 

--- a/xml/System.IO/Path.xml
+++ b/xml/System.IO/Path.xml
@@ -2207,14 +2207,14 @@ On Windows versions that don't expose GetTempPath2, this method instead invokes 
 
 If the `TMPDIR` environment variable has been set, this method returns the value specified by that environment variable. MacOS sets `TMPDIR` on login to a per-user temporary directory.
 
-Otherwise, this method returns `/tmp/`.
+Otherwise, this method returns `/tmp/`, which is shared among all users. If your application needs a private temporary directory, use <xref:System.IO.Directory.CreateTempSubdirectory*>, which creates a subdirectory with owner-only permissions (`700`).
 
 # [Linux](#tab/linux)
 
 If the `TMPDIR` environment variable has been set, this method returns the value specified by that environment variable.
 
 Otherwise, this method returns `/tmp/`.
-The `/tmp/` directory on Linux is commonly shared among all users (`1777` permissions); ensure this meets your application's security needs.
+The `/tmp/` directory on Linux is commonly shared among all users (`1777` permissions); ensure this meets your application's security needs. If your application needs a private temporary directory, use <xref:System.IO.Directory.CreateTempSubdirectory*>, which creates a subdirectory with owner-only permissions (`700`).
 
 ---
 

--- a/xml/System.IO/Path.xml
+++ b/xml/System.IO/Path.xml
@@ -2207,14 +2207,20 @@ On Windows versions that don't expose GetTempPath2, this method instead invokes 
 
 If the `TMPDIR` environment variable has been set, this method returns the value specified by that environment variable. MacOS sets `TMPDIR` on login to a per-user temporary directory.
 
-Otherwise, this method returns `/tmp/`, which is shared among all users. If your application needs a private temporary directory, use <xref:System.IO.Directory.CreateTempSubdirectory*>, which creates a subdirectory with owner-only permissions (`700`).
+Otherwise, this method returns `/tmp/`, which is shared among all users.
+
+> [!CAUTION]
+> If your application needs a private temporary directory, use <xref:System.IO.Directory.CreateTempSubdirectory*>, which creates a subdirectory with owner-only permissions (`700`).
 
 # [Linux](#tab/linux)
 
 If the `TMPDIR` environment variable has been set, this method returns the value specified by that environment variable.
 
 Otherwise, this method returns `/tmp/`.
-The `/tmp/` directory on Linux is commonly shared among all users (`1777` permissions); ensure this meets your application's security needs. If your application needs a private temporary directory, use <xref:System.IO.Directory.CreateTempSubdirectory*>, which creates a subdirectory with owner-only permissions (`700`).
+The `/tmp/` directory on Linux is commonly shared among all users (`1777` permissions); ensure this meets your application's security needs.
+
+> [!CAUTION]
+> If your application needs a private temporary directory, use <xref:System.IO.Directory.CreateTempSubdirectory*>, which creates a subdirectory with owner-only permissions (`700`).
 
 ---
 


### PR DESCRIPTION
On Linux (and macOS fallback), `Path.GetTempPath()` returns a shared directory. The existing Linux tab already notes this, but doesn't point to the secure alternative.

This PR:
- Adds a cross-reference to `Directory.CreateTempSubdirectory` on both the Linux and macOS tabs of `GetTempPath` remarks
- Fills in the empty remarks for `Directory.CreateTempSubdirectory` explaining the owner-only permissions (`700`) behavior on Unix