### PR TITLE
Remove .NET Framework remarks (System.CodeDom*)

### DIFF
--- a/xml/System.CodeDom.Compiler/CodeCompiler.xml
+++ b/xml/System.CodeDom.Compiler/CodeCompiler.xml
@@ -43,9 +43,6 @@
 ## Remarks
  <xref:System.CodeDom.Compiler.CodeCompiler> is a useful utility base class for code generators to derive from in order to provide code compilation functions.
 
-> [!NOTE]
->  This class contains a link demand and an inheritance demand at the class level that applies to all members. A <xref:System.Security.SecurityException> is thrown when either the immediate caller or the derived class does not have full-trust permission.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.CodeDom.Compiler.ICodeCompiler" />

--- a/xml/System.CodeDom.Compiler/CodeDomProvider.xml
+++ b/xml/System.CodeDom.Compiler/CodeDomProvider.xml
@@ -48,16 +48,7 @@
 
  A <xref:System.CodeDom.Compiler.CodeDomProvider> implementation typically provides code generation and/or code compilation interfaces for generating code and managing compilation for a single programming language. Several languages are supported by <xref:System.CodeDom.Compiler.CodeDomProvider> implementations that ship with the Windows SDK. These languages include C#, Visual Basic, C++, and JScript. Developers or compiler vendors can implement the <xref:System.CodeDom.Compiler.ICodeGenerator> and <xref:System.CodeDom.Compiler.ICodeCompiler> interfaces and provide a <xref:System.CodeDom.Compiler.CodeDomProvider> that extends CodeDOM support to other programming languages.
 
- The [&lt;system.codedom&gt; Element](/dotnet/framework/configure-apps/file-schema/compiler/system-codedom-element) in the machine configuration file (Machine.config) provides a mechanism for developers and compiler vendors to add configuration settings for additional <xref:System.CodeDom.Compiler.CodeDomProvider> implementations.
-
  The <xref:System.CodeDom.Compiler.CodeDomProvider> class provides static methods to discover and enumerate the <xref:System.CodeDom.Compiler.CodeDomProvider> implementations on a computer. The <xref:System.CodeDom.Compiler.CodeDomProvider.GetAllCompilerInfo*> method returns the settings for all <xref:System.CodeDom.Compiler.CodeDomProvider> implementations on a computer. The <xref:System.CodeDom.Compiler.CodeDomProvider.GetCompilerInfo*> method returns the settings for a specific <xref:System.CodeDom.Compiler.CodeDomProvider> implementation, based on the programming language name. The <xref:System.CodeDom.Compiler.CodeDomProvider.CreateProvider*> method returns an instance of a <xref:System.CodeDom.Compiler.CodeDomProvider> implementation for a specific language.
-
- For more details on language provider settings in the configuration file, see [Compiler and Language Provider Settings Schema](/dotnet/framework/configure-apps/file-schema/compiler/).
-
-> [!NOTE]
->  This class makes a link demand and an inheritance demand at the class level. A <xref:System.Security.SecurityException> is thrown if either the immediate caller or the derived class does not have full trust permission.
-
-
 
 ## Examples
  The following example program can generate and compile source code based on a CodeDOM model of a program that prints "Hello World" using the <xref:System.Console> class. A Windows Forms user interface is provided. The user can select the target programming language from several selections: C#, Visual Basic, and JScript.
@@ -68,12 +59,11 @@
  ]]></format>
     </remarks>
     <block subset="none" type="overrides">
-      <para>In .NET Framework 1.0 and 1.1, code providers consist of implementations of <see cref="T:System.CodeDom.Compiler.CodeDomProvider" />, <see cref="T:System.CodeDom.Compiler.ICodeGenerator" />, <see cref="T:System.CodeDom.Compiler.ICodeParser" />, and <see cref="T:System.CodeDom.Compiler.ICodeCompiler" />. Starting in .NET Framework 2.0, the <see cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator" />, <see cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateParser" />, and <see cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateCompiler" /> methods are obsolete, and the methods of <see cref="T:System.CodeDom.Compiler.ICodeGenerator" /> and <see cref="T:System.CodeDom.Compiler.ICodeCompiler" /> are directly available in the <see cref="T:System.CodeDom.Compiler.CodeDomProvider" /> class. You should override those methods in your code provider implementation and not call the base methods.</para>
+      <para>The <see cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator" />, <see cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateParser" />, and <see cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateCompiler" /> methods are obsolete, and the methods of <see cref="T:System.CodeDom.Compiler.ICodeGenerator" /> and <see cref="T:System.CodeDom.Compiler.ICodeCompiler" /> are directly available in the <see cref="T:System.CodeDom.Compiler.CodeDomProvider" /> class. You should override those methods in your code provider implementation and not call the base methods.</para>
     </block>
     <altmember cref="T:System.CodeDom.Compiler.CompilerInfo" />
     <altmember cref="T:Microsoft.CSharp.CSharpCodeProvider" />
     <altmember cref="T:Microsoft.VisualBasic.VBCodeProvider" />
-    <related type="Article" href="/dotnet/framework/configure-apps/file-schema/compiler/">Compiler and Language Provider Settings Schema</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -151,27 +141,8 @@
         <param name="compilationUnits">An array of type <see cref="T:System.CodeDom.CodeCompileUnit" /> that indicates the code to compile.</param>
         <summary>Compiles an assembly based on the <see cref="N:System.CodeDom" /> trees contained in the specified array of <see cref="T:System.CodeDom.CodeCompileUnit" /> objects, using the specified compiler settings.</summary>
         <returns>A <see cref="T:System.CodeDom.Compiler.CompilerResults" /> object that indicates the results of the compilation.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!IMPORTANT]
-> On .NET Core and .NET 5+, calls to the `CodeDomProvider.CompileAssemblyFromDom` method throw a <xref:System.PlatformNotSupportedException>. Compile code is not supported.
-
-> [!NOTE]
-> In .NET Framework 2.0 and later versions, this method can be called directly on the code provider even if it's not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeCompiler> implementation is called by the base class.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.NotImplementedException">Neither this method nor the <see cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateCompiler" /> method is overridden in a derived class.</exception>
-        <exception cref="T:System.PlatformNotSupportedException">.NET Core and .NET 5+ only: In all cases.</exception>
-        <block subset="none" type="overrides">
-          <para>If you override this method, you must not call the corresponding method of the base class. The base-class method creates a generator in the derived class using the obsolete <see cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateCompiler" /> method for compatibility with preexisting providers that use code compilers. The base-class method then calls the equivalent method in the <see cref="T:System.CodeDom.Compiler.ICodeCompiler" /> implementation to perform this function. You will get a <see cref="T:System.NotImplementedException" /> if you call the base-class method from a code provider that does not use a code compiler.</para>
-        </block>
-        <altmember cref="T:System.CodeDom.Compiler.CompilerParameters" />
-        <altmember cref="T:System.CodeDom.CodeCompileUnit" />
-        <altmember cref="T:System.CodeDom.Compiler.CompilerResults" />
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="CompileAssemblyFromFile">
@@ -218,26 +189,8 @@
         <param name="fileNames">An array of the names of the files to compile.</param>
         <summary>Compiles an assembly from the source code contained in the specified files, using the specified compiler settings.</summary>
         <returns>A <see cref="T:System.CodeDom.Compiler.CompilerResults" /> object that indicates the results of compilation.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!IMPORTANT]
