### PR TITLE
Remove .NET Framework remarks (System.Globalization)

### DIFF
--- a/xml/System.Globalization/Calendar.xml
+++ b/xml/System.Globalization/Calendar.xml
@@ -2528,7 +2528,7 @@ Only the <xref:System.Globalization.JapaneseCalendar> and the <xref:System.Globa
 - The <xref:System.Globalization.DateTimeFormatInfo.CalendarWeekRule?displayProperty=nameWithType> property contains the default calendar week rule that can be used for the `rule` parameter.
 
 > [!NOTE]
-> This does not map exactly to ISO 8601. The differences are discussed in the blog entry [ISO 8601 Week of Year format in Microsoft .NET](https://learn.microsoft.com/archive/blogs/shawnste/iso-8601-week-of-year-format-in-microsoft-net). Starting with .NET Core 3.0, <xref:System.Globalization.ISOWeek.GetYear*?displayProperty=nameWithType> and <xref:System.Globalization.ISOWeek.GetWeekOfYear*?displayProperty=nameWithType> solve this problem.
+> This does not map exactly to ISO 8601. The differences are discussed in the blog entry [ISO 8601 Week of Year format in Microsoft .NET](https://learn.microsoft.com/archive/blogs/shawnste/iso-8601-week-of-year-format-in-microsoft-net). <xref:System.Globalization.ISOWeek.GetYear*?displayProperty=nameWithType> and <xref:System.Globalization.ISOWeek.GetWeekOfYear*?displayProperty=nameWithType> solve this problem.
 
  The following example uses the current culture's <xref:System.Globalization.DateTimeFormatInfo> object to determine that January 1, 2011 is in the first week of the year in the Gregorian calendar.
 

--- a/xml/System.Globalization/CalendarWeekRule.xml
+++ b/xml/System.Globalization/CalendarWeekRule.xml
@@ -108,7 +108,7 @@
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CalendarWeekRule/Overview/calendarweekruleex.vb" id="Snippet1":::
 
 > [!NOTE]
->  This does not map exactly to ISO 8601. The differences are discussed in the blog entry [ISO 8601 Week of Year format in Microsoft .NET](https://learn.microsoft.com/archive/blogs/shawnste/iso-8601-week-of-year-format-in-microsoft-net). Starting with .NET Core 3.0, <xref:System.Globalization.ISOWeek.GetYear*?displayProperty=nameWithType> and <xref:System.Globalization.ISOWeek.GetWeekOfYear*?displayProperty=nameWithType> solve this problem.
+>  This does not map exactly to ISO 8601. The differences are discussed in the blog entry [ISO 8601 Week of Year format in Microsoft .NET](https://learn.microsoft.com/archive/blogs/shawnste/iso-8601-week-of-year-format-in-microsoft-net). <xref:System.Globalization.ISOWeek.GetYear*?displayProperty=nameWithType> and <xref:System.Globalization.ISOWeek.GetWeekOfYear*?displayProperty=nameWithType> solve this problem.
 
  Each <xref:System.Globalization.CultureInfo> object supports a set of calendars. The <xref:System.Globalization.CultureInfo.Calendar> property returns the default calendar for the culture, and the <xref:System.Globalization.CultureInfo.OptionalCalendars> property returns an array containing all the calendars supported by the culture. To change the calendar used by a <xref:System.Globalization.CultureInfo>, set the <xref:System.Globalization.DateTimeFormatInfo.Calendar> property of <xref:System.Globalization.CultureInfo.DateTimeFormat*?displayProperty=nameWithType> to a new <xref:System.Globalization.Calendar>.
 

--- a/xml/System.Globalization/CharUnicodeInfo.xml
+++ b/xml/System.Globalization/CharUnicodeInfo.xml
@@ -75,25 +75,19 @@
  Use the <xref:System.Globalization.CharUnicodeInfo> class to obtain the <xref:System.Globalization.UnicodeCategory> value for a specific character. The <xref:System.Globalization.CharUnicodeInfo> class defines methods that return the following Unicode character values:
 
 - The specific category to which a character or surrogate pair belongs. The value returned is a member of the <xref:System.Globalization.UnicodeCategory> enumeration.
-
 - Numeric value. Applies only to numeric characters, including fractions, subscripts, superscripts, Roman numerals, currency numerators, encircled numbers, and script-specific digits.
-
 - Digit value. Applies to numeric characters that can be combined with other numeric characters to represent a whole number in a numbering system.
-
 - Decimal digit value. Applies only to characters that represent decimal digits in the decimal (base 10) system. A decimal digit can be one of ten digits, from zero through nine. These characters are members of the <xref:System.Globalization.UnicodeCategory.DecimalDigitNumber?displayProperty=nameWithType> category.
 
 In addition, the <xref:System.Globalization.CharUnicodeInfo> class is used internally by a number of other .NET types and methods that rely on character classification. These include:
 
 - The <xref:System.Globalization.StringInfo> class, which works with textual elements instead of single characters in a string.
-
 - The overloads of the <xref:System.Char.GetUnicodeCategory*?displayProperty=nameWithType> method, which determine the category to which a character or surrogate pair belongs.
-
 - The [character classes](/dotnet/standard/base-types/character-classes-in-regular-expressions) recognized by <xref:System.Text.RegularExpressions.Regex>, .NET's regular expression engine.
 
 When using this class in your applications, keep in mind the following programming considerations for using the <xref:System.Char> type. The type can be difficult to use, and strings are generally preferable for representing linguistic content.
 
 - A <xref:System.Char> object does not always correspond to a single character. Although the <xref:System.Char> type represents a single 16-bit value, some characters (such as grapheme clusters and surrogate pairs) consist of two or more UTF-16 code units. For more information, see "Char Objects and Unicode Characters" in the <xref:System.String> class.
-
 - The notion of a "character" is also flexible. A character is often thought of as a glyph, but many glyphs require multiple code points. For example, ä can be represented either by two code points ("a" plus U+0308, which is the combining diaeresis), or by a single code point ("ä" or U+00A4). Some languages have many letters, characters, and glyphs that require multiple code points, which can cause confusion in linguistic content representation. For example, there is a ΰ (U+03B0, Greek small letter upsilon with dialytika and tonos), but there is no equivalent capital letter. Uppercasing such a value simply retrieves the original value.
 
 ## Examples
@@ -105,19 +99,7 @@ When using this class in your applications, keep in mind the following programmi
  ]]></format>
     </remarks>
     <block subset="none" type="usage">
-      <para>Recognized characters and the specific categories to which they belong are defined by the Unicode standard and can change from one version of the Unicode Standard to another. Categorization of characters in a particular version of .NET Framework is based on a single version of the Unicode Standard, regardless of the underlying operating system on which .NET Framework is running. The following table lists versions of .NET Framework since .NET Framework 4 and the versions of the Unicode Standard used to classify characters.
-
-| .NET Framework version | Unicode Standard version |
-| - | - |
-| .NET Framework 4 | <see href="https://www.unicode.org/versions/Unicode5.0.0/">5.0.0</see> |
-| .NET Framework 4.5 | <see href="https://www.unicode.org/versions/Unicode5.0.0/">5.0.0</see> |
-| .NET Framework 4.5.1 | <see href="https://www.unicode.org/versions/Unicode5.0.0/">5.0.0</see> |
-| .NET Framework 4.5.2 | <see href="https://www.unicode.org/versions/Unicode5.0.0/">5.0.0</see> |
-| .NET Framework 4.6 | <see href="https://www.unicode.org/versions/Unicode6.3.0/">6.3.0</see> |
-| .NET Framework 4.6.1 | <see href="https://www.unicode.org/versions/Unicode6.3.0/">6.3.0</see> |
-| .NET Framework 4.6.2 | <see href="https://www.unicode.org/versions/Unicode8.0.0/">8.0.0</see> |
-
-Each version of the Unicode standard includes information on changes to the Unicode character database since the previous version. The Unicode character database is used by the <see cref="T:System.Globalization.CharUnicodeInfo" /> class for categorizing characters.</para>
+      <para>Recognized characters and the specific categories to which they belong are defined by the Unicode standard and can change from one version of the Unicode Standard to another. Categorization of characters in a particular version of .NET is based on a single version of the Unicode Standard, regardless of the underlying operating system on which .NET is running. Each version of the Unicode standard includes information on changes to the Unicode character database since the previous version. The Unicode character database is used by the <see cref="T:System.Globalization.CharUnicodeInfo" /> class for categorizing characters.</para>
     </block>
     <altmember cref="T:System.Globalization.UnicodeCategory" />
     <altmember cref="N:System.Text" />

--- a/xml/System.Globalization/ChineseLunisolarCalendar.xml
+++ b/xml/System.Globalization/ChineseLunisolarCalendar.xml
@@ -72,7 +72,7 @@
  The <xref:System.Globalization.ChineseLunisolarCalendar> class is derived from the <xref:System.Globalization.EastAsianLunisolarCalendar> class, which represents the lunisolar calendar. The <xref:System.Globalization.EastAsianLunisolarCalendar> class supports the sexagenary year cycle (which repeats every 60 years) in addition to solar years and lunar months. Each solar year in the calendar is associated with a Sexagenary Year, a Celestial Stem, and a Terrestrial Branch, and these calendars can have leap months after any month of the year. The <xref:System.Globalization.ChineseLunisolarCalendar> class calculates years based on solar calculations, and months and days based on lunar calculations.
 
 > [!NOTE]
->  For information about using the <xref:System.Globalization.ChineseLunisolarCalendar> class and the other calendar classes in the .NET Framework, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
+> For information about using the <xref:System.Globalization.ChineseLunisolarCalendar> class and the other calendar classes in .NET, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
 
  A leap month can occur after any month in a year. For example, the <xref:System.Globalization.EastAsianLunisolarCalendar.GetMonth*> method returns a number between 1 and 13 that indicates the month associated with a specified date. If there is a leap month between the eighth and ninth months of the year, the <xref:System.Globalization.EastAsianLunisolarCalendar.GetMonth*> method returns 8 for the eighth month, 9 for the leap eighth month, and 10 for the ninth month.
 

--- a/xml/System.Globalization/CompareInfo.xml
+++ b/xml/System.Globalization/CompareInfo.xml
@@ -1337,11 +1337,11 @@
  The behavior of this overload is dependent on its implementation, which might change from one version of the common language runtime to another, or from one .NET implementation to another.
 
 > [!IMPORTANT]
->  If two character spans are equal, this overload returns identical values. However, there is not a unique hash code value for each unique character span value. Different character spans can return the same hash code.
+> If two character spans are equal, this overload returns identical values. However, there is not a unique hash code value for each unique character span value. Different character spans can return the same hash code.
 >
->  The hash code itself is not guaranteed to be stable. Hash codes for identical character spans can differ across versions of the .NET implementations and across platforms (such as 32-bit and 64-bit) for a single version of .NET.
+> The hash code itself is not guaranteed to be stable. Hash codes for identical character spans can differ across versions of the .NET implementations and across platforms (such as 32-bit and 64-bit) for a single version of .NET.
 >
->  As a result, hash codes should never be used outside of the application domain in which they were created, they should never be used as key fields in a collection, and they should never be persisted.
+> As a result, hash codes should never be used as key fields in a collection, and they should never be persisted.
 
  ]]></format>
         </remarks>
