### PR TITLE
Add use with trusted files remark to FileVersionInfo.GetVersionInfo

### DIFF
--- a/xml/System.Diagnostics/FileVersionInfo.xml
+++ b/xml/System.Diagnostics/FileVersionInfo.xml
@@ -725,7 +725,7 @@
 ## Remarks
 
 > [!CAUTION]
-> Use this with only trusted files. Malformed or malicious files can cause unexpected behavior.
+> Use this method only with trusted files. Malformed or malicious files can cause unexpected behavior.
 
 ## Examples
  The following example calls <xref:System.Diagnostics.FileVersionInfo.GetVersionInfo*> to get the <xref:System.Diagnostics.FileVersionInfo> for Notepad and  displays the file description and version number in the console window.

--- a/xml/System.Diagnostics/FileVersionInfo.xml
+++ b/xml/System.Diagnostics/FileVersionInfo.xml
@@ -722,6 +722,11 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
+## Remarks
+
+> [!CAUTION]
+> Use this with only trusted files. Malformed or malicious files can cause unexpected behavior.
+
 ## Examples
  The following example calls <xref:System.Diagnostics.FileVersionInfo.GetVersionInfo*> to get the <xref:System.Diagnostics.FileVersionInfo> for Notepad and  displays the file description and version number in the console window.
 


### PR DESCRIPTION
## Summary

Add a small remark about using trusted files when calling FileVersionInfo.GetVersionInfo.

<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