-> On .NET Core and .NET 5+, calls to the `CodeDomProvider.CompileAssemblyFromFile` method throw a <xref:System.PlatformNotSupportedException>. Compile from file is not supported.
-
-> [!NOTE]
-> In .NET Framework 2.0 and later versions, this method can be called directly on the code provider even if it's not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeCompiler> implementation is called by the base class.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.NotImplementedException">Neither this method nor the <see cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateCompiler" /> method is overridden in a derived class.</exception>
-        <exception cref="T:System.PlatformNotSupportedException">.NET Core and .NET 5+ only: In all cases.</exception>
-        <block subset="none" type="overrides">
-          <para>If you override this method, you must not call the corresponding method of the base class. The base-class method creates a generator in the derived class using the obsolete <see cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateCompiler" /> method for compatibility with preexisting providers that use code compilers. The base-class method then calls the equivalent method in the <see cref="T:System.CodeDom.Compiler.ICodeCompiler" /> implementation to perform this function. You will get a <see cref="T:System.NotImplementedException" /> if you call the base-class method from a code provider that does not use a code compiler.</para>
-        </block>
-        <altmember cref="T:System.CodeDom.Compiler.CompilerParameters" />
-        <altmember cref="T:System.CodeDom.Compiler.CompilerResults" />
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="CompileAssemblyFromSource">
@@ -284,26 +237,8 @@
         <param name="sources">An array of source code strings to compile.</param>
         <summary>Compiles an assembly from the specified array of strings containing source code, using the specified compiler settings.</summary>
         <returns>A <see cref="T:System.CodeDom.Compiler.CompilerResults" /> object that indicates the results of compilation.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!IMPORTANT]
-> On .NET Core and .NET 5+, calls to the `CodeDomProvider.CompileAssemblyFromSource` method throw a <xref:System.PlatformNotSupportedException>. Compile source code is not supported.
-
-> [!NOTE]
-> In .NET Framework 2.0 and later versions, this method can be called directly on the code provider even if it's not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeCompiler> implementation is called by the base class.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.NotImplementedException">Neither this method nor the <see cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateCompiler" /> method is overridden in a derived class.</exception>
-        <exception cref="T:System.PlatformNotSupportedException">.NET Core and .NET 5+ only: In all cases.</exception>
-        <block subset="none" type="overrides">
-          <para>If you override this method, you must not call the corresponding method of the base class. The base-class method creates a generator in the derived class using the obsolete <see cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateCompiler" /> method for compatibility with preexisting providers that use code compilers. The base-class method then calls the equivalent method in the <see cref="T:System.CodeDom.Compiler.ICodeCompiler" /> implementation to perform this function. You will get a <see cref="T:System.NotImplementedException" /> if you call the base-class method from a code provider that does not use a code compiler.</para>
-        </block>
-        <altmember cref="T:System.CodeDom.Compiler.CompilerParameters" />
-        <altmember cref="T:System.CodeDom.Compiler.CompilerResults" />
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="CreateCompiler">
@@ -404,7 +339,7 @@
  <xref:System.CodeDom.Compiler.CodeDomProvider.CreateEscapedIdentifier*> tests whether the identifier conflicts with any reserved or language keywords, and if so, returns an equivalent name with language-specific escape code formatting. This is referred to an escaped identifier. The escaped identifier contains the same `value` but has escape-code formatting added to differentiate the identifier from the keyword. Two implementation examples are preceding the `value` with "@" or bracketing the `value` with "[" and "]".
 
 > [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, this method is provided by the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation that is returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*> method of the provider. In version 2.0, this method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
+> This method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
 
  ]]></format>
         </remarks>
@@ -684,13 +619,11 @@
 
  The <xref:System.CodeDom.Compiler.CodeDomProvider.IsDefinedLanguage*> method checks whether at least one provider implementation supports a specific language. You can validate a language name using <xref:System.CodeDom.Compiler.CodeDomProvider.IsDefinedLanguage*> before passing it to <xref:System.CodeDom.Compiler.CodeDomProvider.CreateProvider*>. If you pass an unsupported language name to <xref:System.CodeDom.Compiler.CodeDomProvider.CreateProvider*> a <xref:System.Configuration.ConfigurationException?displayProperty=nameWithType> is thrown.
 
- The <xref:System.CodeDom.Compiler.CodeDomProvider.GetAllCompilerInfo*> method can be used to determine all <xref:System.CodeDom.Compiler.CodeDomProvider> implementations on a computer, including additional implementations provided by developers and compiler vendors that are identified in the [&lt;system.codedom&gt; Element](/dotnet/framework/configure-apps/file-schema/compiler/system-codedom-element) in the machine configuration file (Machine.config).
+ The <xref:System.CodeDom.Compiler.CodeDomProvider.GetAllCompilerInfo*> method can be used to determine all <xref:System.CodeDom.Compiler.CodeDomProvider> implementations on a computer.
 
  The <xref:System.CodeDom.Compiler.CodeDomProvider.CreateProvider*> method returns an instance of a <xref:System.CodeDom.Compiler.CodeDomProvider> implementation for a specific language.
 
  Language names are case-insensitive.
-
-
 
 ## Examples
  The following code example determines the <xref:System.CodeDom.Compiler.CodeDomProvider> implementation for an input language and displays the configured settings for the language provider. This code example is part of a larger example provided for the <xref:System.CodeDom.Compiler.CompilerInfo> class.
@@ -808,7 +741,7 @@
  <xref:System.CodeDom.Compiler.CodeDomProvider.CreateValidIdentifier*> tests whether the identifier conflicts with reserved or language keywords, and if so, attempts to return a valid identifier name that does not conflict. Usually the returned identifier is only slightly modified to differentiate the identifier from the keyword; for example, the name might be preceded by the underscore ("_") character.
 
 > [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, this method is provided by the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation that is returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*> method of the provider. In version 2.0, this method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
+> This method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
 
  ]]></format>
         </remarks>