@@ -1402,14 +1402,12 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The behavior of <xref:System.Globalization.CompareInfo.GetHashCode*> is dependent on its implementation, which might change from one version of the common language runtime to another, or from one .NET Framework platform to another.
+ The behavior of <xref:System.Globalization.CompareInfo.GetHashCode*> is dependent on its implementation, which might change from one version of the common language runtime to another, or from one platform to another.
 
 > [!IMPORTANT]
->  If two string objects are equal, the <xref:System.Globalization.CompareInfo.GetHashCode*> method returns identical values. However, there is not a unique hash code value for each unique string value. Different strings can return the same hash code.
+> If two string objects are equal, the <xref:System.Globalization.CompareInfo.GetHashCode*> method returns identical values. However, there is not a unique hash code value for each unique string value. Different strings can return the same hash code.
 >
->  The hash code itself is not guaranteed to be stable. Hash codes for identical strings can differ across versions of the .NET Framework and across platforms (such as 32-bit and 64-bit) for a single version of the .NET Framework. In some cases, they can even differ by application domain.
->
->  As a result, hash codes should never be used outside of the application domain in which they were created, they should never be used as key fields in a collection, and they should never be persisted.
+> The hash code itself is not guaranteed to be stable. Hash codes for identical strings can differ across versions of .NET and across platforms (such as 32-bit and 64-bit) for a single version of .NET. As a result, hash codes should never be used as key fields in a collection, and they should never be persisted.
 
  ]]></format>
         </remarks>
@@ -5306,14 +5304,10 @@ This method has greater overhead than other <xref:System.Globalization.CompareIn
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
- This method overrides the <xref:System.Object.ToString*?displayProperty=nameWithType> method. It returns a string that consists of the class name and the value of the instance <xref:System.Globalization.CompareInfo.Name> property, separated by a hyphen.
+This method overrides the <xref:System.Object.ToString*?displayProperty=nameWithType> method. It returns a string that consists of the class name followed by a space, a hyphen, a space, and the value of the <see cref="P:System.Globalization.CompareInfo.Name" /> property.
 
  ]]></format>
         </remarks>
-        <block subset="none" type="usage">
-          <para>Staring with the .NET Framework 4, the <see cref="M:System.Globalization.CompareInfo.ToString" /> method returns the class name followed by a space, a hyphen, a space, and the value of the <see cref="P:System.Globalization.CompareInfo.Name" /> property. For example, for a <see cref="T:System.Globalization.CompareInfo" /> object that represents the en-US culture, the <see cref="M:System.Globalization.CompareInfo.ToString" /> method returns "CompareInfo - en-US". In previous versions of the .NET Framework, it returns the class name followed by a space, a hyphen, a space, and the value of the <see cref="P:System.Globalization.CompareInfo.LCID" /> property. For example, for a <see cref="T:System.Globalization.CompareInfo" /> object that represents the en-US culture, the <see cref="M:System.Globalization.CompareInfo.ToString" /> method returns "CompareInfo - 1033".</para>
-        </block>
         <altmember cref="M:System.Object.ToString" />
       </Docs>
     </Member>
@@ -5361,13 +5355,7 @@ This method has greater overhead than other <xref:System.Globalization.CompareIn
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The weight of individual characters, and therefore the way in which particular strings are compared or ordered, depends on the version of the Unicode specification that a particular version of the .NET Framework implements. In the .NET Framework 4.5, this also depends on the host operating system, as the following table shows. Note that this list of supported Unicode versions applies to character comparison and sorting only; it does not apply to classification of Unicode characters by category.
-
-|.NET Framework version|Operating system|Unicode version|
-|----------------------------|----------------------|---------------------|
-|.NET Framework 4|All operating systems|Unicode 5.0|
-|.NET Framework 4.5 and later versions|Windows 7|Unicode 5.0|
-|.NET Framework 4.5 and later versions|Windows 8 and later Windows operating system versions|Unicode 6.3|
+ The weight of individual characters, and therefore the way in which particular strings are compared or ordered, depends on the version of the Unicode specification that a particular version of .NET implements and the host operating system.
 
  The <xref:System.Globalization.SortVersion> object returned by the <xref:System.Globalization.CompareInfo.Version> property doesn't identify the precise Unicode version used to compare strings. It is useful only when comparing two <xref:System.Globalization.SortVersion> objects to determine whether they use the same Unicode version and culture to compare strings. For more information and an example, see the <xref:System.Globalization.SortVersion> reference page.
 

--- a/xml/System.Globalization/CompareInfo.xml
+++ b/xml/System.Globalization/CompareInfo.xml
@@ -1407,7 +1407,7 @@
 > [!IMPORTANT]
 > If two string objects are equal, the <xref:System.Globalization.CompareInfo.GetHashCode*> method returns identical values. However, there is not a unique hash code value for each unique string value. Different strings can return the same hash code.
 >
-> The hash code itself is not guaranteed to be stable. Hash codes for identical strings can differ across versions of .NET and across platforms (such as 32-bit and 64-bit) for a single version of .NET. As a result, hash codes should never be used as key fields in a collection, and they should never be persisted.
+> The hash code itself is not guaranteed to be stable. Hash codes for identical strings can differ across versions of .NET and across platforms (such as 32-bit and 64-bit) for a single version of .NET. As a result, hash codes should never be used outside of the application domain in which they were created, and they should never be persisted.
 
  ]]></format>
         </remarks>

--- a/xml/System.Globalization/CompareInfo.xml
+++ b/xml/System.Globalization/CompareInfo.xml
@@ -1341,7 +1341,7 @@
 >
 > The hash code itself is not guaranteed to be stable. Hash codes for identical character spans can differ across versions of the .NET implementations and across platforms (such as 32-bit and 64-bit) for a single version of .NET.
 >
-> As a result, hash codes should never be used as key fields in a collection, and they should never be persisted.
+> As a result, hash codes should not be treated as unique identifiers, they should not be persisted, and they should not be used outside the current process.
 
  ]]></format>
         </remarks>

--- a/xml/System.Globalization/CompareInfo.xml
+++ b/xml/System.Globalization/CompareInfo.xml
@@ -1407,7 +1407,7 @@
 > [!IMPORTANT]
 > If two string objects are equal, the <xref:System.Globalization.CompareInfo.GetHashCode*> method returns identical values. However, there is not a unique hash code value for each unique string value. Different strings can return the same hash code.
 >
-> The hash code itself is not guaranteed to be stable. Hash codes for identical strings can differ across versions of .NET and across platforms (such as 32-bit and 64-bit) for a single version of .NET. As a result, hash codes should never be used outside of the application domain in which they were created, and they should never be persisted.
+> The hash code itself is not guaranteed to be stable. Hash codes for identical strings can differ across versions of .NET and across platforms (such as 32-bit and 64-bit) for a single version of .NET. Hash codes shouldn't be treated as unique identifiers, persisted, or used outside the current process.
 
  ]]></format>
         </remarks>

--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -1726,7 +1726,7 @@ csc /resource:GreetingStrings.resources Example1.cs
         <exception cref="T:System.Globalization.CultureNotFoundException">
           <paramref name="culture" /> specifies a culture that is not supported. See the Notes to Caller section for more information.</exception>
         <block subset="none" type="usage">
-          <para>This method method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="culture" /> from the operating system; if the operating system does not support that culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" />.</para>
+          <para>This method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="culture" /> from the operating system; if the operating system does not support that culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" />.</para>
           <para>A <see cref="T:System.Globalization.CultureNotFoundException" /> is also thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
         </block>
         <altmember cref="P:System.Globalization.CultureInfo.LCID" />

--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -169,13 +169,10 @@ Predefined culture identifiers for cultures available on Windows system are list
  For example, suppose that Arabic (Saudi Arabia) is the current Windows culture and the user has changed the calendar from Hijri to Gregorian.
 
 - With `CultureInfo("0x0401")` (culture name ar-SA), <xref:System.Globalization.CultureInfo.Calendar*> is set to <xref:System.Globalization.GregorianCalendar> (which is the user setting) and <xref:System.Globalization.CultureInfo.UseUserOverride*> is set to `true`.
-
 - With `CultureInfo("0x041E")` (culture name th-TH), <xref:System.Globalization.CultureInfo.Calendar*> is set to <xref:System.Globalization.ThaiBuddhistCalendar> (which is the default calendar for th-TH) and <xref:System.Globalization.CultureInfo.UseUserOverride*> is set to `true`.
 
- For cultures that use the euro, .NET Framework and Windows XP set the default currency as euro. However, older versions of Windows do not. Therefore, if the user of an older version of Windows has not changed the currency setting through the regional and language options portion of Control Panel, the currency might be incorrect. To use the .NET Framework default setting for the currency, the application should use a <xref:System.Globalization.CultureInfo> constructor overload that accepts a `useUserOverride` parameter and set it to `false`.
-
 > [!NOTE]
-> For backwards compatibility, a culture constructed using a `culture` parameter of 0x0004 or 0x7c04 will have a <xref:System.Globalization.CultureInfo.Name> property of `zh-CHS` or `zh-CHT`, respectively. You should instead prefer to construct the culture using the current standard culture names of `zh-Hans` or `zh-Hant`, unless you have a reason for using the older names.
+> For backwards compatibility, a culture constructed using a `culture` parameter of 0x0004 or 0x7c04 has a <xref:System.Globalization.CultureInfo.Name> property of `zh-CHS` or `zh-CHT`, respectively. You should instead prefer to construct the culture using the current standard culture names of `zh-Hans` or `zh-Hant`, unless you have a reason for using the older names.
 
 > [!NOTE]
 > LCIDs are being deprecated, and implementers are strongly encouraged to use newer versions of APIs that support BCP 47 locale names instead. Each LCID can be represented by a BCP 47 locale name, but the reverse is not true. The LCID range is restricted and unable to uniquely identify all the possible combinations of language and region.
@@ -187,8 +184,8 @@ Predefined culture identifiers for cultures available on Windows system are list
         <exception cref="T:System.Globalization.CultureNotFoundException">
           <paramref name="culture" /> is not a valid culture identifier. See the Notes to Callers section for more information.</exception>
         <block subset="none" type="usage">
