### PR TITLE
Document .NET 11 ConstructorInfo.GetGenericArguments behavior change

### DIFF
--- a/xml/System.Reflection/MethodBase.xml
+++ b/xml/System.Reflection/MethodBase.xml
@@ -506,7 +506,7 @@
 
 - If the current method is an open constructed method (that is, the <xref:System.Reflection.MethodBase.ContainsGenericParameters> property returns `true`) in which specific types have been assigned to some type parameters and type parameters of enclosing generic types have been assigned to other type parameters, the array contains both types and type parameters. Use the <xref:System.Type.IsGenericParameter> property to tell them apart. For a demonstration of this scenario, see the code example provided for the <xref:System.Reflection.MethodBase.ContainsGenericParameters> property.
 
-- It the current method is a constructor, the returned array is an empty array in .NET 11 and later. In .NET 10 and earlier versions, the <xref:System.Reflection.MethodBase.GetGenericArguments*> method throws <xref:System.NotSupportedException>.
+- If the current method is a constructor, the returned array is an empty array in .NET 11 and later. In .NET 10 and earlier versions, the <xref:System.Reflection.MethodBase.GetGenericArguments*> method throws <xref:System.NotSupportedException>.
 
  For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodBase.IsGenericMethod> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType?displayProperty=nameWithType> property.
 

--- a/xml/System.Reflection/MethodBase.xml
+++ b/xml/System.Reflection/MethodBase.xml
@@ -506,13 +506,13 @@
 
 - If the current method is an open constructed method (that is, the <xref:System.Reflection.MethodBase.ContainsGenericParameters> property returns `true`) in which specific types have been assigned to some type parameters and type parameters of enclosing generic types have been assigned to other type parameters, the array contains both types and type parameters. Use the <xref:System.Type.IsGenericParameter> property to tell them apart. For a demonstration of this scenario, see the code example provided for the <xref:System.Reflection.MethodBase.ContainsGenericParameters> property.
 
- Generic constructors are not supported in the .NET Framework version 2.0. This property throws <xref:System.NotSupportedException> if not overridden in a derived class, so an exception is thrown if the current instance is of type <xref:System.Reflection.ConstructorInfo>.
+ Generic constructors are not supported. The base <xref:System.Reflection.MethodBase.GetGenericArguments*> implementation throws <xref:System.NotSupportedException> if not overridden in a derived class. In .NET Framework and in .NET (Core) 5.0 through 10.0, <xref:System.Reflection.ConstructorInfo> does not override this method, so calling it on a constructor throws <xref:System.NotSupportedException>. Starting in .NET 11, <xref:System.Reflection.ConstructorInfo.GetGenericArguments*?displayProperty=nameWithType> overrides this method to return an empty array.
 
  For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodBase.IsGenericMethod> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType?displayProperty=nameWithType> property.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.NotSupportedException">The current object is a <see cref="T:System.Reflection.ConstructorInfo" />. Generic constructors are not supported in the .NET Framework version 2.0. This exception is the default behavior if this method is not overridden in a derived class.</exception>
+        <exception cref="T:System.NotSupportedException">This method is not overridden in a derived class. This is the default behavior of the base <see cref="T:System.Reflection.MethodBase" /> implementation. In .NET Framework and in .NET (Core) 5.0 through 10.0, the current object is a <see cref="T:System.Reflection.ConstructorInfo" />, because generic constructors are not supported. Starting in .NET 11, calling this method on a <see cref="T:System.Reflection.ConstructorInfo" /> returns an empty array instead of throwing.</exception>
         <altmember cref="P:System.Reflection.MethodBase.IsGenericMethodDefinition" />
         <altmember cref="M:System.Reflection.MethodInfo.GetGenericArguments" />
         <altmember cref="P:System.Reflection.MethodBase.IsGenericMethod" />

--- a/xml/System.Reflection/MethodBase.xml
+++ b/xml/System.Reflection/MethodBase.xml
@@ -506,13 +506,13 @@
 
 - If the current method is an open constructed method (that is, the <xref:System.Reflection.MethodBase.ContainsGenericParameters> property returns `true`) in which specific types have been assigned to some type parameters and type parameters of enclosing generic types have been assigned to other type parameters, the array contains both types and type parameters. Use the <xref:System.Type.IsGenericParameter> property to tell them apart. For a demonstration of this scenario, see the code example provided for the <xref:System.Reflection.MethodBase.ContainsGenericParameters> property.
 
- Generic constructors are not supported. The base <xref:System.Reflection.MethodBase.GetGenericArguments*> implementation throws <xref:System.NotSupportedException> if not overridden in a derived class. In .NET Framework and in .NET (Core) 5.0 through 10.0, <xref:System.Reflection.ConstructorInfo> does not override this method, so calling it on a constructor throws <xref:System.NotSupportedException>. Starting in .NET 11, <xref:System.Reflection.ConstructorInfo.GetGenericArguments*?displayProperty=nameWithType> overrides this method to return an empty array.
+- It the current method is a constructor, the returned array is an empty array in .NET 11 and later. In .NET 10 and earlier versions, the <xref:System.Reflection.MethodBase.GetGenericArguments*> method throws <xref:System.NotSupportedException>.
 
  For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodBase.IsGenericMethod> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType?displayProperty=nameWithType> property.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.NotSupportedException">This method is not overridden in a derived class. This is the default behavior of the base <see cref="T:System.Reflection.MethodBase" /> implementation. In .NET Framework and in .NET (Core) 5.0 through 10.0, the current object is a <see cref="T:System.Reflection.ConstructorInfo" />, because generic constructors are not supported. Starting in .NET 11, calling this method on a <see cref="T:System.Reflection.ConstructorInfo" /> returns an empty array instead of throwing.</exception>
+        <exception cref="T:System.NotSupportedException">This method is not overridden in a derived class.</exception>
         <altmember cref="P:System.Reflection.MethodBase.IsGenericMethodDefinition" />
         <altmember cref="M:System.Reflection.MethodInfo.GetGenericArguments" />
         <altmember cref="P:System.Reflection.MethodBase.IsGenericMethod" />


### PR DESCRIPTION
## Summary

Updates the `MethodBase.GetGenericArguments` reference docs to reflect the .NET 11 behavior change in dotnet/runtime#128059 (which fixes dotnet/runtime#128041).

Previously, `MethodBase.GetGenericArguments` docs claimed the method throws `NotSupportedException` when invoked on a `ConstructorInfo`. As of .NET 11, `ConstructorInfo` overrides this method to return an empty array.

The remarks and exception text are updated to describe both behaviors:
- .NET Framework and .NET (Core) 5.0 through 10.0: throws `NotSupportedException` on a `ConstructorInfo`.
- .NET 11+: returns an empty array.

## Notes for reviewers

- No dedicated `<Member MemberName="GetGenericArguments">` entry is added in `ConstructorInfo.xml`. The `mdoc` regeneration that runs against .NET 11 ref assemblies should add the skeleton automatically; a follow-up PR can fill in the prose.
- Related: dotnet/runtime#128041 (bug), dotnet/runtime#128059 (fix).