@@ -912,7 +845,7 @@
 ## Remarks
 
 > [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, this method is provided by the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation that is returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*> method of the provider. In version 2.0, this method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
+> This method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
 
 
 
@@ -977,7 +910,7 @@
 ## Remarks
 
 > [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, this method is provided by the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation that is returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*> method of the provider. In version 2.0, this method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
+> This method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
 
  ]]></format>
         </remarks>
@@ -1094,7 +1027,7 @@
 ## Remarks
 
 > [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, this method is provided by the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation that is returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*> method of the provider. In version 2.0, this method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
+> This method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
 
  ]]></format>
         </remarks>
@@ -1151,7 +1084,7 @@
 ## Remarks
 
 > [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, this method is provided by the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation that is returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*> method of the provider. In version 2.0, this method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
+> This method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
 
  ]]></format>
         </remarks>
@@ -1208,7 +1141,7 @@
 ## Remarks
 
 > [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, this method is provided by the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation that is returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*> method of the provider. In version 2.0, this method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
+> This method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
 
  ]]></format>
         </remarks>
@@ -1269,7 +1202,6 @@
         </remarks>
         <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
         <altmember cref="T:System.CodeDom.Compiler.CompilerInfo" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/compiler/">Compiler and Language Provider Settings Schema</related>
       </Docs>
     </Member>
     <Member MemberName="GetCompilerInfo">
@@ -1311,15 +1243,12 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The [&lt;system.codedom&gt; Element](/dotnet/framework/configure-apps/file-schema/compiler/system-codedom-element) in the machine configuration file contains the language provider and compiler configuration settings for each <xref:System.CodeDom.Compiler.CodeDomProvider> implementation on the computer. For information about machine configuration files, see the Machine Configuration Files section in [Configuring Apps](/dotnet/framework/configure-apps/). The <xref:System.CodeDom.Compiler.CodeDomProvider.GetCompilerInfo*> method searches each provider configuration element for the specified language name. The returned <xref:System.CodeDom.Compiler.CompilerInfo> instance contains the configured language provider and compiler settings.
 
  The <xref:System.CodeDom.Compiler.CodeDomProvider.IsDefinedLanguage*> method checks whether at least one provider implementation supports a specific language. You can validate a language name using <xref:System.CodeDom.Compiler.CodeDomProvider.IsDefinedLanguage*> before passing it to <xref:System.CodeDom.Compiler.CodeDomProvider.GetCompilerInfo*>. This prevents throwing a <xref:System.Configuration.ConfigurationException?displayProperty=nameWithType> when you access the <xref:System.CodeDom.Compiler.CompilerInfo> instance for an unsupported language name.
 
  If more than one provider implementation is configured for the input language name, <xref:System.CodeDom.Compiler.CodeDomProvider.GetCompilerInfo*> returns the settings from the last matching provider configuration element.
 
  Language names are case-insensitive.
-
-
 
 ## Examples
  The following code example determines the <xref:System.CodeDom.Compiler.CodeDomProvider> implementation for an input language and displays the configured settings for the language provider. This code example is part of a larger example provided for the <xref:System.CodeDom.Compiler.CompilerInfo> class.
@@ -1334,7 +1263,6 @@
         <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
         <altmember cref="T:System.CodeDom.Compiler.CompilerInfo" />
         <altmember cref="M:System.CodeDom.Compiler.CodeDomProvider.IsDefinedLanguage(System.String)" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/compiler/">Compiler and Language Provider Settings Schema</related>
       </Docs>
     </Member>
     <Member MemberName="GetConverter">
@@ -1419,34 +1347,12 @@
         <param name="extension">A file name extension.</param>
         <summary>Returns a language name associated with the specified file name extension, as configured in the <see cref="T:System.CodeDom.Compiler.CodeDomProvider" /> compiler configuration section.</summary>
         <returns>A language name associated with the file name extension, as configured in the <see cref="T:System.CodeDom.Compiler.CodeDomProvider" /> compiler configuration settings.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The [&lt;system.codedom&gt; Element](/dotnet/framework/configure-apps/file-schema/compiler/system-codedom-element) in the machine configuration file (Machine.config) contains the language provider and compiler configuration settings for each <xref:System.CodeDom.Compiler.CodeDomProvider> implementation on the computer. The <xref:System.CodeDom.Compiler.CodeDomProvider.GetLanguageFromExtension*> method searches each provider configuration element for the specified file name extension.
-
- The <xref:System.CodeDom.Compiler.CodeDomProvider.IsDefinedExtension*> method checks whether at least one provider implementation supports a specific file name extension. You can validate a file name extension using <xref:System.CodeDom.Compiler.CodeDomProvider.IsDefinedExtension*> before passing it to <xref:System.CodeDom.Compiler.CodeDomProvider.GetLanguageFromExtension*>. This prevents <xref:System.CodeDom.Compiler.CodeDomProvider.GetLanguageFromExtension*> from throwing a <xref:System.Configuration.ConfigurationException?displayProperty=nameWithType> for an unsupported file name extension.
-
- If a provider implementation supports the input file name extension, and there are multiple supported languages configured for that provider, then <xref:System.CodeDom.Compiler.CodeDomProvider.GetLanguageFromExtension*> returns the first language name for that provider. If more than one provider implementation is configured for the input file name extension, <xref:System.CodeDom.Compiler.CodeDomProvider.GetLanguageFromExtension*> returns the language name from the last matching provider configuration element.
-
- Language names and file name extensions are case-insensitive.
-
-
-
-## Examples
- The following code example determines the <xref:System.CodeDom.Compiler.CodeDomProvider> implementation for an input file name extension and displays the configured settings for the language provider. This code example is part of a larger example provided for the <xref:System.CodeDom.Compiler.CompilerInfo> class.
-
- :::code language="csharp" source="~/snippets/csharp/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.cs" id="Snippet5":::
- :::code language="vb" source="~/snippets/visualbasic/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.vb" id="Snippet5":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Configuration.ConfigurationException">The <paramref name="extension" /> does not have a configured language provider on this computer.</exception>
         <exception cref="T:System.Configuration.ConfigurationErrorsException">The <paramref name="extension" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
         <altmember cref="M:System.CodeDom.Compiler.CodeDomProvider.IsDefinedExtension(System.String)" />
         <altmember cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateProvider(System.String)" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/compiler/">Compiler and Language Provider Settings Schema</related>
       </Docs>
     </Member>
     <Member MemberName="GetTypeOutput">