-          <para>.NET Framework 3.5 and earlier versions throw an <see cref="T:System.ArgumentException" /> if <paramref name="culture" /> is not a valid culture identifier. Starting with .NET Framework 4, this constructor throws a <see cref="T:System.Globalization.CultureNotFoundException" />. Starting with apps that run under .NET Framework 4 or later on Windows 7 or later, the method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="culture" /> from the operating system; if the operating system does not support that culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" /> exception.</para>
-          <para>On .NET 6 and later versions, a <see cref="T:System.Globalization.CultureNotFoundException" /> is thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
+          <para>This method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="culture" /> from the operating system; if the operating system does not support that culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" /> exception.</para>
+          <para>A <see cref="T:System.Globalization.CultureNotFoundException" /> is also thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
         </block>
         <altmember cref="P:System.Globalization.CultureInfo.LCID" />
         <altmember cref="P:System.Globalization.CultureInfo.UseUserOverride" />
@@ -273,8 +270,8 @@ The <xref:System.Globalization.CultureInfo.LCID> property of the new <xref:Syste
         <exception cref="T:System.Globalization.CultureNotFoundException">
           <paramref name="name" /> is not a valid culture name. For more information, see the Notes to Callers section.</exception>
         <block subset="none" type="usage">
-          <para>.NET Framework 3.5 and earlier versions throw an <see cref="T:System.ArgumentException" /> if <paramref name="name" /> is not a valid culture name. Starting with .NET Framework 4, this constructor throws a <see cref="T:System.Globalization.CultureNotFoundException" />. Starting with apps that run under .NET Framework 4 or later on Windows 7 or later, the method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="name" /> from the operating system; if the operating system does not support that culture, and if <paramref name="name" /> is not the name of a supplementary or replacement culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" /> exception.</para>
-          <para>On .NET 6 and later versions, a <see cref="T:System.Globalization.CultureNotFoundException" /> is thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
+          <para>This method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="name" /> from the operating system; if the operating system does not support that culture, and if <paramref name="name" /> is not the name of a supplementary or replacement culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" /> exception.</para>
+          <para>A <see cref="T:System.Globalization.CultureNotFoundException" /> is also thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
         </block>
         <altmember cref="P:System.Globalization.CultureInfo.LCID" />
         <altmember cref="P:System.Globalization.CultureInfo.UseUserOverride" />
@@ -347,17 +344,12 @@ Predefined culture identifiers available on Windows systems are listed in the **
 
  The value of the `useUserOverride` parameter becomes the value of the <xref:System.Globalization.CultureInfo.UseUserOverride> property.
 
- For example, suppose that Arabic (Saudi Arabia) is the current culture of Windows and the user has changed the calendar from Hijri to Gregorian.
+For example, suppose that Arabic (Saudi Arabia) is the current culture of Windows and the user has changed the calendar from Hijri to Gregorian.
 
 - With `CultureInfo("0x0401", true)` (culture name ar-SA), <xref:System.Globalization.CultureInfo.Calendar*> is set to <xref:System.Globalization.GregorianCalendar> (which is the user setting) and <xref:System.Globalization.CultureInfo.UseUserOverride*> is set to `true`.
-
 - With `CultureInfo("0x0401", false)` (culture name ar-SA), <xref:System.Globalization.CultureInfo.Calendar*> is set to <xref:System.Globalization.HijriCalendar> (which is the default calendar for ar-SA) and <xref:System.Globalization.CultureInfo.UseUserOverride*> is set to `false`.
-
 - With `CultureInfo("0x041E", true)` (culture name th-TH), <xref:System.Globalization.CultureInfo.Calendar*> is set to <xref:System.Globalization.ThaiBuddhistCalendar> (which is the default calendar for th-TH) and <xref:System.Globalization.CultureInfo.UseUserOverride*> is set to `true`.
-
 - With `CultureInfo("0x041E", false)` (culture name th-TH), <xref:System.Globalization.CultureInfo.Calendar*> is set to <xref:System.Globalization.ThaiBuddhistCalendar> (which is the default calendar for th-TH) and <xref:System.Globalization.CultureInfo.UseUserOverride*> is set to `false`.
-
- For cultures that use the euro, the .NET Framework and Windows XP set the default currency as euro. However, older versions of Windows do not. Therefore, if the user of an older version of Windows has not changed the currency setting through the regional and language options portion of Control Panel, the currency might be incorrect. To use the .NET Framework default setting for the currency, the application should set the `useUserOverride` parameter to `false`.
 
 > [!NOTE]
 > For backwards compatibility, a culture constructed using a `culture` parameter of 0x0004 or 0x7c04 will have a <xref:System.Globalization.CultureInfo.Name> property of zh-CHS or zh-CHT, respectively. You should instead prefer to construct the culture using the current standard culture names of `zh-Hans` or zh-Hant, unless you have a reason for using the older names.
@@ -372,8 +364,8 @@ Predefined culture identifiers available on Windows systems are listed in the **
         <exception cref="T:System.Globalization.CultureNotFoundException">
           <paramref name="culture" /> is not a valid culture identifier. See the Notes to Callers section for more information.</exception>
         <block subset="none" type="usage">
-          <para>.NET Framework 3.5 and earlier versions throw an <see cref="T:System.ArgumentException" /> if <paramref name="culture" /> is not a valid culture identifier. Starting with .NET Framework 4, this constructor throws a <see cref="T:System.Globalization.CultureNotFoundException" />. Starting with apps that run under .NET Framework 4 or later on Windows 7 or later, the method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="culture" /> from the operating system; if the operating system does not support that culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" /> exception.</para>
-          <para>On .NET 6 and later versions, a <see cref="T:System.Globalization.CultureNotFoundException" /> is thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
+          <para>This method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="culture" /> from the operating system; if the operating system does not support that culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" /> exception.</para>
+          <para>A <see cref="T:System.Globalization.CultureNotFoundException" /> is also thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
         </block>
         <altmember cref="P:System.Globalization.CultureInfo.LCID" />
         <altmember cref="P:System.Globalization.CultureInfo.UseUserOverride" />
@@ -455,8 +447,6 @@ If `name` is <xref:System.String.Empty?displayProperty=nameWithType>, the constr
 
  The <xref:System.Globalization.CultureInfo.LCID> property of the new <xref:System.Globalization.CultureInfo> is set to the culture identifier associated with the specified name.
 
- For cultures that use the euro, the .NET Framework and Windows XP set the default currency as euro. However, older versions of Windows do not do this. Therefore, if the user of an older version of Windows has not changed the currency setting through the regional and language options portion of Control Panel, the currency might be incorrect. To use the .NET Framework default setting for the currency, the application should set the `useUserOverride` parameter to `false`.
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -464,8 +454,8 @@ If `name` is <xref:System.String.Empty?displayProperty=nameWithType>, the constr
         <exception cref="T:System.Globalization.CultureNotFoundException">
           <paramref name="name" /> is not a valid culture name. See the Notes to Callers section for more information.</exception>
         <block subset="none" type="usage">
-          <para>.NET Framework 3.5 and earlier versions throw an <see cref="T:System.ArgumentException" /> if <paramref name="name" /> is not a valid culture name. Starting with .NET Framework 4, this constructor throws a <see cref="T:System.Globalization.CultureNotFoundException" />. Starting with apps that run under .NET Framework 4 or later on Windows 7 or later, the method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="name" /> from the operating system; if the operating system does not support that culture, and if <paramref name="name" /> is not the name of a supplementary or replacement culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" /> exception.</para>
-          <para>On .NET 6 and later versions, a <see cref="T:System.Globalization.CultureNotFoundException" /> is thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
+          <para>This method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="name" /> from the operating system; if the operating system does not support that culture, and if <paramref name="name" /> is not the name of a supplementary or replacement culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" /> exception.</para>
+          <para>A <see cref="T:System.Globalization.CultureNotFoundException" /> is also thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
         </block>
         <altmember cref="P:System.Globalization.CultureInfo.LCID" />
         <altmember cref="P:System.Globalization.CultureInfo.UseUserOverride" />
@@ -814,13 +804,14 @@ If `name` is <xref:System.String.Empty?displayProperty=nameWithType>, the constr
 
  -or-
 
- The culture specified by <paramref name="name" /> does not have a specific culture associated with it.</exception>
+ The culture specified by <paramref name="name" /> does not have a specific culture associated with it.
+
+ -or-
+
+ The app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.
+ </exception>
         <exception cref="T:System.NullReferenceException">
           <paramref name="name" /> is null.</exception>
-        <block subset="none" type="usage">
-          <para>.NET Framework 3.5 and earlier versions throw an <see cref="T:System.ArgumentException" /> if <paramref name="name" /> is not a valid culture name. Starting with .NET Framework 4, this method throws a <see cref="T:System.Globalization.CultureNotFoundException" />.</para>
-          <para>On .NET 6 and later versions, a <see cref="T:System.Globalization.CultureNotFoundException" /> is thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
-        </block>
         <altmember cref="Overload:System.Globalization.CultureInfo.#ctor" />
         <altmember cref="P:System.Globalization.CultureInfo.Parent" />
       </Docs>
@@ -1126,32 +1117,31 @@ You might choose to override some of the values associated with the current cult
         <ReturnType>System.Globalization.CultureInfo</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets or sets the default culture for threads in the current application domain.</summary>
-        <value>The default culture for threads in the current application domain, or <see langword="null" /> if the current system culture is the default thread culture in the application domain.</value>
+        <summary>Gets or sets the default culture for threads.</summary>
+        <value>The default culture for threads, or <see langword="null" /> if the current system culture is the default thread culture.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- In the .NET Framework 4 and previous versions, by default, the culture of all threads is set to the Windows system culture. For applications whose current culture differs from the default system culture, this behavior is often undesirable. In the .NET Framework 4.5, the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> property enables an application to define the default culture of all threads in an application domain.
+
+The <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> property enables an application to define the default culture of all threads.
 
 > [!IMPORTANT]
-> If you have not explicitly set the culture of any existing threads executing in an application domain, setting the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> property also changes the culture of these threads. However, if these threads execute in another application domain, their culture is defined by the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> property in that application domain or, if no default value is defined, by the default system culture. Because of this, we recommend that you always explicitly set the culture of your main application thread, and not rely on the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> property to define the culture of the main application thread.
+> If you have not explicitly set the culture of any existing threads, setting the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> property also changes the culture of these threads. You should always explicitly set the culture of your main application thread, and not rely on the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> property to define the culture of the main application thread.
 
- Unless it is set explicitly, the value of the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> property is `null`, and the culture of threads in an application domain that have not been assigned an explicit culture is defined by the default Windows system culture.
+ Unless it is set explicitly, the value of the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> property is `null`, and the culture of threads that have not been assigned an explicit culture is defined by the default Windows system culture.
 
- For more information about cultures, threads, and application domains, see the "Culture and threads" and "Culture and application domains" sections in the <xref:System.Globalization.CultureInfo> reference page.
-
-
+ For more information about cultures and threads, see the "Culture and threads" section in the <xref:System.Globalization.CultureInfo> reference page.
 
 ## Examples