@@ -1490,7 +1396,7 @@
 ## Remarks
 
 > [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, this method is provided by the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation that is returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*> method of the provider. In version 2.0, this method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
+> This method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
 
  ]]></format>
         </remarks>
@@ -1536,29 +1442,11 @@
         <summary>Tests whether a file name extension has an associated <see cref="T:System.CodeDom.Compiler.CodeDomProvider" /> implementation configured on the computer.</summary>
         <returns>
           <see langword="true" /> if a <see cref="T:System.CodeDom.Compiler.CodeDomProvider" /> implementation is configured for the specified file name extension; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The [&lt;system.codedom&gt; Element](/dotnet/framework/configure-apps/file-schema/compiler/system-codedom-element) in the machine configuration file (Machine.config) contains the language provider and compiler configuration settings for each <xref:System.CodeDom.Compiler.CodeDomProvider> implementation on the computer. The <xref:System.CodeDom.Compiler.CodeDomProvider.IsDefinedExtension*> method searches the provider configuration elements for the specified file name extension.
-
- File name extensions are case-insensitive.
-
-
-
-## Examples
- The following code example determines the <xref:System.CodeDom.Compiler.CodeDomProvider> implementation for an input file name extension and displays the configured settings for the language provider. This code example is part of a larger example provided for the <xref:System.CodeDom.Compiler.CompilerInfo> class.
-
- :::code language="csharp" source="~/snippets/csharp/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.cs" id="Snippet5":::
- :::code language="vb" source="~/snippets/visualbasic/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.vb" id="Snippet5":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="extension" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
         <altmember cref="M:System.CodeDom.Compiler.CodeDomProvider.GetLanguageFromExtension(System.String)" />
         <altmember cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateProvider(System.String)" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/compiler/">Compiler and Language Provider Settings Schema</related>
       </Docs>
     </Member>
     <Member MemberName="IsDefinedLanguage">
@@ -1597,28 +1485,10 @@
         <summary>Tests whether a language has a <see cref="T:System.CodeDom.Compiler.CodeDomProvider" /> implementation configured on the computer.</summary>
         <returns>
           <see langword="true" /> if a <see cref="T:System.CodeDom.Compiler.CodeDomProvider" /> implementation is configured for the specified language; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The [&lt;system.codedom&gt; Element](/dotnet/framework/configure-apps/file-schema/compiler/system-codedom-element) in the machine configuration file (Machine.config) contains the language provider and compiler configuration settings for each <xref:System.CodeDom.Compiler.CodeDomProvider> implementation on the computer. The <xref:System.CodeDom.Compiler.CodeDomProvider.IsDefinedLanguage*> method searches the provider configuration elements for the specified language name.
-
- Language names are case-insensitive.
-
-
-
-## Examples
- The following code example determines the <xref:System.CodeDom.Compiler.CodeDomProvider> implementation for an input language and displays the configured settings for the language provider. This code example is part of a larger example provided for the <xref:System.CodeDom.Compiler.CompilerInfo> class.
-
- :::code language="csharp" source="~/snippets/csharp/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.cs" id="Snippet6":::
- :::code language="vb" source="~/snippets/visualbasic/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.vb" id="Snippet6":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="language" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
         <altmember cref="M:System.CodeDom.Compiler.CodeDomProvider.CreateProvider(System.String)" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/compiler/">Compiler and Language Provider Settings Schema</related>
       </Docs>
     </Member>
     <Member MemberName="IsValidIdentifier">
@@ -1664,7 +1534,7 @@
  This method tests whether an identifier is valid. The <xref:System.CodeDom.Compiler.CodeDomProvider.IsValidIdentifier*> method is provider specific. Identifiers that are valid for one provider might not be valid for other providers. If `value` contains characters outside of the ASCII character range, check the identifier for all the languages that might be used to compile the code.
 
 > [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, this method is provided by the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation that is returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*> method of the provider. In version 2.0, this method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
+> This method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
 
  ]]></format>
         </remarks>
@@ -1752,7 +1622,7 @@
 ## Remarks
 
 > [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, this method is provided by the <xref:System.CodeDom.Compiler.ICodeParser> implementation that is returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateParser*> method of the provider. In version 2.0, this method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeParser> implementation is called by the base class.
+> This method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeParser> implementation is called by the base class.
 
  ]]></format>
         </remarks>
@@ -1807,7 +1677,7 @@
  This method can be called with a number of <xref:System.CodeDom.Compiler.GeneratorSupport> flags at once to test for a set of capabilities by joining a set of appropriate capability flags together with a binary `OR` operator (&#124;).
 
 > [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, this method is provided by the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation that is returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*> method of the provider. In version 2.0, this method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
+> This method can be called directly on the code provider even if it is not overridden by the code provider. If the code provider does not override this method, the <xref:System.CodeDom.Compiler.ICodeGenerator> implementation is called by the base class.
 
  ]]></format>
         </remarks>

--- a/xml/System.CodeDom.Compiler/CodeGenerator.xml
+++ b/xml/System.CodeDom.Compiler/CodeGenerator.xml
@@ -43,9 +43,6 @@
 ## Remarks
  This is a useful base class for code generators to derive from. Code generators are capable of rendering source code in a specific language according to the structure of a Code Document Object Model (CodeDOM) graph. This class provides many functions and methods to generate specific types of code from a CodeDOM graph.
 
-> [!NOTE]
-> This class contains a link demand and an inheritance demand at the class level that applies to all members. A <xref:System.Security.SecurityException> is thrown when either the immediate caller or the derived class does not have full-trust permission.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.CodeDom.Compiler.ICodeGenerator" />

--- a/xml/System.CodeDom.Compiler/CodeGeneratorOptions.xml
+++ b/xml/System.CodeDom.Compiler/CodeGeneratorOptions.xml
@@ -43,11 +43,6 @@
 
  An <xref:System.CodeDom.Compiler.ICodeGenerator> implementation can provide custom code generation options which you can set or pass data to using the <xref:System.CodeDom.Compiler.CodeGeneratorOptions.Item*> dictionary indexer, which a code generator can search through to locate additional code generation options.
 
-> [!NOTE]
->  This class contains a link demand and an inheritance demand at the class level that applies to all members. A <xref:System.Security.SecurityException> is thrown when either the immediate caller or the derived class does not have full-trust permission.
-
-
-
 ## Examples
  :::code language="csharp" source="~/snippets/csharp/System.CodeDom.Compiler/CodeGeneratorOptions/Overview/class1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.CodeDom.Compiler/CodeGeneratorOptions/Overview/class1.vb" id="Snippet1":::

--- a/xml/System.CodeDom.Compiler/CodeParser.xml
+++ b/xml/System.CodeDom.Compiler/CodeParser.xml
@@ -43,9 +43,6 @@
 ## Remarks
  Developers who build compilers can implement this interface to support code parsing by designers.
 