- The following example illustrates the default behavior of the .NET Framework in defining the current culture of a new thread. At startup, the example sets the current culture and the current UI culture to French (France) on all systems except those on which the default system culture is already French (France). If the default system culture is already French (France), the code sets the current culture and the current UI culture to English (United States). It then calls the `DisplayRandomNumbers` routine, which generates three random numbers and displays them as currency values. Next, it creates a new thread, which also executes the `DisplayRandomNumbers` routine.
+ The following example illustrates the default behavior of .NET in defining the current culture of a new thread. At startup, the example sets the current culture and the current UI culture to French (France) on all systems except those on which the default system culture is already French (France). If the default system culture is already French (France), the code sets the current culture and the current UI culture to English (United States). It then calls the `DisplayRandomNumbers` routine, which generates three random numbers and displays them as currency values. Next, it creates a new thread, which also executes the `DisplayRandomNumbers` routine.
 
  :::code language="csharp" source="~/snippets/csharp/System.Globalization/CultureInfo/DefaultThreadCurrentCulture/defaultculture1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CultureInfo/DefaultThreadCurrentCulture/defaultculture1.vb" id="Snippet1":::
 
  As the output from the example shows, when the example is run on a computer whose system culture is English (United States), the main thread displays its currency values using the formatting conventions of the French (France) culture. However, because the worker thread's culture is derived from the current Windows system culture rather than the application's current culture, the work thread displays its currency values using the formatting conventions of the English (United States) culture.
 
- The following example uses the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture*> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture*> properties  to define the current culture and current UI culture of a new application thread. At startup, the example sets the current culture and the current UI culture to French (France) on all systems except those on which the default system culture is already French (France). If the default system culture is already French (France), it sets the current culture and the current UI culture to English (United States). It then calls the `DisplayRandomNumbers` routine, which generates three random numbers and displays them as currency values. Next, it creates a new thread, which also executes the `DisplayRandomNumbers` routine.
+ The following example uses the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> properties  to define the current culture and current UI culture of a new application thread. At startup, the example sets the current culture and the current UI culture to French (France) on all systems except those on which the default system culture is already French (France). If the default system culture is already French (France), it sets the current culture and the current UI culture to English (United States). It then calls the `DisplayRandomNumbers` routine, which generates three random numbers and displays them as currency values. Next, it creates a new thread, which also executes the `DisplayRandomNumbers` routine.
 
  :::code language="csharp" source="~/snippets/csharp/System.Globalization/CultureInfo/DefaultThreadCurrentCulture/defaultculture2.cs" id="Snippet2":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/CultureInfo/DefaultThreadCurrentCulture/defaultculture2.vb" id="Snippet2":::
@@ -1211,20 +1201,21 @@ You might choose to override some of the values associated with the current cult
         <ReturnType>System.Globalization.CultureInfo</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets or sets the default UI culture for threads in the current application domain.</summary>
-        <value>The default UI culture for threads in the current application domain, or <see langword="null" /> if the current system UI culture is the default thread UI culture in the application domain.</value>
+        <summary>Gets or sets the default UI culture for threads.</summary>
+        <value>The default UI culture for threads, or <see langword="null" /> if the current system UI culture is the default thread UI culture.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- In the .NET Framework 4 and previous versions, by default, the UI culture of all threads is set to the Windows system culture. For applications whose current UI culture differs from the default system culture, this behavior is often undesirable. In .NET Framework 4.5+, the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> property lets you define the default UI culture of all threads in an application domain.
+
+The <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> property lets you define the default UI culture of all threads.
 
 > [!IMPORTANT]
-> If you have not explicitly set the UI culture of any existing threads executing in an application domain, setting the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> property also changes the culture of these threads. However, if these threads execute in another application domain, their culture is defined by the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> property in that application domain or, if no default value is defined, by the default system culture. Because of this, we recommend that you always explicitly set the culture of your main application thread and do not rely on the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> property to define the culture of the main application thread.
+> If you have not explicitly set the UI culture of any existing threads, setting the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> property also changes the culture of these threads. You should always explicitly set the culture of your main application thread, and not rely on the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> property to define the culture of the main application thread.
 
- Unless it is set explicitly, the value of the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> property is `null`, and the current culture of all threads in an application domain that have not been assigned an explicit culture is defined by the default Windows system culture.
+ Unless it is set explicitly, the value of the <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> property is `null`, and the current culture of all threads that have not been assigned an explicit culture is defined by the default Windows system culture.
 
- For more information about cultures, threads, and application domains, see the "Culture and threads" and "Culture and application domains" sections of <xref:System.Globalization.CultureInfo>.
+ For more information about cultures and threads, see the "Culture and threads" section of <xref:System.Globalization.CultureInfo>.
 
 ## Examples
  The following example illustrates the default behavior of .NET in defining the current culture of a new thread. It uses English and Russian language resources. The following text file named GreetingStrings.txt contains the English language resources:
@@ -1420,10 +1411,6 @@ csc /resource:GreetingStrings.resources Example1.cs
 
 ## Remarks
  For example, the <xref:System.Globalization.CultureInfo.EnglishName*> for the specific culture name en-US is "English (United States)".
-
- The value of this property is the same, regardless of the language version of the .NET Framework.
-
-
 
 ## Examples
  The following code example displays several properties of the neutral cultures.
@@ -1739,8 +1726,8 @@ csc /resource:GreetingStrings.resources Example1.cs
         <exception cref="T:System.Globalization.CultureNotFoundException">
           <paramref name="culture" /> specifies a culture that is not supported. See the Notes to Caller section for more information.</exception>
         <block subset="none" type="usage">
-          <para>.NET Framework 3.5 and earlier versions throw an <see cref="T:System.ArgumentException" /> if <paramref name="culture" /> is not a valid culture identifier. Starting with .NET Framework 4, this method throws a <see cref="T:System.Globalization.CultureNotFoundException" />. Starting with apps that run under .NET Framework 4 or later on Windows 7 or later, the method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="culture" /> from the operating system; if the operating system does not support that culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" />.</para>
-          <para>On .NET 6 and later versions, a <see cref="T:System.Globalization.CultureNotFoundException" /> is thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
+          <para>This method method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="culture" /> from the operating system; if the operating system does not support that culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" />.</para>
+          <para>A <see cref="T:System.Globalization.CultureNotFoundException" /> is also thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
         </block>
         <altmember cref="P:System.Globalization.CultureInfo.LCID" />
         <altmember cref="M:System.Globalization.CultureInfo.ClearCachedData" />
@@ -1811,8 +1798,8 @@ For a list of predefined culture names on Windows systems, see the **Language ta
         <exception cref="T:System.Globalization.CultureNotFoundException">
           <paramref name="name" /> specifies a culture that is not supported. See the Notes to Callers section for more information.</exception>
         <block subset="none" type="usage">
-          <para>.NET Framework 3.5 and earlier versions throw an <see cref="T:System.ArgumentException" /> if <paramref name="name" /> is not a valid culture name. Starting with .NET Framework 4, this method throws a <see cref="T:System.Globalization.CultureNotFoundException" />. Starting with apps that run under .NET Framework 4 or later on Windows 7 or later, the method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="name" /> from the operating system; if the operating system does not support that culture, and if <paramref name="name" /> is not the name of a supplementary or replacement culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" />.</para>
-          <para>On .NET 6 and later versions, a <see cref="T:System.Globalization.CultureNotFoundException" /> is thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
+          <para>This method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="name" /> from the operating system; if the operating system does not support that culture, and if <paramref name="name" /> is not the name of a supplementary or replacement culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" />.</para>
+          <para>A <see cref="T:System.Globalization.CultureNotFoundException" /> is also thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
         </block>
         <altmember cref="P:System.Globalization.CultureInfo.Name" />
       </Docs>
@@ -1931,8 +1918,8 @@ Setting `predefinedOnly` to `true` will ensure a culture is created only if the 
         <exception cref="T:System.Globalization.CultureNotFoundException">
           <paramref name="name" /> or <paramref name="altName" /> specifies a culture that is not supported. See the Notes to Callers section for more information.</exception>
         <block subset="none" type="usage">
-          <para>.NET Framework 3.5 and earlier versions throw an <see cref="T:System.ArgumentException" /> if <paramref name="name" /> or <paramref name="altName" /> is not a valid culture name. Starting with .NET Framework 4, this method throws a <see cref="T:System.Globalization.CultureNotFoundException" />. Starting with apps that run under .NET Framework 4 or later on Windows 7 or later, the method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="name" /> from the operating system; if the operating system does not support that culture, and if <paramref name="name" /> is not the name of a supplementary or replacement culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" /> exception.</para>
-          <para>On .NET 6 and later versions, a <see cref="T:System.Globalization.CultureNotFoundException" /> is thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
+          <para>This method attempts to retrieve a <see cref="T:System.Globalization.CultureInfo" /> object whose identifier is <paramref name="name" /> from the operating system; if the operating system does not support that culture, and if <paramref name="name" /> is not the name of a supplementary or replacement culture, the method throws a <see cref="T:System.Globalization.CultureNotFoundException" /> exception.</para>
+          <para>A <see cref="T:System.Globalization.CultureNotFoundException" /> is also thrown if the app is running in an environment where globalization-invariant mode is enabled, for example, some Docker containers, and a culture other than the invariant culture is specified.</para>
         </block>
         <altmember cref="P:System.Globalization.CultureInfo.Name" />
         <altmember cref="M:System.Globalization.CultureInfo.ClearCachedData" />
@@ -2005,9 +1992,6 @@ Setting `predefinedOnly` to `true` will ensure a culture is created only if the 
           <paramref name="name" /> is null.</exception>
         <exception cref="T:System.Globalization.CultureNotFoundException">
           <paramref name="name" /> does not correspond to a supported culture.</exception>
-        <block subset="none" type="usage">
-          <para>.NET Framework 3.5 and earlier versions throw an <see cref="T:System.ArgumentException" /> if <paramref name="name" /> does not correspond to the name of a supported culture. Starting with .NET Framework 4, this method throws a <see cref="T:System.Globalization.CultureNotFoundException" />.</para>
-        </block>
         <altmember cref="P:System.Globalization.CultureInfo.TextInfo" />
         <altmember cref="M:System.Globalization.CultureInfo.ClearCachedData" />
       </Docs>
@@ -2764,14 +2748,7 @@ For a list of predefined culture names and identifiers that the <xref:System.Glo
       <Docs>
         <summary>Gets the culture name, consisting of the language, the country/region, and the optional script, that the culture is set to display.</summary>
         <value>The culture name, consisting of the full name of the language, the full name of the country/region, and the optional script. The format is discussed in the description of the <see cref="T:System.Globalization.CultureInfo" /> class.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The value of this property is the same, regardless of the language version of the .NET Framework.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Globalization.CultureInfo.Name" />
         <altmember cref="P:System.Globalization.CultureInfo.DisplayName" />
         <altmember cref="P:System.Globalization.CultureInfo.EnglishName" />