-> [!NOTE]
->  This class contains a link demand and an inheritance demand at the class level that applies to all members. A <xref:System.Security.SecurityException> is thrown when either the immediate caller or the derived class does not have full-trust permission.
-
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.CodeDom.Compiler/CompilerInfo.xml
+++ b/xml/System.CodeDom.Compiler/CompilerInfo.xml
@@ -36,30 +36,13 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Use the <xref:System.CodeDom.Compiler.CompilerInfo> class to determine whether a <xref:System.CodeDom.Compiler.CodeDomProvider> implementation is configured on the computer, or to examine the configuration and compiler settings for a specific language provider.
 
- The [&lt;system.codedom&gt; Element](/dotnet/framework/configure-apps/file-schema/compiler/system-codedom-element) in the machine configuration file contains the language provider and compiler configuration settings. Each configured language provider has a corresponding compiler configuration element. Each element defines the <xref:System.CodeDom.Compiler.CodeDomProvider> implementation type, supported language names, supported file name extensions, and compiler parameters.
-
- The .NET Framework defines the initial compiler settings in the machine configuration file. Developers and compiler vendors can add configuration settings for a new <xref:System.CodeDom.Compiler.CodeDomProvider> implementation.
-
- The <xref:System.CodeDom.Compiler.CompilerInfo> class provides read-only access to these settings in the machine configuration file. Use the <xref:System.CodeDom.Compiler.CompilerInfo.GetLanguages*>, <xref:System.CodeDom.Compiler.CompilerInfo.GetExtensions*>, and <xref:System.CodeDom.Compiler.CompilerInfo.CodeDomProviderType*> members to examine the corresponding configuration attributes for a language provider. Use the <xref:System.CodeDom.Compiler.CompilerInfo.CreateDefaultCompilerParameters*> method to obtain the compiler options and warning level attribute values for a language provider.
-
- For more details on language provider settings in the configuration file, see [Compiler and Language Provider Settings Schema](/dotnet/framework/configure-apps/file-schema/compiler/).
-
-> [!NOTE]
-> This class contains a link demand at the class level that applies to all members. A <xref:System.Security.SecurityException> is thrown when the immediate caller does not have full-trust permission.
-
-## Examples
- The following code example displays language provider configuration settings. Command-line arguments are used to specify a language, file name extension, or provider type. For the given input, the example determines the corresponding language provider and displays the configured language compiler settings.
-
- :::code language="csharp" source="~/snippets/csharp/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.vb" id="Snippet1":::
+Use the <xref:System.CodeDom.Compiler.CompilerInfo> class to determine whether a <xref:System.CodeDom.Compiler.CodeDomProvider> implementation is configured on the computer, or to examine the configuration and compiler settings for a specific language provider.
 
  ]]></format>
     </remarks>
     <altmember cref="T:System.CodeDom.Compiler.CompilerParameters" />
     <altmember cref="T:System.CodeDom.Compiler.CodeDomProvider" />
-    <related type="Article" href="/dotnet/framework/configure-apps/file-schema/compiler/">Compiler and Language Provider Settings Schema</related>
   </Docs>
   <Members>
     <Member MemberName="CodeDomProviderType">
@@ -155,24 +138,12 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Use the <xref:System.CodeDom.Compiler.CompilerInfo.CreateDefaultCompilerParameters*> method to examine the compiler settings of the <xref:System.CodeDom.Compiler.CompilerInfo> instances returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.GetAllCompilerInfo*?displayProperty=nameWithType> and <xref:System.CodeDom.Compiler.CodeDomProvider.GetCompilerInfo*?displayProperty=nameWithType> methods.
 
- The [&lt;system.codedom&gt; Element](/dotnet/framework/configure-apps/file-schema/compiler/system-codedom-element) in the machine configuration file contains the language provider and compiler configuration settings for each <xref:System.CodeDom.Compiler.CodeDomProvider> implementation on the computer. Each language provider configuration element can contain optional `compilerOptions` and `warningLevel` attributes. These attributes define the default values for the <xref:System.CodeDom.Compiler.CompilerParameters.CompilerOptions*?displayProperty=nameWithType> and <xref:System.CodeDom.Compiler.CompilerParameters.WarningLevel*?displayProperty=nameWithType> properties.
-
- If the language provider configuration element does not define the `compilerOptions` attribute, the <xref:System.CodeDom.Compiler.CompilerParameters.CompilerOptions?displayProperty=nameWithType> property value is an empty string (""). If the language provider configuration element does not define the `warningLevel` attribute, the <xref:System.CodeDom.Compiler.CompilerParameters.WarningLevel?displayProperty=nameWithType> property value is -1.
-
-
-
-## Examples
- The following code example determines whether the input language has a configured <xref:System.CodeDom.Compiler.CodeDomProvider> implementation on the computer. If there is a provider configured for the specified language, the example displays the language provider configuration settings. This code example is part of a larger example provided for the <xref:System.CodeDom.Compiler.CompilerInfo> class.
-
- :::code language="csharp" source="~/snippets/csharp/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.cs" id="Snippet7":::
- :::code language="vb" source="~/snippets/visualbasic/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.vb" id="Snippet7":::
+Use this method to examine the compiler settings of the <xref:System.CodeDom.Compiler.CompilerInfo> instances returned by the <xref:System.CodeDom.Compiler.CodeDomProvider.GetAllCompilerInfo*?displayProperty=nameWithType> and <xref:System.CodeDom.Compiler.CodeDomProvider.GetCompilerInfo*?displayProperty=nameWithType> methods.
 
  ]]></format>
         </remarks>
         <altmember cref="T:System.CodeDom.Compiler.CompilerParameters" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/compiler/">Compiler and Language Provider Settings Schema</related>
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateProvider">
@@ -235,7 +206,6 @@
  ]]></format>
         </remarks>
         <altmember cref="T:System.CodeDom.Compiler.CodeDomProvider" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/compiler/">Compiler and Language Provider Settings Schema</related>
       </Docs>
     </Member>
     <Member MemberName="CreateProvider">
@@ -374,24 +344,8 @@
       <Docs>
         <summary>Returns the file name extensions supported by the language provider.</summary>
         <returns>An array of file name extensions supported by the language provider.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The [&lt;system.codedom&gt; Element](/dotnet/framework/configure-apps/file-schema/compiler/system-codedom-element) in the machine configuration file contains the language provider and compiler configuration settings for each <xref:System.CodeDom.Compiler.CodeDomProvider> implementation on the computer. Each configured language provider supports one or more file name extensions. For example, a <xref:Microsoft.CSharp.CSharpCodeProvider?displayProperty=nameWithType> might support the file name extensions ".cs" and ".c#".