--- a/xml/System.Globalization/CultureNotFoundException.xml
+++ b/xml/System.Globalization/CultureNotFoundException.xml
@@ -76,14 +76,12 @@
 ## Remarks
  A <xref:System.Globalization.CultureNotFoundException> exception is thrown whenever the construction of an invalid culture is eventually attempted within a method. Most commonly, this exception is thrown when a call to one of the following methods fails to create or return a culture:
 
--   <xref:System.Globalization.CultureInfo.%23ctor*?displayProperty=nameWithType> constructors.
-
+- <xref:System.Globalization.CultureInfo.%23ctor*?displayProperty=nameWithType> constructors.
 - The <xref:System.Globalization.CultureInfo.CreateSpecificCulture*?displayProperty=nameWithType> method.
-
 - The <xref:System.Globalization.CultureInfo.GetCultureInfo*?displayProperty=nameWithType> method.
 
 > [!WARNING]
->  On Windows 7 and later operating systems, the .NET Framework retrieves culture data from the operating system. The <xref:System.Globalization.CultureNotFoundException> exception is thrown if the operating system is unable to find the culture, and the culture is not a custom culture or a replacement culture.
+> .NET retrieves culture data from the operating system. The <xref:System.Globalization.CultureNotFoundException> exception is thrown if the operating system is unable to find the culture, and the culture is not a custom culture or a replacement culture.
 
  If the calling code attempted to instantiate a <xref:System.Globalization.CultureInfo> object by using a culture name, the <xref:System.Globalization.CultureNotFoundException.InvalidCultureName> property contains the invalid name, and the <xref:System.Nullable`1.HasValue> property of the <xref:System.Nullable`1> object returned by the <xref:System.Globalization.CultureNotFoundException.InvalidCultureId> property is `false`. If the calling code attempted to instantiate a <xref:System.Globalization.CultureInfo> object by using a culture identifier, the <xref:System.Nullable`1.Value> property of the <xref:System.Nullable`1> object returned by the <xref:System.Globalization.CultureNotFoundException.InvalidCultureId> property contains the invalid identifier, and the value of the <xref:System.Globalization.CultureNotFoundException.InvalidCultureName> property is `null`.
 

--- a/xml/System.Globalization/CultureTypes.xml
+++ b/xml/System.Globalization/CultureTypes.xml
@@ -131,7 +131,7 @@ The following example demonstrates the `CultureTypes.AllCultures` enumeration me
       <Docs>
         <summary>All cultures that are recognized by .NET, including neutral and specific cultures and custom cultures created by the user.
 
-On .NET Framework 4 and later versions and .NET Core running on Windows, it includes the culture data available from the Windows operating system. On .NET Core running on Linux and macOS, it includes culture data defined in the <see href="https://icu.unicode.org/">ICU libraries</see>.
+On Windows, it includes the culture data available from the Windows operating system. On Linux and macOS, it includes culture data defined in the <see href="https://icu.unicode.org/">ICU libraries</see>.
 
  <see cref="F:System.Globalization.CultureTypes.AllCultures" /> is a composite field that includes the <see cref="F:System.Globalization.CultureTypes.NeutralCultures" />, <see cref="F:System.Globalization.CultureTypes.SpecificCultures" />, and <see cref="F:System.Globalization.CultureTypes.InstalledWin32Cultures" /> values.</summary>
       </Docs>
@@ -183,7 +183,7 @@ On .NET Framework 4 and later versions and .NET Core running on Windows, it incl
       </ReturnValue>
       <MemberValue>64</MemberValue>
       <Docs>
-        <summary>**This member is deprecated**; using this value with <see cref="M:System.Globalization.CultureInfo.GetCultures(System.Globalization.CultureTypes)" /> returns neutral and specific cultures shipped with .NET Framework 2.0.</summary>
+        <summary>**This member is deprecated.** Specifies neutral and specific cultures shipped with .NET Framework 2.0.</summary>
       </Docs>
     </Member>
     <Member MemberName="InstalledWin32Cultures">
@@ -305,7 +305,7 @@ On .NET Framework 4 and later versions and .NET Core running on Windows, it incl
       </ReturnValue>
       <MemberValue>16</MemberValue>
       <Docs>
-        <summary>**This member is deprecated.** Custom cultures created by the user that replace cultures shipped with the .NET Framework.</summary>
+        <summary>**This member is deprecated.** Specifies custom cultures created by the user that replace cultures shipped with .NET.</summary>
       </Docs>
     </Member>
     <Member MemberName="SpecificCultures">
@@ -436,12 +436,10 @@ On .NET Framework 4 and later versions and .NET Core running on Windows, it incl
       </ReturnValue>
       <MemberValue>32</MemberValue>
       <Docs>
-        <summary>**This member is deprecated** and is ignored.</summary>
+        <summary>**This member is deprecated and ignored.**</summary>
         <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-If it is used as an argument to the <xref:System.Globalization.CultureInfo.GetCultures*?displayProperty=nameWithType> method on .NET Framework 4 and later versions, the method returns an empty array.
+If used as an argument to the <xref:System.Globalization.CultureInfo.GetCultures*?displayProperty=nameWithType> method, the method returns an empty array.
 
      ]]></format>
       </Docs>

--- a/xml/System.Globalization/CultureTypes.xml
+++ b/xml/System.Globalization/CultureTypes.xml
@@ -305,7 +305,7 @@ On Windows, it includes the culture data available from the Windows operating sy
       </ReturnValue>
       <MemberValue>16</MemberValue>
       <Docs>
-        <summary>**This member is deprecated.** Specifies custom cultures created by the user that replace cultures shipped with .NET.</summary>
+        <summary>**This member is deprecated.** Specifies custom cultures created by the user that replace cultures shipped with .NET Framework.</summary>
       </Docs>
     </Member>
     <Member MemberName="SpecificCultures">

--- a/xml/System.Globalization/EastAsianLunisolarCalendar.xml
+++ b/xml/System.Globalization/EastAsianLunisolarCalendar.xml
@@ -66,7 +66,7 @@
  The <xref:System.Globalization.EastAsianLunisolarCalendar> class supports the sexagenary cycle of years (which repeats every 60 years) in addition to solar years and lunar months. Each solar year in the calendar is associated with a Sexagenary Year (see <xref:System.Globalization.EastAsianLunisolarCalendar.GetSexagenaryYear*>), a Celestial Stem (see <xref:System.Globalization.EastAsianLunisolarCalendar.GetCelestialStem*>), and a Terrestrial Branch (see <xref:System.Globalization.EastAsianLunisolarCalendar.GetTerrestrialBranch*>).
 
 > [!NOTE]
->  For information about using the <xref:System.Globalization.EastAsianLunisolarCalendar> class and the other calendar classes in the .NET Framework, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
+> For information about using the <xref:System.Globalization.EastAsianLunisolarCalendar> class and the other calendar classes in .NET, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
 
  A year can have a leap month after any month of the year, and a month can have a leap day. For example, the <xref:System.Globalization.EastAsianLunisolarCalendar.GetMonth*> method returns a positive integer that indicates the month associated with a specified date. If there is a leap month between the eighth and ninth months of the year, the <xref:System.Globalization.EastAsianLunisolarCalendar.GetMonth*> method returns 8 for the eighth month, 9 for the leap eighth month, and 10 for the ninth month.
 

--- a/xml/System.Globalization/GregorianCalendar.xml
+++ b/xml/System.Globalization/GregorianCalendar.xml
@@ -73,7 +73,7 @@
  The Gregorian calendar recognizes two eras: B.C. or B.C.E., and A.D. or C.E. This implementation of the <xref:System.Globalization.GregorianCalendar> class recognizes only the current era (A.D. or C.E.).
 
 > [!NOTE]
->  For information about using the <xref:System.Globalization.GregorianCalendar> class and the other calendar classes in the .NET Framework, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
+> For information about using the <xref:System.Globalization.GregorianCalendar> class and the other calendar classes in .NET, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
 
  A leap year in the Gregorian calendar is defined as a year that is evenly divisible by 4, unless it is divisible by 100. However, years that are divisible by 400 are leap years. For example, the year 1900 was not a leap year, but the year 2000 was. A common year has 365 days and a leap year has 366 days.
 
@@ -82,7 +82,7 @@
 > [!IMPORTANT]
 >  By default, all <xref:System.DateTime> and <xref:System.DateTimeOffset> values express dates and times in the Gregorian calendar.
 
- The Gregorian calendar was developed as a replacement for the Julian calendar (which is represented by the <xref:System.Globalization.JulianCalendar> class) and was first introduced in a small number of cultures on October 15, 1582. When working with historic dates that precede a culture's adoption of the Gregorian calendar, you should use the original calendar if it is available in the .NET Framework. For example, Denmark changed from the Julian calendar to the Gregorian calendar on February 19 (in the Julian calendar) or March 1 (in the Gregorian calendar) of 1700. In this case, for dates before the adoption of the Gregorian calendar, you should use the Julian calendar. However, note that no culture offers intrinsic support for the <xref:System.Globalization.JulianCalendar> class. You must use the <xref:System.Globalization.JulianCalendar> class as a standalone calendar. For more information, see [Working with calendars](/dotnet/standard/datetime/working-with-calendars).
+ The Gregorian calendar was developed as a replacement for the Julian calendar (which is represented by the <xref:System.Globalization.JulianCalendar> class) and was first introduced in a small number of cultures on October 15, 1582. When working with historic dates that precede a culture's adoption of the Gregorian calendar, you should use the original calendar if it is available in .NET. For example, Denmark changed from the Julian calendar to the Gregorian calendar on February 19 (in the Julian calendar) or March 1 (in the Gregorian calendar) of 1700. In this case, for dates before the adoption of the Gregorian calendar, you should use the Julian calendar. However, no culture offers intrinsic support for the <xref:System.Globalization.JulianCalendar> class. You must use the <xref:System.Globalization.JulianCalendar> class as a standalone calendar. For more information, see [Working with calendars](/dotnet/standard/datetime/working-with-calendars).
 
  The following example illustrates that February 18, 1700 in the Julian calendar, which is the last day the Julian calendar was officially used in Denmark, is one day earlier than March 1, 1700 in the Gregorian calendar.
 
@@ -502,7 +502,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Examples
- The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type found in the .NET Framework and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
+ The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type in .NET and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
 
  :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/AlgorithmType/algorithmtype1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/AlgorithmType/algorithmtype1.vb" id="Snippet1":::

--- a/xml/System.Globalization/HebrewCalendar.xml
+++ b/xml/System.Globalization/HebrewCalendar.xml
@@ -73,7 +73,7 @@
  The Hebrew calendar recognizes two eras: B.C.E. (before the common era) and A.M. (Latin "Anno Mundi", which means "the year of the world"). This implementation of the <xref:System.Globalization.HebrewCalendar> class recognizes only the current era (A.M.) and the Hebrew years 5343 to 5999 (1583 to 2239 in the Gregorian calendar).
 
 > [!NOTE]
->  For information about using the <xref:System.Globalization.HebrewCalendar> class and the other calendar classes in the .NET Framework, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
+> For information about using the <xref:System.Globalization.HebrewCalendar> class and the other calendar classes in .NET, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
 
  In every 19-year cycle that ends with a year that is evenly divisible by 19, the 3rd, 6th, 8th, 11th, 14th, 17th, and 19th years are leap years. A common year can have from 353 to 355 days, depending on the placement of Jewish holidays. A leap year can have from 383 to 385 days.
 
@@ -390,7 +390,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Examples
- The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type found in the .NET Framework and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
+ The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type in .NET and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
 
  :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/AlgorithmType/algorithmtype1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/AlgorithmType/algorithmtype1.vb" id="Snippet1":::

--- a/xml/System.Globalization/HijriCalendar.xml
+++ b/xml/System.Globalization/HijriCalendar.xml
@@ -73,7 +73,7 @@
  The Hijri calendar recognizes one era: A.H. (Latin "Anno Hegirae", which means "the year of the migration," in reference to the migration of Muhammad (PBUH) from Mecca).
 
 > [!NOTE]
->  For information about using the <xref:System.Globalization.HijriCalendar> class and the other calendar classes in the .NET Framework, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
+> For information about using the <xref:System.Globalization.HijriCalendar> class and the other calendar classes in .NET, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
 
  In every 30-year cycle that ends with a year that is evenly divisible by 30, the 2nd, 5th, 7th, 10th, 13th, 16th, 18th, 21st, 24th, 26th, and 29th years are leap years. A common year has 354 days and a leap year has 355 days.
 
@@ -377,7 +377,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Examples
- The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type found in the .NET Framework and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
+ The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type in .NET and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
 
  :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/AlgorithmType/algorithmtype1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/AlgorithmType/algorithmtype1.vb" id="Snippet1":::

--- a/xml/System.Globalization/IdnMapping.xml
+++ b/xml/System.Globalization/IdnMapping.xml
@@ -73,19 +73,9 @@
 
  The IDNA mechanism uses Punycode to map an internationalized domain name that contains Unicode characters outside the US-ASCII character range to the US-ASCII character range supported by the domain name system. The IDNA mechanism is used to convert only domain names, not data transmitted over the Internet.
 