-
-
-
-## Examples
- The following code example enumerates the language providers on the computer and displays the configuration and compiler settings for each language provider. This code example is part of a larger example provided for the <xref:System.CodeDom.Compiler.CompilerInfo> class.
-
- :::code language="csharp" source="~/snippets/csharp/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.cs" id="Snippet8":::
- :::code language="vb" source="~/snippets/visualbasic/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.vb" id="Snippet8":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.CodeDom.Compiler.CodeDomProvider.IsDefinedExtension(System.String)" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/compiler/">Compiler and Language Provider Settings Schema</related>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -481,24 +435,8 @@
       <Docs>
         <summary>Gets the language names supported by the language provider.</summary>
         <returns>An array of language names supported by the language provider.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The [&lt;system.codedom&gt; Element](/dotnet/framework/configure-apps/file-schema/compiler/system-codedom-element) in the machine configuration file contains the language provider and compiler configuration settings for each <xref:System.CodeDom.Compiler.CodeDomProvider> implementation on the computer. Each configured language provider supports one or more language names. For example, the <xref:System.CodeDom.Compiler.CompilerInfo> object for a <xref:Microsoft.CSharp.CSharpCodeProvider?displayProperty=nameWithType> might return an array with the language names "c#", "cs", and "csharp".
-
-
-
-## Examples
- The following code example enumerates the language providers on the computer and displays the configuration and compiler settings for each language provider. This code example is part of a larger example provided for the <xref:System.CodeDom.Compiler.CompilerInfo> class.
-
- :::code language="csharp" source="~/snippets/csharp/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.cs" id="Snippet8":::
- :::code language="vb" source="~/snippets/visualbasic/System.CodeDom.Compiler/CodeDomProvider/CreateProvider/source.vb" id="Snippet8":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.CodeDom.Compiler.CodeDomProvider.IsDefinedLanguage(System.String)" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/compiler/">Compiler and Language Provider Settings Schema</related>
       </Docs>
     </Member>
     <Member MemberName="IsCodeDomProviderTypeValid">

--- a/xml/System.CodeDom.Compiler/CompilerParameters.xml
+++ b/xml/System.CodeDom.Compiler/CompilerParameters.xml
@@ -47,10 +47,7 @@
 
  To specify a warning level at which to halt compilation, set the <xref:System.CodeDom.Compiler.CompilerParameters.WarningLevel> property to an integer that represents the warning level at which to halt compilation. You can also configure the compiler to halt compilation if warnings are encountered by setting the <xref:System.CodeDom.Compiler.CompilerParameters.TreatWarningsAsErrors> property to `true`.
 
- To specify a custom command-line arguments string to use when invoking the compilation process, set the string in the <xref:System.CodeDom.Compiler.CompilerParameters.CompilerOptions> property. If a Win32 security token is required to invoke the compiler process, specify the token in the <xref:System.CodeDom.Compiler.CompilerParameters.UserToken> property. To include .NET Framework resource files in the compiled assembly, add the names of the resource files to the <xref:System.CodeDom.Compiler.CompilerParameters.EmbeddedResources> property. To reference .NET Framework resources in another assembly, add the names of the resource files to the <xref:System.CodeDom.Compiler.CompilerParameters.LinkedResources> property. To include a Win32 resource file in the compiled assembly, specify the name of the Win32 resource file in the <xref:System.CodeDom.Compiler.CompilerParameters.Win32Resource> property.
-
-> [!NOTE]
-> This class contains a link demand and an inheritance demand at the class level that applies to all members. A <xref:System.Security.SecurityException> is thrown when either the immediate caller or the derived class does not have full-trust permission.
+ To specify a custom command-line arguments string to use when invoking the compilation process, set the string in the <xref:System.CodeDom.Compiler.CompilerParameters.CompilerOptions> property. If a Win32 security token is required to invoke the compiler process, specify the token in the <xref:System.CodeDom.Compiler.CompilerParameters.UserToken> property. To include .NET resource files in the compiled assembly, add the names of the resource files to the <xref:System.CodeDom.Compiler.CompilerParameters.EmbeddedResources> property. To reference .NET resources in another assembly, add the names of the resource files to the <xref:System.CodeDom.Compiler.CompilerParameters.LinkedResources> property. To include a Win32 resource file in the compiled assembly, specify the name of the Win32 resource file in the <xref:System.CodeDom.Compiler.CompilerParameters.Win32Resource> property.
 
 ## Examples
  The following example builds a CodeDOM source graph for a simple Hello World program.  The source is then saved to a file, compiled into an executable, and run. The `CompileCode` method illustrates how to use the <xref:System.CodeDom.Compiler.CompilerParameters> class to specify various compiler settings and options.
@@ -748,13 +745,8 @@ An <xref:System.CodeDom.Compiler.ICodeCompiler> typically includes this string o
 ## Remarks
  The temporary files in the collection are retained or deleted upon the completion of compiler activity based on the value of the <xref:System.CodeDom.Compiler.TempFileCollection.KeepFiles> property in the collection. The <xref:System.CodeDom.Compiler.TempFileCollection.KeepFiles> property is set if the collection is created using the <xref:System.CodeDom.Compiler.TempFileCollection.%23ctor(System.String,System.Boolean)> constructor with the `keepFiles` parameter set to `true`.
 
-> [!NOTE]
->  This class contains a link demand and an inheritance demand at the class level that applies to all members. A <xref:System.Security.SecurityException> is thrown when either the immediate caller or the derived class does not have full-trust permission.
-
-
-
 ## Examples
- The following example illustrates using <xref:System.CodeDom.Compiler.CompilerParameters> to specify various compiler settings and options. This code example is part of a larger example provided for the <xref:System.CodeDom.Compiler.CompilerParameters> class.
+ The following example illustrates using <xref:System.CodeDom.Compiler.CompilerParameters> to specify various compiler settings and options.
 
  :::code language="csharp" source="~/snippets/csharp/System.CodeDom.Compiler/CompilerParameters/Overview/source.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.CodeDom.Compiler/CompilerParameters/Overview/source.vb" id="Snippet2":::
@@ -925,9 +917,9 @@ An <xref:System.CodeDom.Compiler.ICodeCompiler> typically includes this string o
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Linking files through this property is similar to the `/winres` and `/winresource` command-line arguments supported by many of the .NET Framework compilers.
+ Linking files through this property is similar to the `/winres` and `/winresource` command-line arguments supported by many of the .NET compilers.
 