-> [!IMPORTANT]
->  In the .NET Framework 4.5, the <xref:System.Globalization.IdnMapping> class supports different versions of the IDNA standard, depending on the operating system in use:
->
-> - When run on Windows 8, it supports the 2008 version of the IDNA standard outlined by [RFC 5891: Internationalized Domain Names in Applications (IDNA): Protocol](https://datatracker.ietf.org/doc/html/rfc5891).
-> - When run on earlier versions of the Windows operating system, it supports the 2003 version of the standard outlined by [RFC 3490: Internationalizing Domain Names in Applications (IDNA)](https://www.rfc-editor.org/rfc/rfc3490.txt).
->
->  See [Unicode Technical Standard #46: IDNA Compatibility Processing](https://www.unicode.org/reports/tr46/) for the differences in the way these standards handle particular sets of characters.
-
  The <xref:System.Globalization.IdnMapping.GetAscii*?displayProperty=nameWithType> method normalizes a domain name, converts the normalized name to a representation that consists of displayable Unicode characters in the US-ASCII code point range (U+0020 to U+007E), and prepends an ASCII-compatible encoding (ACE) prefix ("xn--") to each label. The <xref:System.Globalization.IdnMapping.GetUnicode*?displayProperty=nameWithType> method restores the domain name labels converted by the <xref:System.Globalization.IdnMapping.GetAscii*> method.
 
  If the string to be converted includes the label separator characters IDEOGRAPHIC FULL STOP (U+3002), FULLWIDTH FULL STOP (U+FF0E), and HALFWIDTH IDEOGRAPHIC FULL STOP (U+FF61), the <xref:System.Globalization.IdnMapping.GetAscii*> method converts them to the label separator FULL STOP (period, U+002E). The <xref:System.Globalization.IdnMapping.GetUnicode*> method, however, does not restore the original label separator character.
-
-
 
 ## Examples
  The following example uses the <xref:System.Globalization.IdnMapping.GetAscii(System.String,System.Int32,System.Int32)> method to convert an array of internationalized domain names to Punycode. The <xref:System.Globalization.IdnMapping.GetUnicode*> method then converts the Punycode domain name back to the original domain name, but replaces the original label separators with the standard label separator.
@@ -354,15 +344,6 @@
           <paramref name="unicode" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="unicode" /> is invalid based on the <see cref="P:System.Globalization.IdnMapping.AllowUnassigned" /> and <see cref="P:System.Globalization.IdnMapping.UseStd3AsciiRules" /> properties, and the IDNA standard.</exception>
-        <block subset="none" type="usage">
-          <para>In the .NET Framework 4.5, the <see cref="T:System.Globalization.IdnMapping" /> class supports different versions of the IDNA standard, depending on the operating system in use:
-
-- When run on Windows 8, it supports the 2008 version of the IDNA standard outlined by <see href="https://datatracker.ietf.org/doc/html/rfc5891">RFC 5891: Internationalized Domain Names in Applications (IDNA): Protocol</see>.
-
-- When run on earlier versions of the Windows operating system, it supports the 2003 version of the standard outlined by <see href="https://www.rfc-editor.org/rfc/rfc3490.txt">RFC 3490: Internationalizing Domain Names in Applications (IDNA)</see>.
-
- See <see href="https://www.unicode.org/reports/tr46/">Unicode Technical Standard #46: IDNA Compatibility Processing</see> for the differences in the way these standards handle particular sets of characters.</para>
-        </block>
       </Docs>
     </Member>
     <Member MemberName="GetAscii">
@@ -448,15 +429,6 @@
  <paramref name="index" /> is greater than the length of <paramref name="unicode" />.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="unicode" /> is invalid based on the <see cref="P:System.Globalization.IdnMapping.AllowUnassigned" /> and <see cref="P:System.Globalization.IdnMapping.UseStd3AsciiRules" /> properties, and the IDNA standard.</exception>
-        <block subset="none" type="usage">
-          <para>In the .NET Framework 4.5, the <see cref="T:System.Globalization.IdnMapping" /> class supports different versions of the IDNA standard, depending on the operating system in use:
-
-- When run on Windows 8, it supports the 2008 version of the IDNA standard outlined by <see href="https://datatracker.ietf.org/doc/html/rfc5891">RFC 5891: Internationalized Domain Names in Applications (IDNA): Protocol</see>.
-
-- When run on earlier versions of the Windows operating system, it supports the 2003 version of the standard outlined by <see href="https://www.rfc-editor.org/rfc/rfc3490.txt">RFC 3490: Internationalizing Domain Names in Applications (IDNA)</see>.
-
- See <see href="https://www.unicode.org/reports/tr46/">Unicode Technical Standard #46: IDNA Compatibility Processing</see> for the differences in the way these standards handle particular sets of characters.</para>
-        </block>
       </Docs>
     </Member>
     <Member MemberName="GetAscii">
@@ -552,15 +524,6 @@
  <paramref name="index" /> is greater than the length of <paramref name="unicode" /> minus <paramref name="count" />.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="unicode" /> is invalid based on the <see cref="P:System.Globalization.IdnMapping.AllowUnassigned" /> and <see cref="P:System.Globalization.IdnMapping.UseStd3AsciiRules" /> properties, and the IDNA standard.</exception>
-        <block subset="none" type="usage">
-          <para>In the .NET Framework 4.5, the <see cref="T:System.Globalization.IdnMapping" /> class supports different versions of the IDNA standard, depending on the operating system in use:
-
-- When run on Windows 8, it supports the 2008 version of the IDNA standard outlined by <see href="https://datatracker.ietf.org/doc/html/rfc5891">RFC 5891: Internationalized Domain Names in Applications (IDNA): Protocol</see>.
-
-- When run on earlier versions of the Windows operating system, it supports the 2003 version of the standard outlined by <see href="https://www.rfc-editor.org/rfc/rfc3490.txt">RFC 3490: Internationalizing Domain Names in Applications (IDNA)</see>.
-
- See <see href="https://www.unicode.org/reports/tr46/">Unicode Technical Standard #46: IDNA Compatibility Processing</see> for the differences in the way these standards handle particular sets of characters.</para>
-        </block>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">

--- a/xml/System.Globalization/JapaneseCalendar.xml
+++ b/xml/System.Globalization/JapaneseCalendar.xml
@@ -1677,7 +1677,7 @@ The following code example gets the minimum value and the maximum value of the c
 The earliest date supported by the <xref:System.Globalization.JapaneseCalendar> class is October 23, 1868 C.E., in the first year of the Meiji era. Ordinarily, date and time operations that use the <xref:System.Globalization.JapaneseCalendar> class throw an <xref:System.ArgumentOutOfRangeException> exception for dates before this date. However, some members, such as the <xref:System.Globalization.JapaneseCalendar.GetEra*> method, support dates from January 1, 1868 through October 22 in the year Meiji 1.
 
 > [!NOTE]
-> In .NET Framework versions and in .NET Core 1.0 through .NET 10, this property returns a date and time representing the first moment of September 8, 1868 C.E. in the Gregorian calendar.
+> In .NET 10 and earlier versions, this property returns a date and time representing the first moment of September 8, 1868 C.E. in the Gregorian calendar.
 
 ## Examples
 

--- a/xml/System.Globalization/JulianCalendar.xml
+++ b/xml/System.Globalization/JulianCalendar.xml
@@ -73,7 +73,7 @@
  In 45 B.C., Julius Caesar ordered a calendar reform, which resulted in the calendar called the Julian calendar. The Julian calendar is the predecessor of the Gregorian calendar.
 
 > [!NOTE]
->  For information about using the <xref:System.Globalization.JulianCalendar> class and the other calendar classes in the .NET Framework, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
+> For information about using the <xref:System.Globalization.JulianCalendar> class and the other calendar classes in .NET, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
 
  The <xref:System.Globalization.JulianCalendar> class recognizes only the current era.
 
@@ -362,7 +362,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Examples
- The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type found in the .NET Framework and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
+ The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type in .NET and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
 
  :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/AlgorithmType/algorithmtype1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/AlgorithmType/algorithmtype1.vb" id="Snippet1":::

--- a/xml/System.Globalization/KoreanCalendar.xml
+++ b/xml/System.Globalization/KoreanCalendar.xml
@@ -73,7 +73,7 @@
  The Korean calendar is exactly like the Gregorian calendar, except that the year and era are different.
 
 > [!NOTE]
->  For information about using the <xref:System.Globalization.KoreanCalendar> class and the other calendar classes in the .NET Framework, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
+> For information about using the <xref:System.Globalization.KoreanCalendar> class and the other calendar classes in .NET, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
 
  The <xref:System.Globalization.KoreanCalendar> class recognizes only the current era.
 
@@ -378,7 +378,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Examples
- The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type found in the .NET Framework and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
+ The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type in .NET and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
 
  :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/AlgorithmType/algorithmtype1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/AlgorithmType/algorithmtype1.vb" id="Snippet1":::

--- a/xml/System.Globalization/KoreanLunisolarCalendar.xml
+++ b/xml/System.Globalization/KoreanLunisolarCalendar.xml
@@ -72,7 +72,7 @@
  The <xref:System.Globalization.KoreanLunisolarCalendar> class is derived from the <xref:System.Globalization.EastAsianLunisolarCalendar> class, which represents the lunisolar calendar. The <xref:System.Globalization.EastAsianLunisolarCalendar> class supports the sexagenary year cycle (which repeats every 60 years) in addition to solar years and lunar months. Each solar year in the calendar is associated with a Sexagenary Year, a Celestial Stem, and a Terrestrial Branch, and these calendars can have leap months after any month of the year.
 
 > [!NOTE]
->  For information about using the <xref:System.Globalization.KoreanLunisolarCalendar> class and the other calendar classes in the .NET Framework, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
+> For information about using the <xref:System.Globalization.KoreanLunisolarCalendar> class and the other calendar classes in .NET, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
 
  The <xref:System.Globalization.KoreanLunisolarCalendar> class calculates years using the Gregorian calendar, and days and months using the <xref:System.Globalization.EastAsianLunisolarCalendar> class.
 
@@ -423,7 +423,7 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-In .NET Framework, the earliest supported date and time supported is equivalent to the first moment of February 14, 918 C.E. in the Gregorian calendar. In .NET Core, it is equivalent to the first moment of February 19, 918 C.E.
+In .NET Framework, the earliest supported date and time is equivalent to the first moment of February 14, 918 C.E. in the Gregorian calendar. In .NET, it's equivalent to the first moment of February 19, 918 C.E.
 
          ]]></format>
         </remarks>

--- a/xml/System.Globalization/NumberFormatInfo.xml
+++ b/xml/System.Globalization/NumberFormatInfo.xml
@@ -590,7 +590,7 @@ On Windows, the initial value of this property is derived from the settings in t
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentOutOfRangeException">The property is set to a value that's less than 0 or greater than 16. On .NET Framework, this exception is thrown if the value is greater than 15.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException">The property is set to a value that's less than 0 or greater than 16.</exception>
         <exception cref="T:System.InvalidOperationException">The property is being set and the <see cref="T:System.Globalization.NumberFormatInfo" /> object is read-only.</exception>
         <altmember cref="P:System.Globalization.NumberFormatInfo.CurrencyDecimalDigits" />
         <altmember cref="P:System.Globalization.NumberFormatInfo.CurrencyDecimalSeparator" />

--- a/xml/System.Globalization/PersianCalendar.xml
+++ b/xml/System.Globalization/PersianCalendar.xml
@@ -334,10 +334,8 @@
 ## Remarks
  A date calculation for a particular calendar depends on whether the calendar is solar-based, lunar-based, or lunisolar-based.
 
-
-
 ## Examples
- The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type found in the .NET Framework and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
+ The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type in .NET and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
 
  :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/AlgorithmType/algorithmtype1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/AlgorithmType/algorithmtype1.vb" id="Snippet1":::
@@ -1252,12 +1250,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
- Starting with the .NET Framework 4.6, the implementation of the <xref:System.Globalization.PersianCalendar> class has changed from an observational algorithm to the Hijri solar algorithm. As a result, the <xref:System.Globalization.PersianCalendar.IsLeapYear*> method may return different values when run on .NET Framework 4.6 than when run on previous versions of the .NET Framework.
-
-
-
 ## Examples
+
  The following code example demonstrates the use of the <xref:System.Globalization.PersianCalendar.IsLeapYear*> method.
 
  :::code language="csharp" source="~/snippets/csharp/System.Globalization/PersianCalendar/Overview/pcal.cs" id="Snippet1":::
@@ -1320,11 +1314,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The value of the <xref:System.Globalization.PersianCalendar.MaxSupportedDateTime> property is the last moment of December 31, 9999 C.E. in the Gregorian calendar. In the .NET Framework 4.6, this value is equivalent to the 13th day of the 10th month of the year 9378 in the Persian calendar. In previous versions of the .NET Framework, it is equivalent to the 10th day of the 10th month of the year 9378 in the Persian calendar. For more information, see "The PersianCalendar class and .NET Framework versions" in the <xref:System.Globalization.PersianCalendar> topic.
-
- 9999 C.E. is equivalent to the year 9378 in the Persian calendar.
-
-
+ The value of the <xref:System.Globalization.PersianCalendar.MaxSupportedDateTime> property is the last moment of December 31, 9999 C.E. in the Gregorian calendar. This value is equivalent to the 13th day of the 10th month of the year 9378 in the Persian calendar.
 
 ## Examples
  The following code example demonstrates the use of the <xref:System.Globalization.PersianCalendar.MaxSupportedDateTime> property.
@@ -1384,11 +1374,10 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Starting with the .NET Framework 4.6, the value of the <xref:System.Globalization.PersianCalendar.MinSupportedDateTime> property is equivalent to the first moment of March 22, 622 C.E. in the Gregorian calendar. In previous versions of the .NET Framework, it is equivalent to the first moment of March 21, 622 C.E. in the Gregorian calendar. For more information, see "The PersianCalendar class and .NET Framework versions" in the <xref:System.Globalization.PersianCalendar> topic.
 
- 622 C.E. is equivalent to the year 0001 in the Persian calendar.
+The value of the <xref:System.Globalization.PersianCalendar.MinSupportedDateTime> property is equivalent to the first moment of March 22, 622 C.E. in the Gregorian calendar.
 
-
+622 C.E. is equivalent to the year 0001 in the Persian calendar.
 
 ## Examples
  The following code example demonstrates the use of the <xref:System.Globalization.PersianCalendar.MinSupportedDateTime> property.

--- a/xml/System.Globalization/RegionInfo.xml
+++ b/xml/System.Globalization/RegionInfo.xml
@@ -144,7 +144,7 @@
 
 The culture identifier is mapped to the corresponding National Language Support (NLS) locale identifier. For more information, see [Windows LCID reference](/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c).
 
-The value of the <xref:System.Globalization.RegionInfo.Name> property of the new <xref:System.Globalization.RegionInfo> object instantiated by calling this constructor is the ISO 3166 2-letter code for the country/region, not the combined language and country/region code. For example, if a <xref:System.Globalization.RegionInfo> object is instantiated with the culture identifier 0x0409 for the English (United States) culture, the value of the <xref:System.Globalization.RegionInfo.Name> property is "US". In contrast, if a <xref:System.Globalization.RegionInfo> object is instantiated with the combined language and country/region code `en-US` for the English (United States) culture, the value of the <xref:System.Globalization.RegionInfo.Name> property is "en-US" in .NET Framework and just "US" in .NET Core and .NET 5+.
+The value of the <xref:System.Globalization.RegionInfo.Name> property of the new <xref:System.Globalization.RegionInfo> object instantiated by calling this constructor is the ISO 3166 2-letter code for the country/region, not the combined language and country/region code. For example, if a <xref:System.Globalization.RegionInfo> object is instantiated with the culture identifier 0x0409 for the English (United States) culture, the value of the <xref:System.Globalization.RegionInfo.Name> property is "US". In contrast, if a <xref:System.Globalization.RegionInfo> object is instantiated with the combined language and country/region code `en-US` for the English (United States) culture, the value of the <xref:System.Globalization.RegionInfo.Name> property is "en-US" in .NET Framework and just "US" in modern .NET.
 
 ## Examples
 
@@ -1094,7 +1094,7 @@ The following code example displays the properties of the <xref:System.Globaliza
 
 If the current <xref:System.Globalization.RegionInfo> object is created with the <xref:System.Globalization.RegionInfo.%23ctor(System.Int32)?displayProperty=nameWithType> constructor that takes a culture identifier parameter, the <xref:System.Globalization.RegionInfo.Name> property value is one of the two-letter codes defined in ISO 3166 for the country/region and is formatted in uppercase. For example, the two-letter code for the United States is "US".
 
-If the current <xref:System.Globalization.RegionInfo> object is created with the <xref:System.Globalization.RegionInfo.%23ctor(System.String)?displayProperty=nameWithType> constructor and is passed a full culture name such as "en-US", the <xref:System.Globalization.RegionInfo.Name> property value is a full culture name in .NET Framework and just the region name in .NET Core and .NET 5+.
+If the current <xref:System.Globalization.RegionInfo> object is created with the <xref:System.Globalization.RegionInfo.%23ctor(System.String)?displayProperty=nameWithType> constructor and is passed a full culture name such as "en-US", the <xref:System.Globalization.RegionInfo.Name> property value is a full culture name in .NET Framework and just the region name in modern .NET.
 
 ## Examples
 

--- a/xml/System.Globalization/StringInfo.xml
+++ b/xml/System.Globalization/StringInfo.xml
@@ -108,7 +108,7 @@ This example uses the <xref:System.Globalization.StringInfo.GetTextElementEnumer
  ]]></format>
     </remarks>
     <block subset="none" type="usage">
-      <para>Internally, the methods of the <see cref="T:System.Globalization.StringInfo" /> class call the methods of the <see cref="T:System.Globalization.CharUnicodeInfo" /> class to determine character categories. Starting with the .NET Framework 4.6.2, character classification is based on <see href="https://unicode.org/versions/Unicode8.0.0">The Unicode Standard, Version 8.0.0</see>. For the .NET Framework 4 through the .NET Framework 4.6.1, it is based on <see href="https://www.unicode.org/versions/Unicode6.3.0/">The Unicode Standard, Version 6.3.0</see>. In .NET Core, it is based on <see href="https://unicode.org/versions/Unicode8.0.0">The Unicode Standard, Version 8.0.0</see>.</para>
+      <para>Internally, the methods of the <see cref="T:System.Globalization.StringInfo" /> class call the methods of the <see cref="T:System.Globalization.CharUnicodeInfo" /> class to determine character categories. In modern .NET, character classification is based on <see href="https://unicode.org/versions/Unicode8.0.0">The Unicode Standard, Version 8.0.0</see>.</para>
     </block>
     <related type="ExternalDocumentation" href="https://www.microsoft.com/download/details.aspx?id=10921">Sorting Weight Tables for Windows operating systems</related>
     <related type="ExternalDocumentation" href="https://www.unicode.org/Public/UCA/latest/allkeys.txt">Default Unicode Collation Element Table, for Linux and macOS</related>
@@ -903,10 +903,9 @@ A grapheme cluster is a sequence of one or more Unicode code points that should 
 
  The length of each element is easily computed as the difference between successive indexes. The length of the array will always be less than or equal to the length of the string. For example, given the string "\u4f00\u302a\ud800\udc00\u4f01", this method returns the indexes 0, 2, and 4.
 
-## Equivalent Members
- Starting in version 2.0 of the .NET Framework, the <xref:System.Globalization.StringInfo.SubstringByTextElements*> method and <xref:System.Globalization.StringInfo.LengthInTextElements> property provide an easy to use implementation of the functionality offered by the <xref:System.Globalization.StringInfo.ParseCombiningCharacters*> method.
+## Equivalent members
 
-
+The <xref:System.Globalization.StringInfo.SubstringByTextElements*> method and <xref:System.Globalization.StringInfo.LengthInTextElements> property provide an easy to use implementation of the functionality offered by the <xref:System.Globalization.StringInfo.ParseCombiningCharacters*> method.
 
 ## Examples
  The following example demonstrates calling the <xref:System.Globalization.StringInfo.ParseCombiningCharacters*> method. This code example is part of a larger example provided for the <xref:System.Globalization.StringInfo> class.

--- a/xml/System.Globalization/TaiwanCalendar.xml
+++ b/xml/System.Globalization/TaiwanCalendar.xml
@@ -73,7 +73,7 @@
  The Taiwan calendar works exactly like the Gregorian calendar, except that the year and era are different. The <xref:System.Globalization.TaiwanCalendar> class recognizes only the current era.
 
 > [!NOTE]
->  For information about using the <xref:System.Globalization.TaiwanCalendar> class and the other calendar classes in the .NET Framework, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
+> For information about using the <xref:System.Globalization.TaiwanCalendar> class and the other calendar classes in .NET, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
 
  Leap years in the Taiwan calendar correspond to the same leap years in the Gregorian calendar. A leap year in the Gregorian calendar is defined as a Gregorian year that is evenly divisible by four, except if it is divisible by 100. However, Gregorian years that are divisible by 400 are leap years. A common year has 365 days and a leap year has 366 days.
 
@@ -368,7 +368,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Examples
- The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type found in the .NET Framework and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
+ The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type in .NET and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
 
  :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/AlgorithmType/algorithmtype1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/AlgorithmType/algorithmtype1.vb" id="Snippet1":::

--- a/xml/System.Globalization/TaiwanLunisolarCalendar.xml
+++ b/xml/System.Globalization/TaiwanLunisolarCalendar.xml
@@ -72,7 +72,7 @@
  The Taiwan lunisolar calendar works exactly like the Gregorian calendar, except that the year and era are different. The <xref:System.Globalization.TaiwanLunisolarCalendar> class calculates years using the Gregorian calendar, days and months using the <xref:System.Globalization.EastAsianLunisolarCalendar> class, and recognizes only the current era.
 
 > [!NOTE]
->  For information about using the <xref:System.Globalization.TaiwanLunisolarCalendar> class and the other calendar classes in the .NET Framework, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
+> For information about using the <xref:System.Globalization.TaiwanLunisolarCalendar> class and the other calendar classes in .NET, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
 
  The <xref:System.Globalization.TaiwanLunisolarCalendar> class is derived from the <xref:System.Globalization.EastAsianLunisolarCalendar> class, which represents the lunisolar calendar. The <xref:System.Globalization.EastAsianLunisolarCalendar> class supports the sexagenary year cycle (which repeats every 60 years) in addition to solar years and lunar months. Each solar year in the calendar is associated with a Sexagenary Year, a Celestial Stem, and a Terrestrial Branch, and these calendars can have leap months after any month of the year.
 

--- a/xml/System.Globalization/TextElementEnumerator.xml
+++ b/xml/System.Globalization/TextElementEnumerator.xml
@@ -78,7 +78,7 @@
 .NET defines a text element as a unit of text that's displayed as a single character, that is, a grapheme. A text element can be any of the following:
 
 - A base character, which is represented as a single <xref:System.Char> value. For example, LATIN CAPITAL LETTER A (U+0041) and LATIN SMALL LETTER AE (U+00E6) are base characters.
-- A combining character sequence, which consists of a base character and one or more combining characters. For example, example, LATIN CAPITAL LETTER A (U+0041) followed by COMBINING MACRON (U+0304) is a combining character sequence.
+- A combining character sequence, which consists of a base character and one or more combining characters. For example, LATIN CAPITAL LETTER A (U+0041) followed by COMBINING MACRON (U+0304) is a combining character sequence.
 - Surrogate pairs, which the [Unicode Standard](https://www.unicode.org/) defines as a coded character representation for a single abstract character that consists of a sequence of two code units: a high surrogate, and a low surrogate. Surrogate pairs are used to represent characters outside of the Unicode Basic Multilingual Plane as UTF-16 encoded characters. For example, GOTHIC LETTER SAUIL (U+10343) is represented in UTF-16 encoding as a high surrogate whose value is 0xD800 and a low surrogate whose value is 0xDF43. A surrogate pair can represent a base character or a combining character.
 
  The <xref:System.Globalization.TextElementEnumerator> class allows you to work with the text elements in a string rather than with single <xref:System.Char> objects.

--- a/xml/System.Globalization/TextElementEnumerator.xml
+++ b/xml/System.Globalization/TextElementEnumerator.xml
@@ -74,12 +74,11 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The .NET Framework defines a text element as a unit of text that is displayed as a single character, that is, a grapheme. A text element can be any of the following:
+
+.NET defines a text element as a unit of text that's displayed as a single character, that is, a grapheme. A text element can be any of the following:
 
 - A base character, which is represented as a single <xref:System.Char> value. For example, LATIN CAPITAL LETTER A (U+0041) and LATIN SMALL LETTER AE (U+00E6) are base characters.
-
 - A combining character sequence, which consists of a base character and one or more combining characters. For example, example, LATIN CAPITAL LETTER A (U+0041) followed by COMBINING MACRON (U+0304) is a combining character sequence.
-
 - Surrogate pairs, which the [Unicode Standard](https://www.unicode.org/) defines as a coded character representation for a single abstract character that consists of a sequence of two code units: a high surrogate, and a low surrogate. Surrogate pairs are used to represent characters outside of the Unicode Basic Multilingual Plane as UTF-16 encoded characters. For example, GOTHIC LETTER SAUIL (U+10343) is represented in UTF-16 encoding as a high surrogate whose value is 0xD800 and a low surrogate whose value is 0xDF43. A surrogate pair can represent a base character or a combining character.
 
  The <xref:System.Globalization.TextElementEnumerator> class allows you to work with the text elements in a string rather than with single <xref:System.Char> objects.
@@ -91,14 +90,9 @@
  The <xref:System.Globalization.TextElementEnumerator> object represents a snapshot of the current state of a string variable or string literal at the moment that the <xref:System.Globalization.TextElementEnumerator> object is instantiated. Note that:
 
 - Text element enumerators can only be used to read data in a string. They cannot modify the underlying string.
-
 - An enumerator does not have exclusive access to the string that it represents. A string variable can be modified after the enumerator is created.
-
 - A <xref:System.Globalization.TextElementEnumerator> object enumerates the text elements present in the string at the time that the <xref:System.Globalization.TextElementEnumerator> object was instantiated. It does not reflect any subsequent changes to the string variable if that variable is modified afterward.
-
 - Because the <xref:System.Globalization.TextElementEnumerator> class does not override <xref:System.Object.Equals*?displayProperty=nameWithType>, two <xref:System.Globalization.TextElementEnumerator> objects that represent the same string will be considered unequal.
-
-
 
 ## Examples
  The following example uses the <xref:System.Globalization.TextElementEnumerator> class to enumerate the text elements of a string.

--- a/xml/System.Globalization/ThaiBuddhistCalendar.xml
+++ b/xml/System.Globalization/ThaiBuddhistCalendar.xml
@@ -73,7 +73,7 @@
  The Thai Buddhist calendar works exactly like the Gregorian calendar, except that the year and era are different.
 
 > [!NOTE]
->  For information about using the <xref:System.Globalization.ThaiBuddhistCalendar> class and the other calendar classes in the .NET Framework, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
+> For information about using the <xref:System.Globalization.ThaiBuddhistCalendar> class and the other calendar classes in .NET, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
 
  The <xref:System.Globalization.ThaiBuddhistCalendar> class recognizes only the current era.
 
@@ -365,7 +365,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Examples
- The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type found in the .NET Framework and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
+ The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type in .NET and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
 
  :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/AlgorithmType/algorithmtype1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/AlgorithmType/algorithmtype1.vb" id="Snippet1":::

--- a/xml/System.Globalization/UmAlQuraCalendar.xml
+++ b/xml/System.Globalization/UmAlQuraCalendar.xml
@@ -72,7 +72,7 @@
  The <xref:System.Globalization.UmAlQuraCalendar> class is nearly identical to the <xref:System.Globalization.HijriCalendar> class, except the Um Al Qura calendar uses a table-based algorithm licensed from the Saudi government to calculate dates, can express dates to the year 1500 A.H., and does not support the <xref:System.Globalization.HijriCalendar.HijriAdjustment> property.
 
 > [!NOTE]
->  For information about using the <xref:System.Globalization.UmAlQuraCalendar> class and the other calendar classes in the .NET Framework, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
+> For information about using the <xref:System.Globalization.UmAlQuraCalendar> class and the other calendar classes in .NET, see [Working with Calendars](/dotnet/standard/datetime/working-with-calendars).
 
  For the <xref:System.Globalization.UmAlQuraCalendar> class, each month has either 29 or 30 days, but usually in no discernible order. Whereas the documentation for the Hijri Calendar gives a table that shows the corresponding days in each month, no such general table can be produced for the Um Al Qura calendar.
 
@@ -342,7 +342,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Examples
- The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type found in the .NET Framework and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
+ The following example uses reflection to instantiate each <xref:System.Globalization.Calendar> type in .NET and displays the value of its <xref:System.Globalization.Calendar.AlgorithmType> property.
 
  :::code language="csharp" source="~/snippets/csharp/System.Globalization/Calendar/AlgorithmType/algorithmtype1.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Globalization/Calendar/AlgorithmType/algorithmtype1.vb" id="Snippet1":::
@@ -1375,13 +1375,6 @@
         <value>The latest date and time supported by the <see cref="T:System.Globalization.UmAlQuraCalendar" /> class, which is equivalent to the last moment of November 16, 2077 C.E. in the Gregorian calendar.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!NOTE]
->  Starting with the .NET Framework 4.5, the value of the <xref:System.Globalization.UmAlQuraCalendar.MaxSupportedDateTime> property is 11/16/2077. In previous versions of the .NET Framework, its value is the last moment of May 13, 2029 C.E. in the Gregorian calendar.
-
-
 
 ## Examples
  The following example displays the date ranges supported by the <xref:System.Globalization.UmAlQuraCalendar> class in both the Gregorian and Um Al Qura calendars.


### PR DESCRIPTION
.NET Framework API ref has moved to its own repo (https://github.com/dotnet/dotnetfw-api-docs), so we can clean up .NET Framework remarks, exceptions, and code examples out of this repo. Contributes to #12513.

Removes remarks related to:

- .NET Framework versions
- Code-access security
- Configuring apps via app.config file
- App domains

*Hide whitespace changes*