- Use <xref:System.CodeDom.Compiler.CompilerParameters.Win32Resource*> to compile a Win32 resource file into the assembly. Use <xref:System.CodeDom.Compiler.CompilerParameters.EmbeddedResources*> or <xref:System.CodeDom.Compiler.CompilerParameters.LinkedResources*> to compile with .NET Framework resource files.
+ Use <xref:System.CodeDom.Compiler.CompilerParameters.Win32Resource*> to compile a Win32 resource file into the assembly. Use <xref:System.CodeDom.Compiler.CompilerParameters.EmbeddedResources*> or <xref:System.CodeDom.Compiler.CompilerParameters.LinkedResources*> to compile with .NET resource files.
 
  Not all compilers support Win32 resource files, so you should test a code generator for this support before linking a resource file by calling the <xref:System.CodeDom.Compiler.ICodeGenerator.Supports*> method with the flag <xref:System.CodeDom.Compiler.GeneratorSupport.Win32Resources>.
 

--- a/xml/System.CodeDom.Compiler/CompilerResults.xml
+++ b/xml/System.CodeDom.Compiler/CompilerResults.xml
@@ -133,16 +133,7 @@
       <Docs>
         <summary>Gets or sets the compiled assembly.</summary>
         <value>An <see cref="T:System.Reflection.Assembly" /> that indicates the compiled assembly.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!NOTE]
->  The `get` accessor for the <xref:System.CodeDom.Compiler.CompilerResults.CompiledAssembly> property calls the <xref:System.AppDomain.Load*> method to load the compiled assembly into the current application domain.  After calling the `get` accessor, the compiled assembly cannot be deleted until the current <xref:System.AppDomain> is unloaded.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="T:System.Reflection.Assembly" />
       </Docs>
     </Member>

--- a/xml/System.CodeDom.Compiler/Executor.xml
+++ b/xml/System.CodeDom.Compiler/Executor.xml
@@ -39,9 +39,6 @@
 ## Remarks
  This class provides a collection of methods that can be used to invoke a compiler, typically from an <xref:System.CodeDom.Compiler.ICodeCompiler> implementation.
 
-> [!NOTE]
->  This class contains a link demand at the class level that applies to all members. A <xref:System.Security.SecurityException> is thrown when the immediate caller does not have full-trust permission.
-
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.CodeDom.Compiler/ICodeCompiler.xml
+++ b/xml/System.CodeDom.Compiler/ICodeCompiler.xml
@@ -37,7 +37,7 @@
 ## Remarks
 
 > [!NOTE]
-> Starting in .NET Framework 2.0, the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*>, <xref:System.CodeDom.Compiler.CodeDomProvider.CreateParser*>, and <xref:System.CodeDom.Compiler.CodeDomProvider.CreateCompiler*> methods are obsolete, and the methods of <xref:System.CodeDom.Compiler.ICodeGenerator> and <xref:System.CodeDom.Compiler.ICodeCompiler> are directly available in the <xref:System.CodeDom.Compiler.CodeDomProvider> class. You should override those methods in your code provider implementation and not call the base methods.
+> The <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*>, <xref:System.CodeDom.Compiler.CodeDomProvider.CreateParser*>, and <xref:System.CodeDom.Compiler.CodeDomProvider.CreateCompiler*> methods are obsolete, and the methods of <xref:System.CodeDom.Compiler.ICodeGenerator> and <xref:System.CodeDom.Compiler.ICodeCompiler> are directly available in the <xref:System.CodeDom.Compiler.CodeDomProvider> class. You should override those methods in your code provider implementation and not call the base methods.
 
  The <xref:System.CodeDom.Compiler.ICodeCompiler> interface can be implemented for a specific compiler to enable developers to programmatically compile assemblies from Code Document Object Model (CodeDOM) compile units, strings containing source code, or source code files.
 

--- a/xml/System.CodeDom.Compiler/ICodeGenerator.xml
+++ b/xml/System.CodeDom.Compiler/ICodeGenerator.xml
@@ -37,7 +37,7 @@
 ## Remarks
 
 > [!NOTE]
-> Starting in .NET Framework 2.0, the <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*>, <xref:System.CodeDom.Compiler.CodeDomProvider.CreateParser*>, and <xref:System.CodeDom.Compiler.CodeDomProvider.CreateCompiler*> methods are obsolete, and the methods of <xref:System.CodeDom.Compiler.ICodeGenerator> and <xref:System.CodeDom.Compiler.ICodeCompiler> are directly available in the <xref:System.CodeDom.Compiler.CodeDomProvider> class. You should override those methods in your code provider implementation and not call the base methods.
+> The <xref:System.CodeDom.Compiler.CodeDomProvider.CreateGenerator*>, <xref:System.CodeDom.Compiler.CodeDomProvider.CreateParser*>, and <xref:System.CodeDom.Compiler.CodeDomProvider.CreateCompiler*> methods are obsolete, and the methods of <xref:System.CodeDom.Compiler.ICodeGenerator> and <xref:System.CodeDom.Compiler.ICodeCompiler> are directly available in the <xref:System.CodeDom.Compiler.CodeDomProvider> class. You should override those methods in your code provider implementation and not call the base methods.
 
  Developers of compilers can implement this interface to allow people to dynamically generate code in a particular language. This can be used for a variety of purposes, such as creating code-generating wizards, creating dynamic assemblies with content that can be debugged, and for templated documents with embedded code, such as ASP.NET.
 

--- a/xml/System.CodeDom.Compiler/IndentedTextWriter.xml
+++ b/xml/System.CodeDom.Compiler/IndentedTextWriter.xml
@@ -82,11 +82,6 @@
 
  The tab string is the string that each indentation consists of. Typically the tab string contains white space.
 
-> [!NOTE]
->  This class contains a link demand and an inheritance demand at the class level that applies to all members. A <xref:System.Security.SecurityException> is thrown when either the immediate caller or the derived class does not have full-trust permission.
-
-
-
 ## Examples
  The following code example demonstrates using an <xref:System.CodeDom.Compiler.IndentedTextWriter> to write text at different levels of indentation.
 

--- a/xml/System.CodeDom.Compiler/TempFileCollection.xml
+++ b/xml/System.CodeDom.Compiler/TempFileCollection.xml
@@ -61,11 +61,6 @@
 
  The <xref:System.CodeDom.Compiler.TempFileCollection.BasePath> property indicates a full path to the base file name, without a file name extension, used to generate the file names returned by the <xref:System.CodeDom.Compiler.TempFileCollection.AddExtension*> method.
 
-> [!NOTE]
->  This class contains a link demand and an inheritance demand at the class level that applies to all members. A <xref:System.Security.SecurityException> is thrown when either the immediate caller or the derived class does not have full-trust permission.
-
-
-
 ## Examples
  The following example shows the use of the <xref:System.CodeDom.Compiler.TempFileCollection> class and the <xref:System.CodeDom.Compiler.TempFileCollection.AddExtension*> and <xref:System.CodeDom.Compiler.TempFileCollection.AddFile*> methods.
 

--- a/xml/System.CodeDom/CodeDefaultValueExpression.xml
+++ b/xml/System.CodeDom/CodeDefaultValueExpression.xml
@@ -38,7 +38,9 @@
 ## Remarks
  A <xref:System.CodeDom.CodeDefaultValueExpression> can be used to represent a reference to a default value.
 
- The <xref:System.CodeDom.CodeDefaultValueExpression.Type> property specifies the reference to the value type. The <xref:System.CodeDom.CodeDefaultValueExpression> class is used in the generation of generics-based code. For more information on generics, see [Generics in the .NET Framework Class Library](/dotnet/standard/generics/). The following code steps are provided in this section to further describe the use of the <xref:System.CodeDom.CodeDefaultValueExpression> class to add a new default value to a code graph.
+ The <xref:System.CodeDom.CodeDefaultValueExpression.Type> property specifies the reference to the value type. The <xref:System.CodeDom.CodeDefaultValueExpression> class is used in the generation of generics-based code. For more information on generics, see [Generics](/dotnet/standard/generics/).
+
+ The following code steps are provided in this section to further describe the use of the <xref:System.CodeDom.CodeDefaultValueExpression> class to add a new default value to a code graph.
 
  The code in part 1 is part of a larger example provided for the <xref:System.CodeDom.CodeTypeParameter> class. This code, when run through the C# code generator, results in the C# code that appears in part 2. When this code is called in the statement in part 3, the result is the output shown in part 4.
 
@@ -80,8 +82,6 @@ dict.Print<System.Decimal, int>();
 0
 
 ```
-
-
 
 ## Examples
  The following code example shows the use of the <xref:System.CodeDom.CodeDefaultValueExpression> to create default values for decimal and integer parameters. This example is part of a larger example provided for the <xref:System.CodeDom.CodeTypeParameter> class.

--- a/xml/System.CodeDom/CodePrimitiveExpression.xml
+++ b/xml/System.CodeDom/CodePrimitiveExpression.xml
@@ -162,14 +162,7 @@
       <Docs>
         <summary>Gets or sets the primitive data type to represent.</summary>
         <value>The primitive data type instance to represent the value of.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Any .NET Framework primitive type can be used here.
-
- ]]></format>
-        </remarks>
+        <remarks>Any .NET primitive type can be used here.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.CodeDom/CodeTypeDeclaration.xml
+++ b/xml/System.CodeDom/CodeTypeDeclaration.xml
@@ -173,22 +173,17 @@
 ## Remarks
  To generate a class in Visual Basic that does not inherit from a base type, but that does implement one or more interfaces, you must include <xref:System.Object> as the first item in the <xref:System.CodeDom.CodeTypeDeclaration.BaseTypes*> collection.
 
-> [!NOTE]
->  In the .NET Framework version 2.0 you do not need the <xref:System.CodeDom.CodeTypeReference> for <xref:System.Object> if the interface you are implementing already exists and you are referring to it by type. For example, if you are implementing the <xref:System.Collections.ICollection> interface and add it to the collection with this statement, `ctd.BaseTypes.Add(New CodeTypeReference(typeof(ICollection)))`, you do not need the preceding `ctd.BaseTypes.Add(New CodeTypeReference(GetType(Object)))` statement.
-
  The following code illustrates the addition of a <xref:System.CodeDom.CodeTypeReference> to the collection that refers to <xref:System.Object>.
 
 ```vb
 Dim ctd As New CodeTypeDeclaration("Class1")
 ctd.IsClass = True
-ctd.BaseTypes.Add(New CodeTypeReference(GetType(Object)))
 ctd.BaseTypes.Add(New CodeTypeReference("Interface1"))
 ```
 
 ```csharp
 CodeTypeDeclaration ctd = new CodeTypeDeclaration("Class1");
 ctd.IsClass = true;
-ctd.BaseTypes.Add(new CodeTypeReference(typeof(Object)));
 ctd.BaseTypes.Add(new CodeTypeReference("Interface1"));
 ```
 
@@ -615,7 +610,7 @@ Implements Interface1
 ## Remarks
  A generic type declaration contains one or more unspecified types known as type parameters. A type parameter name stands for the type within the body of the generic declaration. For example, the generic declaration for the <xref:System.Collections.Generic.List`1> class contains the type parameter `T`.
 
- For more information on generics, see [Generics in the .NET Framework Class Library](/dotnet/standard/generics/).
+ For more information on generics, see [Generics](/dotnet/standard/generics/).
 
  ]]></format>
         </remarks>

--- a/xml/System.CodeDom/CodeTypeDeclaration.xml
+++ b/xml/System.CodeDom/CodeTypeDeclaration.xml
@@ -173,7 +173,7 @@
 ## Remarks
  To generate a class in Visual Basic that does not inherit from a base type, but that does implement one or more interfaces, you must include <xref:System.Object> as the first item in the <xref:System.CodeDom.CodeTypeDeclaration.BaseTypes*> collection.
 
- The following code illustrates the addition of a <xref:System.CodeDom.CodeTypeReference> to the collection that refers to <xref:System.Object>.
+The following code illustrates adding base type references to the collection.
 
 ```vb
 Dim ctd As New CodeTypeDeclaration("Class1")

--- a/xml/System.CodeDom/CodeTypeParameter.xml
+++ b/xml/System.CodeDom/CodeTypeParameter.xml
@@ -40,9 +40,7 @@
 
  A generic type or method declaration contains one or more unspecified types known as type parameters. A type parameter name stands for the type within the body of the generic declaration. For example, the generic declaration for the <xref:System.Collections.Generic.List`1> class contains the type parameter `T`.
 
- For more information on generics, see [Generics in the .NET Framework Class Library](/dotnet/standard/generics/).
-
-
+ For more information on generics, see [Generics](/dotnet/standard/generics/).
 
 ## Examples
  The following code example shows the use of the <xref:System.CodeDom.CodeTypeParameter> class to create a CodeDOM graph to generate an application containing generics code.


### PR DESCRIPTION
.NET Framework API ref has moved to its own repo (https://github.com/dotnet/dotnetfw-api-docs), so we can clean up .NET Framework remarks, exceptions, and code examples out of this repo. Contributes to #12513.

Removes remarks related to:

- Code-access security
- Configuring apps via app.config file
- Application domains

*Hide whitespace changes*