### PR TITLE
Remove .NET Framework remarks (System.Configuration)

### DIFF
--- a/xml/System.Configuration/AppSettingsReader.xml
+++ b/xml/System.Configuration/AppSettingsReader.xml
@@ -33,57 +33,7 @@
   <Interfaces />
   <Docs>
     <summary>Provides a method for reading values of a particular type from the configuration.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[
-
-## Examples
- The following example creates a configuration file that contains the `<appSettings>` section, and then uses the <xref:System.Configuration.AppSettingsReader> to read the settings just generated.
-
-```csharp
-using System;
-using System.Configuration;
-
-class Program
-{
-    static void Main(string[] args)
-    {
-        var reader = new AppSettingsReader();
-
-        var stringSetting = reader.GetValue("String setting", typeof(string));
-        Console.WriteLine("String setting: " + stringSetting);
-
-        var dateTimeSetting = reader.GetValue("DateTime setting", typeof(DateTime));
-        Console.WriteLine("DateTime setting: " + dateTimeSetting);
-
-        try
-        {
-            var missingSetting = reader.GetValue("Int setting", typeof(Int32));
-        }
-        catch (InvalidOperationException e)
-        {
-            Console.WriteLine("Missing key error: " + e.Message);
-        }
-
-        Console.WriteLine("Press any key to continue");
-        Console.ReadKey();
-    }
-}
-```
-
- The following example demonstrates a configuration file used by the previous example.
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <appSettings>
-        <add key="String setting" value="String retrieved from App.Config"/>
-        <add key="Date setting" value="Thursday, December 01, 2005 12:53:56 PM"/>
-    </appSettings>
-</configuration>
-```
-
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
     <altmember cref="T:System.Configuration.AppSettingsSection" />
   </Docs>
   <Members>
@@ -115,57 +65,7 @@ class Program
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Configuration.AppSettingsReader" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Examples
- The following example creates a configuration file that contains the `<appSettings>` section, and then uses the <xref:System.Configuration.AppSettingsReader> to read the settings just generated.
-
-```csharp
-using System;
-using System.Configuration;
-
-class Program
-{
-    static void Main(string[] args)
-    {
-        var reader = new AppSettingsReader();
-
-        var stringSetting = reader.GetValue("String setting", typeof(string));
-        Console.WriteLine("String setting: " + stringSetting);
-
-        var dateTimeSetting = reader.GetValue("DateTime setting", typeof(DateTime));
-        Console.WriteLine("DateTime setting: " + dateTimeSetting);
-
-        try
-        {
-            var missingSetting = reader.GetValue("Int setting", typeof(Int32));
-        }
-        catch (InvalidOperationException e)
-        {
-            Console.WriteLine("Missing key error: " + e.Message);
-        }
-
-        Console.WriteLine("Press any key to continue");
-        Console.ReadKey();
-    }
-}
-```
-
- The following example demonstrates a configuration file used by the previous example.
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <appSettings>
-        <add key="String setting" value="String retrieved from App.Config"/>
-        <add key="Date setting" value="Thursday, December 01, 2005 12:53:56 PM"/>
-    </appSettings>
-</configuration>
-```
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="T:System.Configuration.AppSettingsSection" />
       </Docs>
     </Member>

--- a/xml/System.Configuration/AppSettingsSection.xml
+++ b/xml/System.Configuration/AppSettingsSection.xml
@@ -32,26 +32,7 @@
   <Interfaces />
   <Docs>
     <summary>Provides configuration system support for the <see langword="appSettings" /> configuration section. This class cannot be inherited.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[
-
-## Remarks
- The `appSettings` configuration section provides for key/value pairs of `string` values for an application. Rather than accessing these values by using an instance of an <xref:System.Configuration.AppSettingsSection> object, you should use the <xref:System.Configuration.ConfigurationManager.AppSettings> property of the <xref:System.Configuration.ConfigurationManager> class or the <xref:System.Web.Configuration.WebConfigurationManager.AppSettings> property of the <xref:System.Web.Configuration.WebConfigurationManager> class.
-
-
-
-## Examples
- The following example shows how to use the <xref:System.Configuration.AppSettingsSection> class in a console application. It reads and writes the key/value pairs that are contained by the `appSettings` section. It also shows how to access the <xref:System.Configuration.AppSettingsSection.File> property of the <xref:System.Configuration.AppSettingsSection> class.
-
-> [!NOTE]
->  Before you compile this code, add a reference in your project to System.Configuration.dll.
-
- :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WebNet/System.Configuration.AppSettingsSection/CS/UsingAppSettingsSection.cs" id="Snippet21":::
- :::code language="vb" source="~/snippets/visualbasic/VS_Snippets_WebNet/System.Configuration.AppSettingsSection/VB/AppSettingsSection.vb" id="Snippet21":::
- :::code language="vb" source="~/snippets/visualbasic/VS_Snippets_WebNet/System.Configuration.AppSettingsSection/VB/UsingAppSettingsSection.vb" id="Snippet21":::
-
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
     <altmember cref="T:System.Configuration.ConfigurationManager" />
   </Docs>
   <Members>

--- a/xml/System.Configuration/ApplicationSettingsBase.xml
+++ b/xml/System.Configuration/ApplicationSettingsBase.xml
@@ -246,7 +246,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This constructor initializes the <xref:System.Configuration.ApplicationSettingsBase.SettingsKey> property to the value of the `settingsKey` parameter. This property is useful in disambiguating different instances of the settings wrapper class in the same application domain.
+ This constructor initializes the <xref:System.Configuration.ApplicationSettingsBase.SettingsKey> property to the value of the `settingsKey` parameter. This property is useful in disambiguating different instances of the settings wrapper class.
 
  For information about how reflection is used during the instantiation of a wrapper class, see the default <xref:System.Configuration.ApplicationSettingsBase.%23ctor> constructor.
 
@@ -294,7 +294,7 @@
 ## Remarks
  The <xref:System.ComponentModel.IComponent> object specified by the `owner` parameter acts as the owner of the current instance of this applications settings class. During the initialization of the settings wrapper class derived from <xref:System.Configuration.ApplicationSettingsBase>, the owner's site is queried for a <xref:System.Configuration.ISettingsProviderService>. If one exists, it is used in preference to native settings provider for all the properties of the wrapper class, as specified by the <xref:System.Configuration.SettingsProviderAttribute>.
 
- This constructor initializes the <xref:System.Configuration.ApplicationSettingsBase.SettingsKey> property to the value of the `settingsKey` parameter. This property is useful in disambiguating different instances of the wrapper class in the same application domain.
+ This constructor initializes the <xref:System.Configuration.ApplicationSettingsBase.SettingsKey> property to the value of the `settingsKey` parameter. This property is useful in disambiguating different instances of the wrapper class.
 
  For information about how reflection is used during the instantiation of a wrapper class, see the default <xref:System.Configuration.ApplicationSettingsBase.%23ctor> constructor.
 

--- a/xml/System.Configuration/ClientSettingsSection.xml
+++ b/xml/System.Configuration/ClientSettingsSection.xml
@@ -36,11 +36,10 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The .NET Framework contains a single default settings provider, <xref:System.Configuration.LocalFileSettingsProvider>, which stores configuration data to the local file system in files with the extension `.config`. The contents of configuration files are structured as XML documents. User-scoped settings are persisted in a file with the name `username.config`. Within this file, data is stored as elements within a `<userSettings>` section. Each of these sections is represented by a corresponding <xref:System.Configuration.ClientSettingsSection>. Each section object is owned and administered by a configuration section handler, which is an <xref:System.Configuration.IConfigurationSectionHandler>.
 
- The <xref:System.Configuration.ClientSettingsSection> class represents a simple extension of the <xref:System.Configuration.ConfigurationSection> class, which is used in the .NET Framework support for general configuration files.
+.NET contains a single default settings provider, <xref:System.Configuration.LocalFileSettingsProvider>, which stores configuration data to the local file system in files with the extension `.config`. The contents of configuration files are structured as XML documents. User-scoped settings are persisted in a file with the name `username.config`. Within this file, data is stored as elements within a `<userSettings>` section. Each of these sections is represented by a corresponding <xref:System.Configuration.ClientSettingsSection>. Each section object is owned and administered by a configuration section handler, which is an <xref:System.Configuration.IConfigurationSectionHandler>.
 
- For more information about application settings, see the topic [Application Settings for Windows Forms](/dotnet/desktop/winforms/advanced/application-settings-for-windows-forms).
+ The <xref:System.Configuration.ClientSettingsSection> class represents a simple extension of the <xref:System.Configuration.ConfigurationSection> class, which is used in the .NET support for general configuration files.
 
  ]]></format>
     </remarks>

--- a/xml/System.Configuration/Configuration.xml
+++ b/xml/System.Configuration/Configuration.xml
@@ -173,7 +173,7 @@ Note: If you use a static <see langword="GetSection" /> method that takes a path
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This property enables a consumer of the .NET configuration system to set a function delegate that is used to transform assembly strings found in configuration files. The function makes sure that assembly strings are formatted correctly for the targeted version of the .NET when configuration files are updated.
+ This property enables a consumer of the .NET configuration system to set a function delegate that is used to transform assembly strings found in configuration files. The function makes sure that assembly strings are formatted correctly for the targeted version of .NET when configuration files are updated.
 
  ]]></format>
         </remarks>

--- a/xml/System.Configuration/Configuration.xml
+++ b/xml/System.Configuration/Configuration.xml
@@ -43,7 +43,6 @@
  You can get a <xref:System.Configuration.Configuration> object by using the following classes:
 
 - The <xref:System.Configuration.ConfigurationManager> class, if your entity is a client application.
-
 - The <xref:System.Web.Configuration.WebConfigurationManager> class, if your entity is a Web application.
 
  The names of the methods that return a <xref:System.Configuration.Configuration> object begin with "Open".
@@ -51,15 +50,12 @@
  You can also generate a configuration file that represents the configuration settings in a <xref:System.Configuration.Configuration> object. To do this, use one of the following methods:
 
 - Call the <xref:System.Configuration.Configuration.Save*> method to create a new configuration file.
-
 - Call the <xref:System.Configuration.Configuration.SaveAs*> method to generate a new configuration file at another location.
 
  The names of the methods that create configuration files begin with "Save".
 
 > [!NOTE]
->  To enable access to configuration settings on a remote computer, use the Aspnet_regiis command-line tool. For information about creating and accessing custom configuration settings other than the intrinsic sections included in the .NET Framework, refer to <xref:System.Configuration.ConfigurationSection>.
-
-
+> To enable access to configuration settings on a remote computer, use the Aspnet_regiis command-line tool. For information about creating and accessing custom configuration settings other than the intrinsic sections included in .NET, see <xref:System.Configuration.ConfigurationSection>.
 
 ## Examples
  The following code example demonstrates how to use the <xref:System.Configuration.Configuration> class to access configuration file elements.
@@ -92,7 +88,6 @@ Note: If you use a static <see langword="GetSection" /> method that takes a path
     </block>
     <altmember cref="T:System.Configuration.ConfigurationSection" />
     <altmember cref="T:System.Configuration.ConfigurationManager" />
-    <related type="Article" href="/dotnet/framework/configure-apps/">Configuration Files</related>
   </Docs>
   <Members>
     <Member MemberName="AppSettings">
@@ -178,7 +173,7 @@ Note: If you use a static <see langword="GetSection" /> method that takes a path
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This property enables a consumer of the .NET Framework configuration system to set a function delegate that is used to transform assembly strings found in configuration files. Visual Studio 2010 uses this property when a project is targeted for an earlier version of the .NET Framework. The function makes sure that assembly strings are formatted correctly for the targeted version of the .NET Framework when configuration files are updated.
+ This property enables a consumer of the .NET configuration system to set a function delegate that is used to transform assembly strings found in configuration files. The function makes sure that assembly strings are formatted correctly for the targeted version of the .NET when configuration files are updated.
 
  ]]></format>
         </remarks>
@@ -466,17 +461,11 @@ Note: If you use a static <see langword="GetSection" /> method that takes a path
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The <xref:System.Configuration.Configuration.HasFile> property also returns `true` when the resource represented by this <xref:System.Configuration.Configuration> object inherits settings from a Web.config file.
 
- The <xref:System.Configuration.Configuration.HasFile> property returns `false` when this <xref:System.Configuration.Configuration> object represents a location-specific configuration.
-
-
+The <xref:System.Configuration.Configuration.HasFile> property returns `false` when this <xref:System.Configuration.Configuration> object represents a location-specific configuration.
 
 ## Examples
  The following code example demonstrates how to use the <xref:System.Configuration.Configuration.HasFile> property.
-
- :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WebNet/System.Configuration.Configuration/CS/Configuration.cs" id="Snippet9":::
- :::code language="vb" source="~/snippets/visualbasic/VS_Snippets_WebNet/System.Configuration.Configuration/VB/Configuration.vb" id="Snippet9":::
 
  ]]></format>
         </remarks>
@@ -1138,7 +1127,7 @@ Note: If you use a static <see langword="GetSection" /> method that takes a path
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This property enables a consumer of the .NET Framework configuration system to set a function delegate that is used to transform type strings found in configuration files. Visual Studio 2010 uses this property when a project is targeted for an earlier version of the .NET Framework. The function makes sure that type strings are formatted correctly for the targeted version of the .NET Framework when configuration files are updated.
+ This property enables a consumer of the .NET configuration system to set a function delegate that is used to transform type strings found in configuration files. The function makes sure that type strings are formatted correctly for the targeted version of the .NET when configuration files are updated.
 
  ]]></format>
         </remarks>

--- a/xml/System.Configuration/Configuration.xml
+++ b/xml/System.Configuration/Configuration.xml
@@ -464,8 +464,6 @@ Note: If you use a static <see langword="GetSection" /> method that takes a path
 
 The <xref:System.Configuration.Configuration.HasFile> property returns `false` when this <xref:System.Configuration.Configuration> object represents a location-specific configuration.
 
-## Examples
- The following code example demonstrates how to use the <xref:System.Configuration.Configuration.HasFile> property.
 
  ]]></format>
         </remarks>

--- a/xml/System.Configuration/ConfigurationCollectionAttribute.xml
+++ b/xml/System.Configuration/ConfigurationCollectionAttribute.xml
@@ -138,9 +138,8 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- You use this constructor to tell the .NET Framework the custom type of the property collection to be created.
 
-
+You use this constructor to declare the custom type of the property collection to be created.
 
 ## Examples
  The following example shows how to use the <xref:System.Configuration.ConfigurationCollectionAttribute.%23ctor*>.

--- a/xml/System.Configuration/ConfigurationElement.xml
+++ b/xml/System.Configuration/ConfigurationElement.xml
@@ -36,52 +36,10 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The <xref:System.Configuration.ConfigurationElement> is an abstract class that is used to represent an XML element in a configuration file (such as Web.config). An element in a configuration file can contain zero, one, or more child elements.
 
- Because the <xref:System.Configuration.ConfigurationElement> class is defined as abstract, you cannot create an instance of it. You can only derive classes from it. The .NET Framework includes classes that derive from the <xref:System.Configuration.ConfigurationElement> class in order to represent standard XML configuration elements, such as <xref:System.Configuration.ConfigurationSection>. You can also extend the <xref:System.Configuration.ConfigurationElement> class to access custom configuration elements and sections. The example included later in this topic shows how to access custom configuration elements and sections by using custom classes that derive from <xref:System.Configuration.ConfigurationElement>.
+Because the <xref:System.Configuration.ConfigurationElement> class is defined as abstract, you cannot create an instance of it. You can only derive classes from it. .NET includes classes that derive from the <xref:System.Configuration.ConfigurationElement> class to represent standard XML configuration elements, such as <xref:System.Configuration.ConfigurationSection>. You can also extend the <xref:System.Configuration.ConfigurationElement> class to access custom configuration elements and sections. The example included later in this topic shows how to access custom configuration elements and sections by using custom classes that derive from <xref:System.Configuration.ConfigurationElement>.
 
- You can also extend the standard configuration types such as <xref:System.Configuration.ConfigurationElement>, <xref:System.Configuration.ConfigurationElementCollection>, <xref:System.Configuration.ConfigurationProperty>, and <xref:System.Configuration.ConfigurationSection>. For more information, see the documentation for those classes.
-
- For more information about how to access information in configuration files, see the <xref:System.Configuration.ConfigurationManager> class and the <xref:System.Web.Configuration.WebConfigurationManager> class.
-
-
-
-## Examples
- The following code example shows how to implement a custom <xref:System.Configuration.ConfigurationElement> both as an individual element in a custom section and as a collection of elements in a custom section. The example consists of the following files:
-
-- An app.config file that contains a custom section that is named `MyUrls`. This section contains a simple element (it does not contain any other elements) and a collection of elements. The simple element is named `simple` and the collection is named `urls`.
-
-- A console application. The application reads the contents of the app.config file and writes the information to the console. It uses classes that derive from <xref:System.Configuration.ConfigurationElement>, <xref:System.Configuration.ConfigurationElementCollection>, and <xref:System.Configuration.ConfigurationSection>.
-
-- A class named `UrlsSection` that derives from the <xref:System.Configuration.ConfigurationSection> class. This class is used to access the `MyUrls` section in the configuration file.
-
-- A class named `UrlsCollection` that derives from the <xref:System.Configuration.ConfigurationElementCollection> class. This class is used to access the `urls` collection in the configuration file.
-
-- A class named `UrlConfigElement` that derives from the <xref:System.Configuration.ConfigurationElement> class. This class is used to access the `simple` element and the members of the `urls` collection in the configuration file.
-
- To run the example, perform the following steps:
-
-1.  Create a solution that has a console application project and a class library project that is named `ConfigurationElement`.
-
-2.  Put the three class files in the class library project and put the other files in the console library project.
-
-3.  In both projects set a reference to `System.Configuration`.
-
-4.  In the console application project set a project reference to the class library project.
-
-
-
- :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WebNet/System.Configuration.ConfigurationElement/CS/ConfigurationElement.cs" id="Snippet151":::
- :::code language="vb" source="~/snippets/visualbasic/VS_Snippets_WebNet/System.Configuration.ConfigurationElement/VB/ConfigurationElement.vb" id="Snippet151":::
-
- :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WebNet/System.Configuration.ConfigurationElement/CS/CustomSection.cs" id="Snippet71":::
- :::code language="vb" source="~/snippets/visualbasic/VS_Snippets_WebNet/System.Configuration.ConfigurationElement/VB/CustomSection.vb" id="Snippet71":::
-
- :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WebNet/System.Configuration.ConfigurationElement/CS/CustomElementCollection.cs" id="Snippet51":::
- :::code language="vb" source="~/snippets/visualbasic/VS_Snippets_WebNet/System.Configuration.ConfigurationElement/VB/CustomElementCollection.vb" id="Snippet51":::
-
- :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WebNet/System.Configuration.ConfigurationElement/CS/CustomElement.cs" id="Snippet31":::
- :::code language="vb" source="~/snippets/visualbasic/VS_Snippets_WebNet/System.Configuration.ConfigurationElement/VB/CustomElement.vb" id="Snippet31":::
+You can also extend the standard configuration types such as <xref:System.Configuration.ConfigurationElement>, <xref:System.Configuration.ConfigurationElementCollection>, <xref:System.Configuration.ConfigurationProperty>, and <xref:System.Configuration.ConfigurationSection>.
 
  ]]></format>
     </remarks>
@@ -492,7 +450,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The <xref:System.Configuration.ConfigurationElement.SerializeElement*> method and the <xref:System.Configuration.ConfigurationElement.SerializeToXmlElement*> method call this method in order to transform an assembly name when an earlier version of the .NET Framework is targeted.
+ The <xref:System.Configuration.ConfigurationElement.SerializeElement*> method and the <xref:System.Configuration.ConfigurationElement.SerializeToXmlElement*> method call this method in order to transform an assembly name when an earlier version of .NET is targeted.
 
  ]]></format>
         </remarks>
@@ -536,7 +494,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The <xref:System.Configuration.ConfigurationElement.SerializeElement*> method and the <xref:System.Configuration.ConfigurationElement.SerializeToXmlElement*> method call this method in order to transform a type name when an earlier version of the .NET Framework is targeted.
+ The <xref:System.Configuration.ConfigurationElement.SerializeElement*> method and the <xref:System.Configuration.ConfigurationElement.SerializeToXmlElement*> method call this method in order to transform a type name when an earlier version of .NET is targeted.
 
  ]]></format>
         </remarks>

--- a/xml/System.Configuration/ConfigurationManager.xml
+++ b/xml/System.Configuration/ConfigurationManager.xml
@@ -271,13 +271,11 @@ End Module
  ]]></format>
     </remarks>
     <block subset="none" type="overrides">
-      <para>The <see cref="T:System.Configuration.Configuration" /> class enables programmatic access for editing configuration files. You use one of the <c>Open</c> methods provided by <see cref="T:System.Configuration.ConfigurationManager" />. These methods return a <see cref="T:System.Configuration.Configuration" /> object, which in turn provides the required methods and properties to handle the underlying configuration files. You can access these files for reading or writing.
+      <para>The <see cref="T:System.Configuration.Configuration" /> class enables programmatic access for editing configuration files. You use one of the <c>Open</c> methods provided by <see cref="T:System.Configuration.ConfigurationManager" />. These methods return a <see cref="T:System.Configuration.Configuration" /> object, which in turn provides the required methods and properties to handle the underlying configuration files. You can access these files for reading or writing.</para>
 
- To read the configuration files, use <see cref="M:System.Configuration.Configuration.GetSection(System.String)" /> or <see cref="M:System.Configuration.Configuration.GetSectionGroup(System.String)" />.
+ <para>To read the configuration files, use <see cref="M:System.Configuration.Configuration.GetSection(System.String)" /> or <see cref="M:System.Configuration.Configuration.GetSectionGroup(System.String)" />.</para>
 
- If your application needs read-only access to its own configuration, we recommend that you use the <see cref="M:System.Configuration.ConfigurationManager.GetSection(System.String)" /> method. This method provides access to the cached configuration values for the current application, which has better performance than the <see cref="T:System.Configuration.Configuration" /> class.
-
- To write to the configuration files, use one of the <see cref="Overload:System.Configuration.Configuration.Save" /> methods.
+ <para>To write to the configuration files, use one of the <see cref="Overload:System.Configuration.Configuration.Save" /> methods.</para>
     </block>
     <altmember cref="T:System.Configuration.Configuration" />
   </Docs>

--- a/xml/System.Configuration/ConfigurationManager.xml
+++ b/xml/System.Configuration/ConfigurationManager.xml
@@ -808,7 +808,7 @@ Calling this method overload is equivalent to calling the <xref:System.Configura
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Machine configuration settings apply to the whole computer and all applications that reside on it, unless overridden for the local application. Machine configuration settings are read from the Machine.config file of the currently running version .NET. The Machine.config file is located in the following subdirectory:
+ Machine configuration settings apply to the whole computer and all applications that reside on it, unless overridden for the local application. Machine configuration settings are read from the Machine.config file of the currently running version of .NET. The Machine.config file is located in the following subdirectory:
 
  *%windir%*\Microsoft.NET\Framework\\*version*\config
 

--- a/xml/System.Configuration/ConfigurationManager.xml
+++ b/xml/System.Configuration/ConfigurationManager.xml
@@ -36,12 +36,7 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The <xref:System.Configuration.ConfigurationManager> class enables you to access machine, application, and user configuration information. This class replaces the <xref:System.Configuration.ConfigurationSettings> class, which is deprecated. For web applications, use the <xref:System.Web.Configuration.WebConfigurationManager> class.
-
- To use the <xref:System.Configuration.ConfigurationManager> class, your project must reference the `System.Configuration` assembly. By default, some project templates, like Console Application, do not reference this assembly so you must manually reference it.
-
-> [!NOTE]
->  The name and location of the application configuration file depend on the application's host. For more information, see [Configuring Apps by using Configuration Files](/dotnet/framework/configure-apps/).
+ The <xref:System.Configuration.ConfigurationManager> class enables you to access machine, application, and user configuration information.
 
  You can use the built-in <xref:System.Configuration> types or derive from them to handle configuration information. By using these types, you can work directly with configuration information and you can extend configuration files to include custom information.
 
@@ -53,21 +48,15 @@
 
 - Support configuration tasks. The following types are used to support various configuration tasks:
 
-    -   <xref:System.Configuration.SectionInformation>
+  - <xref:System.Configuration.SectionInformation>
+  - <xref:System.Configuration.PropertyInformation>
+  - <xref:System.Configuration.PropertyInformationCollection>
+  - <xref:System.Configuration.ElementInformation>
+  - <xref:System.Configuration.ContextInformation>
+  - <xref:System.Configuration.ConfigurationSectionGroup>
+  - <xref:System.Configuration.ConfigurationSectionGroupCollection>
 
-    -   <xref:System.Configuration.PropertyInformation>
-
-    -   <xref:System.Configuration.PropertyInformationCollection>
-
-    -   <xref:System.Configuration.ElementInformation>
-
-    -   <xref:System.Configuration.ContextInformation>
-
-    -   <xref:System.Configuration.ConfigurationSectionGroup>
-
-    -   <xref:System.Configuration.ConfigurationSectionGroupCollection>
-
-     In addition to working with existing configuration information, you can create and work with custom configuration elements by extending the built-in configuration types such as the <xref:System.Configuration.ConfigurationElement>, <xref:System.Configuration.ConfigurationElementCollection>, <xref:System.Configuration.ConfigurationProperty>, and <xref:System.Configuration.ConfigurationSection> classes. For an example of how to extend a built-in configuration type programmatically, see <xref:System.Configuration.ConfigurationSection>. For an example of how to extend a built-in configuration type that uses the attribute-based model, see <xref:System.Configuration.ConfigurationElement>.
+  In addition to working with existing configuration information, you can create and work with custom configuration elements by extending the built-in configuration types such as the <xref:System.Configuration.ConfigurationElement>, <xref:System.Configuration.ConfigurationElementCollection>, <xref:System.Configuration.ConfigurationProperty>, and <xref:System.Configuration.ConfigurationSection> classes. For an example of how to extend a built-in configuration type programmatically, see <xref:System.Configuration.ConfigurationSection>. For an example of how to extend a built-in configuration type that uses the attribute-based model, see <xref:System.Configuration.ConfigurationElement>.
 
 ## Examples
  The first example shows a simple console application that reads application settings, adds a new setting, and updates an existing setting.
@@ -284,22 +273,13 @@ End Module
     <block subset="none" type="overrides">
       <para>The <see cref="T:System.Configuration.Configuration" /> class enables programmatic access for editing configuration files. You use one of the <c>Open</c> methods provided by <see cref="T:System.Configuration.ConfigurationManager" />. These methods return a <see cref="T:System.Configuration.Configuration" /> object, which in turn provides the required methods and properties to handle the underlying configuration files. You can access these files for reading or writing.
 
- To read the configuration files, use <see cref="M:System.Configuration.Configuration.GetSection(System.String)" /> or <see cref="M:System.Configuration.Configuration.GetSectionGroup(System.String)" />. The user or process that reads must have the following permissions:
-
-- Read permission on the configuration file at the current configuration hierarchy level.
-
-- Read permissions on all the parent configuration files.
+ To read the configuration files, use <see cref="M:System.Configuration.Configuration.GetSection(System.String)" /> or <see cref="M:System.Configuration.Configuration.GetSectionGroup(System.String)" />.
 
  If your application needs read-only access to its own configuration, we recommend that you use the <see cref="M:System.Configuration.ConfigurationManager.GetSection(System.String)" /> method. This method provides access to the cached configuration values for the current application, which has better performance than the <see cref="T:System.Configuration.Configuration" /> class.
 
- To write to the configuration files, use one of the <see cref="Overload:System.Configuration.Configuration.Save" /> methods. The user or process that writes must have the following permissions:
-
-- Write permission on the configuration file and directory at the current configuration hierarchy level.
-
-- Read permissions on all the configuration files.</para>
+ To write to the configuration files, use one of the <see cref="Overload:System.Configuration.Configuration.Save" /> methods.
     </block>
     <altmember cref="T:System.Configuration.Configuration" />
-    <related type="Article" href="/dotnet/framework/configure-apps/">Configuration Files</related>
   </Docs>
   <Members>
     <Member MemberName="AppSettings">
@@ -644,11 +624,11 @@ End Module
 
  The <xref:System.Configuration.ConfigurationManager.GetSection*> method accesses run-time configuration information that it cannot change. To change the configuration, you use the <xref:System.Configuration.Configuration.GetSection*> method on the configuration file that you obtain by using one of the following methods:
 
--   <xref:System.Configuration.ConfigurationManager.OpenExeConfiguration*>
+- <xref:System.Configuration.ConfigurationManager.OpenExeConfiguration*>
 
--   <xref:System.Configuration.ConfigurationManager.OpenMachineConfiguration*>
+- <xref:System.Configuration.ConfigurationManager.OpenMachineConfiguration*>
 
--   <xref:System.Configuration.ConfigurationManager.OpenMappedExeConfiguration*>
+- <xref:System.Configuration.ConfigurationManager.OpenMappedExeConfiguration*>
 
 ## Examples
  The following example shows how to use the <xref:System.Configuration.ConfigurationManager.GetSection*> method. The example is part of a larger example that is provided for the <xref:System.Configuration.ConfigurationManager> class.
@@ -830,12 +810,12 @@ Calling this method overload is equivalent to calling the <xref:System.Configura
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Machine configuration settings apply to the whole computer and all applications that reside on it, unless overridden for the local application. Machine configuration settings are read from the Machine.config file of the currently running version of .NET Framework. The Machine.config file is located in the following subdirectory:
+ Machine configuration settings apply to the whole computer and all applications that reside on it, unless overridden for the local application. Machine configuration settings are read from the Machine.config file of the currently running version .NET. The Machine.config file is located in the following subdirectory:
 
  *%windir%*\Microsoft.NET\Framework\\*version*\config
 
 > [!NOTE]
-> To obtain the <xref:System.Configuration.Configuration> object for a resource, your code must have read permissions on all the configuration files from which it inherits settings. To update a configuration file, your code must additionally have write permissions for both the configuration file and the directory in which it exists. It is not possible to access the Machine.config file for other versions of the .NET Framework that might be installed on the computer.
+> To obtain the <xref:System.Configuration.Configuration> object for a resource, your code must have read permissions on all the configuration files from which it inherits settings. To update a configuration file, your code must additionally have write permissions for both the configuration file and the directory in which it exists. It's not possible to access the Machine.config file for other versions of .NET that might be installed on the computer.
 
 ## Examples
  The following code example shows how to use the <xref:System.Configuration.ConfigurationManager.OpenMachineConfiguration*> method to obtain all sections that are contained in the configuration file.
@@ -1011,12 +991,12 @@ Calling this method overload is equivalent to calling the <xref:System.Configura
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Machine configuration settings apply to the whole computer and all applications that reside on it, unless overridden for the local application. Machine configuration settings are read from the Machine.config file of the currently running version of .NET Framework. The Machine.config file is located in the following subdirectory:
+ Machine configuration settings apply to the whole computer and all applications that reside on it, unless overridden for the local application. Machine configuration settings are read from the Machine.config file of the currently running version of .NET. The Machine.config file is located in the following subdirectory:
 
  *%windir%*\Microsoft.NET\Framework\\*version*\config
 
 > [!NOTE]
-> To obtain the <xref:System.Configuration.Configuration> object for a resource, your code must have read permissions on all the configuration files from which it inherits settings. To update a configuration file, your code must additionally have write permissions for both the configuration file and the directory in which it exists. It is not possible to access the Machine.config file for other versions of the .NET Framework that might be installed on the computer.
+> To obtain the <xref:System.Configuration.Configuration> object for a resource, your code must have read permissions on all the configuration files from which it inherits settings. To update a configuration file, your code must additionally have write permissions for both the configuration file and the directory in which it exists. It's not possible to access the Machine.config file for other versions of .NET that might be installed on the computer.
 
 ## Examples
  The following code example shows how to use the <xref:System.Configuration.ConfigurationManager.OpenMappedMachineConfiguration*> method to obtain all sections in the configuration file.

--- a/xml/System.Configuration/ConfigurationPermission.xml
+++ b/xml/System.Configuration/ConfigurationPermission.xml
@@ -48,8 +48,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The <xref:System.Configuration.ConfigurationPermission> class provides a permission structure that allows methods or classes to access configuration files. Also, <xref:System.Configuration.ConfigurationPermission> provides ways to resolve multiple permissions values through such methods as <xref:System.Configuration.ConfigurationPermission.Union*> and <xref:System.Configuration.ConfigurationPermission.Intersect*>.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Configuration.ConfigurationPermissionAttribute" />
@@ -214,14 +212,7 @@ The <see langword="version" /> attribute for the given <paramref name="securityE
         <param name="target">The object containing the permissions to perform the intersection with.</param>
         <summary>Returns the logical intersection between the <see cref="T:System.Configuration.ConfigurationPermission" /> object and a given object that implements the <see cref="T:System.Security.IPermission" /> interface.</summary>
         <returns>The logical intersection between the <see cref="T:System.Configuration.ConfigurationPermission" /> and a given object that implements <see cref="T:System.Security.IPermission" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Although the method signature accepts any object that implements the <xref:System.Security.IPermission> interface, an <xref:System.ArgumentException> exception will be thrown if calling the <xref:System.Object.GetType*> method on the object referenced by the `target` parameter does not return <xref:System.Configuration.ConfigurationPermission?displayProperty=nameWithType>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not typed as <see cref="T:System.Configuration.ConfigurationPermission" />.</exception>
       </Docs>
@@ -262,16 +253,7 @@ The <see langword="version" /> attribute for the given <paramref name="securityE
         <summary>Compares the <see cref="T:System.Configuration.ConfigurationPermission" /> object with an object implementing the <see cref="T:System.Security.IPermission" /> interface.</summary>
         <returns>
           <see langword="true" /> if the permission state is equal; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Although the method signature accepts any object that implements the <xref:System.Security.IPermission> interface, an <xref:System.ArgumentException> exception will be thrown if calling the <xref:System.Object.GetType*> method on the object referenced by the `target` parameter does not return <xref:System.Configuration.ConfigurationPermission?displayProperty=nameWithType>.
-
- If the object referenced by the `target` parameter is `null`, the comparison is done between the permission state of the <xref:System.Configuration.ConfigurationPermission> object and the <xref:System.Security.Permissions.PermissionState.None> value of the <xref:System.Security.Permissions.PermissionState> enumeration.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not typed as <see cref="T:System.Configuration.ConfigurationPermission" />.</exception>
       </Docs>

--- a/xml/System.Configuration/ConfigurationPermissionAttribute.xml
+++ b/xml/System.Configuration/ConfigurationPermissionAttribute.xml
@@ -121,14 +121,7 @@
       <Docs>
         <summary>Creates and returns an object that implements the <see cref="T:System.Security.IPermission" /> interface.</summary>
         <returns>An object that implements <see cref="T:System.Security.IPermission" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method returns a new <xref:System.Configuration.ConfigurationPermission> object.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Configuration/ConfigurationProperty.xml
+++ b/xml/System.Configuration/ConfigurationProperty.xml
@@ -568,7 +568,7 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Indicates whether the assembly name for the configuration property requires transformation when it is serialized for an earlier version of the .NET Framework.</summary>
+        <summary>Indicates whether the assembly name for the configuration property requires transformation when it is serialized for an earlier version of .NET.</summary>
         <value>
           <see langword="true" /> if the property requires assembly name transformation; otherwise, <see langword="false" />.</value>
         <remarks>
@@ -762,7 +762,7 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Indicates whether the type name for the configuration property requires transformation when it is serialized for an earlier version of the .NET Framework.</summary>
+        <summary>Indicates whether the type name for the configuration property requires transformation when it is serialized for an earlier version of .NET.</summary>
         <value>
           <see langword="true" /> if the property requires type-name transformation; otherwise, <see langword="false" />.</value>
         <remarks>
@@ -811,9 +811,10 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- If you are creating a configuration property for the .NET Framework 4 or later versions, and if the property value should not be serialized to XML when an earlier version of the framework is targeted, set this property to `true`.
 
- You use <xref:System.Configuration.ConfigurationPropertyOptions> to set this property when you call a constructor that includes a <xref:System.Configuration.ConfigurationPropertyOptions> parameter.
+If you're creating a configuration property and the property value should not be serialized to XML when an earlier version of the framework is targeted, set this property to `true`.
+
+Use <xref:System.Configuration.ConfigurationPropertyOptions> to set this property when you call a constructor that includes a <xref:System.Configuration.ConfigurationPropertyOptions> parameter.
 
  ]]></format>
         </remarks>

--- a/xml/System.Configuration/ConfigurationSection.xml
+++ b/xml/System.Configuration/ConfigurationSection.xml
@@ -40,9 +40,6 @@
 
  A section registers its handling type with an entry in the `configSections` element. For an example, see the configuration file excerpt shown in the Example section.
 
-> [!NOTE]
->  In previous versions of the .NET Framework, configuration section handlers were used to make changes to configuration settings programmatically. Now, all the default configuration sections are represented by classes that extend the <xref:System.Configuration.ConfigurationSection> class.
-
 ## Examples
  The following example shows how to implement a custom section programmatically.
 
@@ -472,15 +469,15 @@ Note: If you use a static <see langword="GetSection" /> method that takes a <par
       <Docs>
         <param name="element">The <see cref="T:System.Configuration.ConfigurationElement" /> object that is a candidate for serialization.</param>
         <param name="elementName">The name of the <see cref="T:System.Configuration.ConfigurationElement" /> object as it occurs in XML.</param>
-        <param name="targetFramework">The target version of the .NET Framework.</param>
-        <summary>Indicates whether the specified element should be serialized when the configuration object hierarchy is serialized for the specified target version of the .NET Framework.</summary>
+        <param name="targetFramework">The target version of .NET.</param>
+        <summary>Indicates whether the specified element should be serialized when the configuration object hierarchy is serialized for the specified target version of .NET.</summary>
         <returns>
           <see langword="true" /> if the <paramref name="element" /> should be serialized; otherwise, <see langword="false" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Each configuration section that is created for the .NET Framework 4 and later versions must explicitly override this method and return `true`, but only if the specified element is valid for the specified version of the .NET Framework. Existing configuration sections that were created for earlier versions of the .NET Framework do not have to be changed.
+ Each configuration section that's created must explicitly override this method and return `true`, but only if the specified element is valid for the specified version of .NET.
 
  The base type contains a default implementation of this method that always returns `true`. If you implement a configuration section and you do not override this method, by default all configuration elements that are contained in the configuration section will be serialized for all framework versions.
 
@@ -528,16 +525,16 @@ Note: If you use a static <see langword="GetSection" /> method that takes a <par
       <Docs>
         <param name="property">The <see cref="T:System.Configuration.ConfigurationProperty" /> object that is a candidate for serialization.</param>
         <param name="propertyName">The name of the <see cref="T:System.Configuration.ConfigurationProperty" /> object as it occurs in XML.</param>
-        <param name="targetFramework">The target version of the .NET Framework.</param>
+        <param name="targetFramework">The target version of .NET.</param>
         <param name="parentConfigurationElement">The parent element of the property.</param>
-        <summary>Indicates whether the specified property should be serialized when the configuration object hierarchy is serialized for the specified target version of the .NET Framework.</summary>
+        <summary>Indicates whether the specified property should be serialized when the configuration object hierarchy is serialized for the specified target version of .NET.</summary>
         <returns>
           <see langword="true" /> if the <paramref name="property" /> should be serialized; otherwise, <see langword="false" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Each configuration section that is created for the .NET Framework 4 and later versions must explicitly override this method and return `true`, but only if the specified property is valid for the specified version of the .NET Framework. Existing configuration sections that were created for earlier versions of the .NET Framework do not have to be changed.
+ Each configuration section that's created must explicitly override this method and return `true`, but only if the specified property is valid for the specified version of .NET.
 
  The base type contains a default implementation of this method that always returns `true`. If you implement a configuration section and you do not override this method, by default all configuration properties that are contained in the configuration section will be serialized for all framework versions.
 
@@ -580,15 +577,15 @@ Note: If you use a static <see langword="GetSection" /> method that takes a <par
         <Parameter Name="targetFramework" Type="System.Runtime.Versioning.FrameworkName" />
       </Parameters>
       <Docs>
-        <param name="targetFramework">The target version of the .NET Framework.</param>
-        <summary>Indicates whether the current <see cref="T:System.Configuration.ConfigurationSection" /> instance should be serialized when the configuration object hierarchy is serialized for the specified target version of the .NET Framework.</summary>
+        <param name="targetFramework">The target version of .NET.</param>
+        <summary>Indicates whether the current <see cref="T:System.Configuration.ConfigurationSection" /> instance should be serialized when the configuration object hierarchy is serialized for the specified target version of .NET.</summary>
         <returns>
           <see langword="true" /> if the current section should be serialized; otherwise, <see langword="false" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Each configuration section that is created for the .NET Framework 4 and later versions must explicitly override this method and return `true`, but only if the configuration section is valid for the specified version of the .NET Framework. Existing configuration sections that were created for earlier versions of the .NET Framework do not have to be changed.
+ Each configuration section that's created must explicitly override this method and return `true`, but only if the configuration section is valid for the specified version of .NET.
 
  The base type contains a default implementation of this method that always returns `true`. If you implement a configuration section and you do not override this method, by default the configuration section will be serialized for all framework versions.
 

--- a/xml/System.Configuration/ConfigurationSectionGroup.xml
+++ b/xml/System.Configuration/ConfigurationSectionGroup.xml
@@ -32,49 +32,7 @@
   <Interfaces />
   <Docs>
     <summary>Represents a group of related sections within a configuration file.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[
-
-## Remarks
- Settings in configuration files (such as the Web.config file) are organized into sections. Because some sections are related, it is often convenient to group them in a section group. The <xref:System.Configuration.ConfigurationSectionGroup> class represents the `sectionGroup` XML element that is used to group sections when they are defined in the `configSections` element of a configuration file. Section groups can be nested (a section group can contain other section groups as well as sections). The following example shows a `configSections` element that defines three nested section groups:
-
-```xml
-<configSections>
-  <sectionGroup name="system.web.extensions"...>
-    <sectionGroup name="scripting" ...>
-      <section name="scriptResourceHandler".../>
-      <sectionGroup name="webServices"...>
-        <section name="jsonSerialization" .../>
-        <section name="profileService" ... />        <section name="authenticationService" .../>
-        <section name="roleService" .../>
-      </sectionGroup>
-    </sectionGroup>
-  </sectionGroup>
-</configSections>
-```
-
- The configuration system loads settings from configuration files into <xref:System.Configuration.ConfigurationSectionGroup> objects. You can use the <xref:System.Configuration.ConfigurationSectionGroup.Sections*> and <xref:System.Configuration.ConfigurationSectionGroup.SectionGroups*> properties to access the sections and section groups that are contained in a <xref:System.Configuration.ConfigurationSectionGroup> object.
-
- For more information about how to access information from configuration files, see the <xref:System.Configuration.ConfigurationManager> class.
-
-
-
-## Examples
- The following example shows how to use the <xref:System.Configuration.ConfigurationSectionGroup> class to retrieve configuration settings. The example is a console application that reads configuration settings and writes information about each configuration section group and the sections in it to the console.
-
- The `Main` method loads the configuration settings into a <xref:System.Configuration.Configuration> object, retrieves the <xref:System.Configuration.Configuration.SectionGroups*> collection from the <xref:System.Configuration.Configuration> object, and then calls the `ShowSectionGroupCollectionInfo` method to display the section property values.
-
- The `ShowSectionGroupCollectionInfo` method iterates through the section groups and calls the `ShowSectionGroupInfo` method for each one.
-
- The `ShowSectionGroupInfo` method displays the name of the section group, some property values, and the names of the sections that it contains. If the section group contains section groups, this method calls `ShowSectionGroupCollectionInfo` recursively to display those section groups.
-
- The `indentLevel` field is used to add spaces to the left side of displayed lines to show logical groupings. All lines are limited to 79 characters of text to avoid line wrapping, which would make it harder to distinguish the logical groupings.
-
- :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WebNet/System.Configuration.ConfigurationSectionGroup/CS/ConfigurationSectionGroup.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/VS_Snippets_WebNet/System.Configuration.ConfigurationSectionGroup/VB/ConfigurationSectionGroup.vb" id="Snippet1":::
-
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
     <altmember cref="T:System.Configuration.ConfigurationSectionGroup" />
     <altmember cref="T:System.Configuration.ConfigurationSectionCollection" />
     <altmember cref="T:System.Configuration.ConfigurationSection" />
@@ -572,15 +530,15 @@
         <Parameter Name="targetFramework" Type="System.Runtime.Versioning.FrameworkName" />
       </Parameters>
       <Docs>
-        <param name="targetFramework">The target version of the .NET Framework.</param>
-        <summary>Indicates whether the current <see cref="T:System.Configuration.ConfigurationSectionGroup" /> instance should be serialized when the configuration object hierarchy is serialized for the specified target version of the .NET Framework.</summary>
+        <param name="targetFramework">The target version of .NET.</param>
+        <summary>Indicates whether the current <see cref="T:System.Configuration.ConfigurationSectionGroup" /> instance should be serialized when the configuration object hierarchy is serialized for the specified target version of .NET.</summary>
         <returns>
           <see langword="true" /> if the current section group should be serialized; otherwise, <see langword="false" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Each configuration section group that is created for the .NET Framework 4 and later versions must explicitly override this method and return `true`, but only if the section group is valid for the specified version of the .NET Framework. Existing configuration section groups that were created for earlier versions of the .NET Framework do not have to be changed.
+ Each configuration section group that is created must explicitly override this method and return `true`, but only if the section group is valid for the specified version of .NET.
 
  The base type contains a default implementation of this method that always returns `true`. In other words, if a configuration section group implementer does not override this method, by default the configuration section group will be serialized for all framework versions.
 

--- a/xml/System.Configuration/ConfigurationSettings.xml
+++ b/xml/System.Configuration/ConfigurationSettings.xml
@@ -32,18 +32,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Provides runtime versions 1.0 and 1.1 support for reading configuration sections and common configuration settings.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use the static methods and properties of the <xref:System.Configuration.ConfigurationSettings> type to read configuration information at run time for version 1.0 and 1.1 applications.
-
-> [!NOTE]
-> The <xref:System.Configuration.ConfigurationSettings> class provides backward compatibility only. For new applications, use the <xref:System.Configuration.ConfigurationManager> class or <xref:System.Web.Configuration.WebConfigurationManager> class instead. To use these two classes, add a reference in your project to the `System.Configuration` namespace.
-
- ]]></format>
-    </remarks>
+    <summary>Provides legacy support for reading configuration sections and common configuration settings.</summary>
+    <remarks>To be added.</remarks>
     <altmember cref="T:System.Configuration.ConfigurationSection" />
   </Docs>
   <Members>

--- a/xml/System.Configuration/ExeConfigurationFileMap.xml
+++ b/xml/System.Configuration/ExeConfigurationFileMap.xml
@@ -46,7 +46,6 @@
  ]]></format>
     </remarks>
     <altmember cref="T:System.Configuration.ConfigurationFileMap" />
-    <related type="Article" href="/dotnet/framework/configure-apps/">Configuration Files</related>
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
@@ -122,11 +121,10 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- You use this constructor when you are targeting a version of the .NET Framework that is earlier than the latest one that is installed on the computer. This constructor enables you to specify a machine configuration file that is appropriate to the version of the .NET Framework that you are targeting.
+ You use this constructor when you are targeting a version of .NET Framework that is earlier than the latest one that is installed on the computer. This constructor enables you to specify a machine configuration file that is appropriate to the version of .NET Framework that you are targeting.
 
  ]]></format>
         </remarks>
-        <related type="Article" href="/dotnet/framework/configure-apps/">Configuration Files</related>
       </Docs>
     </Member>
     <Member MemberName="Clone">

--- a/xml/System.Configuration/IApplicationSettingsProvider.xml
+++ b/xml/System.Configuration/IApplicationSettingsProvider.xml
@@ -192,7 +192,8 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The .NET Framework enables side-by-side installation and execution of different versions of the same application. The application settings provider stores the application settings for each version of an application separately to ensure isolation. However, you may want to migrate settings from the previous version of an application to the current one. To provide this migration functionality, use the <xref:System.Configuration.IApplicationSettingsProvider.Upgrade*> method, implemented in a class derived from <xref:System.Configuration.SettingsProvider>.
+
+.NET enables side-by-side installation and execution of different versions of the same application. The application settings provider stores the application settings for each version of an application separately to ensure isolation. However, you may want to migrate settings from the previous version of an application to the current one. To provide this migration functionality, use the <xref:System.Configuration.IApplicationSettingsProvider.Upgrade*> method, implemented in a class derived from <xref:System.Configuration.SettingsProvider>.
 
  You can use the <xref:System.Configuration.IApplicationSettingsProvider.Upgrade*> method in conjunction with the <xref:System.Configuration.IApplicationSettingsProvider.GetPreviousVersion*> method to migrate application settings during or after the installation of a new version of an application.
 

--- a/xml/System.Configuration/IConfigurationSectionHandler.xml
+++ b/xml/System.Configuration/IConfigurationSectionHandler.xml
@@ -37,7 +37,7 @@
 ## Remarks
 
  > [!IMPORTANT]
- > <xref:System.Configuration.IConfigurationSectionHandler> is deprecated starting in .NET Framework 2.0. In .NET Framework version 2.0 and later, you must instead derive from the <xref:System.Configuration.ConfigurationSection> class to implement the related configuration section handler.
+ > <xref:System.Configuration.IConfigurationSectionHandler> is deprecated. Instead, derive from the <xref:System.Configuration.ConfigurationSection> class to implement the related configuration section handler.
 
  Instances of the <xref:System.Configuration.IConfigurationSectionHandler> class must be thread safe and stateless. The <xref:System.Configuration.IConfigurationSectionHandler.Create*> method must be callable from multiple threads simultaneously.
 

--- a/xml/System.Configuration/IdnElement.xml
+++ b/xml/System.Configuration/IdnElement.xml
@@ -36,9 +36,8 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The existing <xref:System.Uri?displayProperty=nameWithType> class has been extended to provide support for International Resource Identifiers (IRI) based on RFC 3987. Users upgrading from .NET Framework 2.0 won't see any change in behavior unless they specifically enable IRI. This ensures application compatibility with prior versions of .NET Framework.
 
- The configuration setting for the <xref:System.Configuration.IdnElement> is indirectly controlled by the <xref:System.Configuration.IriParsingElement> configuration setting that controls IRI processing in the <xref:System.Uri?displayProperty=nameWithType> class. IRI processing must be enabled for IDN processing to be possible. If IRI processing is disabled, then IDN processing will be set to the default setting where the .NET Framework 2.0 behavior is used for compatibility and IDN names are not used.
+ The configuration setting for the <xref:System.Configuration.IdnElement> is indirectly controlled by the <xref:System.Configuration.IriParsingElement> configuration setting that controls IRI processing in the <xref:System.Uri?displayProperty=nameWithType> class. IRI processing must be enabled for IDN processing to be possible. If IRI processing is disabled, then IDN processing will be set to the default setting where IDN names are not used.
 
  The Internationalized Domain Name (IDN) attribute only controls IDN processing. All other IRI processing (character normalization, for example) is performed by default.
 
@@ -133,7 +132,7 @@
 ## Remarks
  The International Domain Name (IDN) attribute only controls IDN processing. All other International Resource Identifiers (IRI)  processing (character normalization, for example) is performed by default.
 
- The configuration setting for the <xref:System.Configuration.IdnElement> is indirectly controlled by the <xref:System.Configuration.IriParsingElement?displayProperty=nameWithType> configuration setting that controls IRI processing in the <xref:System.Uri?displayProperty=nameWithType> class. IRI processing must be enabled for IDN processing to be possible. If IRI processing is disabled, then IDN processing will be set to the default setting where the .NET Framework 2.0 behavior is used for compatibility and IDN names are not used.
+ The configuration setting for the <xref:System.Configuration.IdnElement> is indirectly controlled by the <xref:System.Configuration.IriParsingElement?displayProperty=nameWithType> configuration setting that controls IRI processing in the <xref:System.Uri?displayProperty=nameWithType> class. IRI processing must be enabled for IDN processing to be possible. If IRI processing is disabled, then IDN processing will be set to the default setting where IDN names are not used.
 
  The configuration setting for the <xref:System.Configuration.IdnElement> will be read once when the first <xref:System.Uri?displayProperty=nameWithType> class is constructed. Changes to configuration settings after that time are ignored.
 

--- a/xml/System.Configuration/IriParsingElement.xml
+++ b/xml/System.Configuration/IriParsingElement.xml
@@ -36,7 +36,6 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The existing <xref:System.Uri?displayProperty=nameWithType> class has been extended to provide support for International Resource Identifiers (IRI) based on RFC 3987. Users upgrading from .NET Framework 2.0 won't see any change in behavior unless they specifically enable IRI. This ensures application compatibility with prior versions of the .NET Framework.
 
  The configuration setting for the <xref:System.Configuration.IriParsingElement> will be read once when the first <xref:System.Uri?displayProperty=nameWithType> class is constructed. Changes to configuration settings after that time are ignored.
 
@@ -127,7 +126,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The <xref:System.Configuration.IriParsingElement> configuration setting controls IRI processing in the <xref:System.Uri?displayProperty=nameWithType> class. This setting also indirectly controls International Domain Name (IDN) processing set with the <xref:System.Configuration.IdnElement?displayProperty=nameWithType> class. IRI processing must be enabled for IDN processing to be possible. If IRI processing is disabled, then IDN processing will be set to the default setting where the .NET Framework 2.0 behavior is used for compatibility and IDN names are not used.
+ The <xref:System.Configuration.IriParsingElement> configuration setting controls IRI processing in the <xref:System.Uri?displayProperty=nameWithType> class. This setting also indirectly controls International Domain Name (IDN) processing set with the <xref:System.Configuration.IdnElement?displayProperty=nameWithType> class. IRI processing must be enabled for IDN processing to be possible. If IRI processing is disabled, then IDN processing will be set to the default setting where IDN names are not used.
 
  The configuration setting for the <xref:System.Configuration.IriParsingElement> will be read once when the first <xref:System.Uri?displayProperty=nameWithType> class is constructed. Changes to configuration settings after that time are ignored.
 

--- a/xml/System.Configuration/LocalFileSettingsProvider.xml
+++ b/xml/System.Configuration/LocalFileSettingsProvider.xml
@@ -40,7 +40,7 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Setting providers define a mechanism for storing configuration data used in the application settings architecture. The .NET Framework contains a single default settings provider, <xref:System.Configuration.LocalFileSettingsProvider>, which stores configuration data to the local file system. An application settings property or group of properties are associated to a specific settings provider through the use of the <xref:System.Configuration.SettingsProviderAttribute>.
+ Setting providers define a mechanism for storing configuration data used in the application settings architecture. .NET contains a single default settings provider, <xref:System.Configuration.LocalFileSettingsProvider>, which stores configuration data to the local file system. An application settings property or group of properties are associated to a specific settings provider through the use of the <xref:System.Configuration.SettingsProviderAttribute>.
 
  Typically, the client program does not explicitly access this class; rather, the application settings architecture automatically invokes the appropriate settings provider when its services are required. For example, many of the members of <xref:System.Configuration.ApplicationSettingsBase> delegate their work to the associated settings provider.
 

--- a/xml/System.Configuration/ProtectedConfigurationProviderCollection.xml
+++ b/xml/System.Configuration/ProtectedConfigurationProviderCollection.xml
@@ -40,7 +40,7 @@
 
  You can encrypt sections of a configuration file to protect sensitive information used by your application. This improves security by making unauthorized access difficult, even if an attacker gains access to your configuration file.
 
- The .NET Framework includes two protected configuration providers that can be used to encrypt sections of a configuration file: the <xref:System.Configuration.RsaProtectedConfigurationProvider> class, which uses the <xref:System.Security.Cryptography.RSACryptoServiceProvider> class to encrypt configuration sections, and the <xref:System.Configuration.DpapiProtectedConfigurationProvider> class, which uses the Windows Data Protection API (DPAPI) to encrypt configuration sections.
+.NET includes two protected configuration providers that can be used to encrypt sections of a configuration file: the <xref:System.Configuration.RsaProtectedConfigurationProvider> class, which uses the <xref:System.Security.Cryptography.RSACryptoServiceProvider> class to encrypt configuration sections, and the <xref:System.Configuration.DpapiProtectedConfigurationProvider> class, which uses the Windows Data Protection API (DPAPI) to encrypt configuration sections.
 
  You might have a requirement to encrypt sensitive information using an algorithm other than the RSA or DPAPI providers. In this case, you can build your own custom protected-configuration provider. The <xref:System.Configuration.ProtectedConfigurationProvider> class is an abstract base class that you must inherit from to create your own protected-configuration provider.
 

--- a/xml/System.Configuration/RsaProtectedConfigurationProvider.xml
+++ b/xml/System.Configuration/RsaProtectedConfigurationProvider.xml
@@ -35,58 +35,11 @@
     <remarks>
       <format type="text/markdown"><![CDATA[
 
-## Remarks
- The <xref:System.Configuration.RsaProtectedConfigurationProvider> class gives you a way to encrypt sensitive information stored in a configuration file, which helps protect it from unauthorized access. You use the built-in <xref:System.Configuration.RsaProtectedConfigurationProvider> instance by declaring the provider and making appropriate settings in the configuration file instead of creating an instance of this class, as shown in the Examples section.
-
- The <xref:System.Configuration.RsaProtectedConfigurationProvider> object uses the cryptography functions provided by <xref:System.Security.Cryptography.RSA> class to encrypt and decrypt configuration sections.
-
 > [!NOTE]
->  Before ASP.NET can decrypt encrypted information in your configuration file, the identity of your ASP.NET application must have read access to the encryption key used to encrypt and decrypt the configuration data.
-
-> [!NOTE]
-> On .NET Core and .NET 5+, the <xref:System.Configuration.RsaProtectedConfigurationProvider> type is not supported. All APIs throw a <xref:System.PlatformNotSupportedException> at run time.
-
-## Examples
-
-The following example shows how to use the standard <xref:System.Configuration.RsaProtectedConfigurationProvider> to protect or unprotect a configuration section.
-
- :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WebNet/System.Configuration.RsaProtectedConfigurationProvider/CS/RsaProtectedConfigurationProvider.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/VS_Snippets_WebNet/System.Configuration.RsaProtectedConfigurationProvider/VB/RsaProtectedConfigurationProvider.vb" id="Snippet1":::
-
- The following example shows an excerpt from a configuration file after encryption.
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <connectionStrings configProtectionProvider="RsaProtectedConfigurationProvider">
-    <EncryptedData Type="http://www.w3.org/2001/04/xmlenc#Element"
-        xmlns="http://www.w3.org/2001/04/xmlenc#">
-      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc" />
-      <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
-        <EncryptedKey xmlns="http://www.w3.org/2001/04/xmlenc#">
-          <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5" />
-          <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
-            <KeyName>Rsa Key</KeyName>
-          </KeyInfo>
-          <CipherData>
-            <CipherValue>B702tRDVHJjC3CYXt7I0ucCDjdht/Vyk/DdUhwQyt7vepSD85dwCP8ox9Y1BUdjajFeTFfFBsGypbli5HPGRYamQdrVkPo07bBBXNT5H02qxREguGUU4iDtV1Xp8BLVZjQMV4ZgP6Wbctw2xRvPC7GvKHLI4fUN/Je5LmutsijA=</CipherValue>
-          </CipherData>
-        </EncryptedKey>
-      </KeyInfo>
-      <CipherData>
-        <CipherValue>ME+XJA2TAj3QN3yT4pJq3sRArC0i7Cz3Da71BkaRe9QNfuVuUjcv0jeGUN4wDdOAZ7LPq6UpVrpirY3kQcALDvPJ5nKxk++Mw75rjtIO8eh2goTY9rCK6zanfzaDshFy7IqItpvs/y2kmij25nM3ury6uO0hCf0UbEL1mbT2jXDqvcrHZUobO1Ef6bygBZ/8HpU+VfF9CTCob/BBE9zUkK37EQhcduwsnzBvDblYbF/Rd+F4lxAkZnecGLfCZjOzJB4xH1a0vvWtPR7zNwL/7I0uHzQjyMdWrkBnotMjoR70R7NELBotCogWO0MBimncKigdR3dTTdrCd72a7UJ4LMlEQaZXGIJp4PIg6qVDHII=</CipherValue>
-      </CipherData>
-    </EncryptedData>
-  </connectionStrings>
-</configuration>
-```
+> The <xref:System.Configuration.RsaProtectedConfigurationProvider> type is not supported. All APIs throw a <xref:System.PlatformNotSupportedException> at run time.
 
  ]]></format>
     </remarks>
-    <altmember cref="T:System.Configuration.ProtectedConfigurationProvider" />
-    <altmember cref="T:System.Configuration.DpapiProtectedConfigurationProvider" />
-    <altmember cref="T:System.Security.Cryptography.RSA" />
-    <related type="Article" href="/dotnet/standard/security/cryptographic-services">Cryptographic Services</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -116,14 +69,7 @@ The following example shows how to use the standard <xref:System.Configuration.R
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Configuration.RsaProtectedConfigurationProvider" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Configuration.RsaProtectedConfigurationProvider.%23ctor*> constructor is not intended to be used directly from your code. It is called by the ASP.NET configuration system.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="T:System.Configuration.ProtectedConfigurationProvider" />
       </Docs>
     </Member>

--- a/xml/System.Configuration/SchemeSettingElement.xml
+++ b/xml/System.Configuration/SchemeSettingElement.xml
@@ -46,7 +46,6 @@
     <altmember cref="P:System.Configuration.UriSection.SchemeSettings" />
     <altmember cref="T:System.GenericUriParserOptions" />
     <altmember cref="T:System.Uri" />
-    <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/">Network Settings Schema</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -132,7 +131,6 @@
         <altmember cref="P:System.Configuration.UriSection.SchemeSettings" />
         <altmember cref="T:System.GenericUriParserOptions" />
         <altmember cref="T:System.Uri" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/">Network Settings Schema</related>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -186,7 +184,6 @@
         <altmember cref="P:System.Configuration.UriSection.SchemeSettings" />
         <altmember cref="T:System.GenericUriParserOptions" />
         <altmember cref="T:System.Uri" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/">Network Settings Schema</related>
       </Docs>
     </Member>
     <Member MemberName="Properties">

--- a/xml/System.Configuration/SchemeSettingElementCollection.xml
+++ b/xml/System.Configuration/SchemeSettingElementCollection.xml
@@ -66,7 +66,6 @@
     <altmember cref="P:System.Configuration.UriSection.SchemeSettings" />
     <altmember cref="T:System.GenericUriParserOptions" />
     <altmember cref="T:System.Uri" />
-    <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/">Network Settings Schema</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Configuration/SectionInformation.xml
+++ b/xml/System.Configuration/SectionInformation.xml
@@ -337,18 +337,12 @@
  A <xref:System.Configuration.ConfigurationSection> implementation can optionally specify a separate file in which the configuration settings for that section are defined. This can be useful in multiple ways:
 
 - Using include files can result in a more logical and modular structure for configuration files.
-
 - File-access security and permissions can be used to restrict access to sections of configuration settings.
-
 - Settings in an include file that are not used during application initialization can be modified and reloaded without requiring an application restart.
 
  The following example shows how this attribute is used in a configuration file to specify that the `pages` section is defined in an external include file:
 
  `<pages configSource="pages.config"/>`
-
- If any of the settings in a configuration include file require the application to restart when they are modified, set the <xref:System.Configuration.SectionInformation.RestartOnExternalChanges> property to `true`.
-
- In ASP.NET applications, at run time you can assign to the <xref:System.Configuration.SectionInformation.ConfigSource> property the name of an alternative configuration file. In that case, the contents of the file are overwritten by the default connection string information that is contained in the Web.config file. This occurs also when the alternative file does not exist and it is created at run time. If the Web.config file does not contain any connection string information, an empty  section is added to the alternative file.
 
  ]]></format>
         </remarks>
@@ -1223,53 +1217,9 @@ The following example shows how to get the <xref:System.Configuration.SectionInf
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- When <xref:System.Configuration.SectionInformation.RequirePermission*> is set to `true`, the `GetSection` methods are restricted by the trust level setting of the application. This means that methods or properties that allow access to configuration section handlers are restricted by the trust level set for the Web application.
 
 > [!NOTE]
->  Because high and full trust are the only levels that allow access to files outside the current application domain, an application can use configuration section handlers only at these trust levels.
-
- When <xref:System.Configuration.SectionInformation.RequirePermission*> is set to `false`, the access to the configuration data is not restricted by the application's trust level settings.
-
-> [!NOTE]
->  The appropriate file ACL (Access Control List) permissions are still required, regardless of the <xref:System.Configuration.SectionInformation.RequirePermission*> setting. ACL permissions determine who can access the configuration file.
-
-
-
-## Examples
- The following example shows two possible trust levels for a Web application when the <xref:System.Configuration.SectionInformation.RequirePermission> property of the `appSettings` section is `true`.
-
-```xml
-<system.web>
-   // With the following trust value
-   // the code below works.
-  <trust level="Full" />
-</system.web>
-
-<system.web>
-  // With the following trust value
-  // the code below does not work.
-  <trust level="Medium" />
-</system.web>
-```
-
- The following example shows code that runs without errors when the trust level is set to full. Otherwise, the code results in an error.
-
-```csharp
-AppSettingsSection apSection =
-  ConfigurationManager.GetSection("appSettings") as AppSettingsSection;
-
-NameValueCollection apSectionCollection =
-  ConfigurationManager.AppSettings;
-```
-
-```vb
-Dim apSection As AppSettingsSection = _
-  TryCast(ConfigurationManager.GetSection("appSettings"),
-    AppSettingsSection)
-
-  Dim apSectionCollection As NameValueCollection = _
-    ConfigurationManager.AppSettings
-```
+> The appropriate file ACL (Access Control List) permissions are still required, regardless of the <xref:System.Configuration.SectionInformation.RequirePermission*> setting. ACL permissions determine who can access the configuration file.
 
  ]]></format>
         </remarks>

--- a/xml/System.Configuration/SettingsProvider.xml
+++ b/xml/System.Configuration/SettingsProvider.xml
@@ -36,21 +36,19 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- A settings provider defines the mechanism for storing configuration data used in the application settings architecture. The .NET Framework contains a single default settings provider, <xref:System.Configuration.LocalFileSettingsProvider>, which stores configuration data to the local file system. However, you can create alternate storage mechanisms by deriving from the abstract <xref:System.Configuration.SettingsProvider> class. The provider that a wrapper class uses is determined by decorating the wrapper class with the <xref:System.Configuration.SettingsProviderAttribute>. If this attribute is not provided, the default, <xref:System.Configuration.LocalFileSettingsProvider>, is used.
+ A settings provider defines the mechanism for storing configuration data used in the application settings architecture. .NET contains a single default settings provider, <xref:System.Configuration.LocalFileSettingsProvider>, which stores configuration data to the local file system. However, you can create alternate storage mechanisms by deriving from the abstract <xref:System.Configuration.SettingsProvider> class. The provider that a wrapper class uses is determined by decorating the wrapper class with the <xref:System.Configuration.SettingsProviderAttribute>. If this attribute is not provided, the default, <xref:System.Configuration.LocalFileSettingsProvider>, is used.
 
  When you create a custom settings provider, at minimum, you must provide implementations for the three methods of this class: <xref:System.Configuration.SettingsProvider.GetPropertyValues*>, <xref:System.Configuration.SettingsProvider.SetPropertyValues*> and <xref:System.Configuration.SettingsProvider.ApplicationName*>.
 
  For client applications, you can add more standardized functionality to a custom provider by also implementing the <xref:System.Configuration.IApplicationSettingsProvider> interface. This interface mirrors methods found in the <xref:System.Configuration.ApplicationSettingsBase> class, which mainly enables versioning support.
 
- Typically, you should design settings providers to be single-instanced to avoid storage resource contention. Providers should also be thread-safe because they can be called simultaneously from multiple wrapper instances in a single application domain or from multiple applications in different domains.
+ Typically, you should design settings providers to be single-instanced to avoid storage resource contention. Providers should also be thread-safe because they can be called simultaneously from multiple wrapper instances or from multiple applications.
 
  At minimum, a settings provider must recognize three attributes - <xref:System.Configuration.ApplicationScopedSettingAttribute>, <xref:System.Configuration.UserScopedSettingAttribute>, and <xref:System.Configuration.DefaultSettingValueAttribute>. For a full listing of attributes that can be applied to application settings, see [Application Settings Attributes](/dotnet/desktop/winforms/advanced/application-settings-attributes). A custom setting provider should resolve attributes applied to settings properties in the following manner:
 
-1.  If the provider can fulfill the request implied by the attribute, obviously it should do so.
-
-2.  If the provider cannot fulfill the request, it should ignore it silently.
-
-3.  If two or more properties conflict; for example, a property being decorated with both <xref:System.Configuration.ApplicationScopedSettingAttribute> and <xref:System.Configuration.UserScopedSettingAttribute>; the provider should throw a <xref:System.Configuration.ConfigurationException>.
+1. If the provider can fulfill the request implied by the attribute, obviously it should do so.
+2. If the provider cannot fulfill the request, it should ignore it silently.
+3. If two or more properties conflict; for example, a property being decorated with both <xref:System.Configuration.ApplicationScopedSettingAttribute> and <xref:System.Configuration.UserScopedSettingAttribute>; the provider should throw a <xref:System.Configuration.ConfigurationException>.
 
  ]]></format>
     </remarks>
@@ -98,9 +96,9 @@
 
  Client code typically does not directly instantiate a settings provider; instead, you use the following procedure to find a settings provider for a particular settings property:
 
-1.  Call the <xref:System.ComponentModel.Component.GetService*> method on the current <xref:System.ComponentModel.Component> or <xref:System.ComponentModel.ISite> to return a reference to the current <xref:System.Configuration.ISettingsProviderService>.
+1. Call the <xref:System.ComponentModel.Component.GetService*> method on the current <xref:System.ComponentModel.Component> or <xref:System.ComponentModel.ISite> to return a reference to the current <xref:System.Configuration.ISettingsProviderService>.
 
-2.  Call the <xref:System.Configuration.ISettingsProviderService.GetSettingsProvider*> method of the <xref:System.Configuration.ISettingsProviderService> retrieved in the first step to return the settings provider.
+2. Call the <xref:System.Configuration.ISettingsProviderService.GetSettingsProvider*> method of the <xref:System.Configuration.ISettingsProviderService> retrieved in the first step to return the settings provider.
 
  ]]></format>
         </remarks>
@@ -241,12 +239,6 @@
 
 ## Remarks
  <xref:System.Configuration.ApplicationSettingsBase> contains the <xref:System.Configuration.ApplicationSettingsBase.Save*> method, which is called to persist the values of all of its settings properties. This method enumerates through all the settings providers associated with its settings properties, and calls the <xref:System.Configuration.SettingsProvider.SetPropertyValues*> method for each <xref:System.Configuration.SettingsProvider> to perform the actual serialization operation.
-
- The <xref:System.Configuration.SettingsProvider.SetPropertyValues*> method should be implemented with security in mind:
-
-- Only fully trusted code should be allowed to update application settings. Partially trusted code should be allowed to update only user application settings. Untrusted code is not typically allowed to update application settings.
-
-- Usage quotas should be considered to guard against resource attacks by partially trusted applications.
 
  ]]></format>
         </remarks>

--- a/xml/System.Configuration/SettingsSerializeAsAttribute.xml
+++ b/xml/System.Configuration/SettingsSerializeAsAttribute.xml
@@ -42,7 +42,7 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- A settings provider often supports more than one of the .NET Framework standard serialization schemes. These schemes are outlined by the <xref:System.Configuration.SettingsSerializeAs> enumeration, and include plain text, XML, and binary serialization. In addition, a provider may optionally support a custom serialization scheme.
+ A settings provider often supports more than one of the .NET standard serialization schemes. These schemes are outlined by the <xref:System.Configuration.SettingsSerializeAs> enumeration, and include plain text, XML, and binary serialization. In addition, a provider may optionally support a custom serialization scheme.
 
  With the <xref:System.Configuration.SettingsSerializeAsAttribute>, you can specify which serialization mechanism should be used for a given application settings class or property. This attribute is considered a request to the settings provider. It may be ignored or cause an error if the provider or the individual property type does not support the specified serialization scheme. If this attribute is not present, the provider will usually provide a default serialization mechanism, most commonly plain text.
 

--- a/xml/System.Configuration/SettingsSerializeAsAttribute.xml
+++ b/xml/System.Configuration/SettingsSerializeAsAttribute.xml
@@ -42,7 +42,7 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- A settings provider often supports more than one of the .NET standard serialization schemes. These schemes are outlined by the <xref:System.Configuration.SettingsSerializeAs> enumeration, and include plain text, XML, and binary serialization. In addition, a provider may optionally support a custom serialization scheme.
+ A settings provider often supports more than one of the standard .NET serialization schemes. These schemes are outlined by the <xref:System.Configuration.SettingsSerializeAs> enumeration, and include plain text, XML, and binary serialization. In addition, a provider may optionally support a custom serialization scheme.
 
  With the <xref:System.Configuration.SettingsSerializeAsAttribute>, you can specify which serialization mechanism should be used for a given application settings class or property. This attribute is considered a request to the settings provider. It may be ignored or cause an error if the provider or the individual property type does not support the specified serialization scheme. If this attribute is not present, the provider will usually provide a default serialization mechanism, most commonly plain text.
 

--- a/xml/System.Configuration/UriSection.xml
+++ b/xml/System.Configuration/UriSection.xml
@@ -37,13 +37,11 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The existing <xref:System.Uri?displayProperty=nameWithType> class has been extended to provide support for International Resource Identifiers (IRI) and Internationalized Domain Names. Users upgrading from .NET Framework 2.0  won't see any change in behavior unless they specifically enable IRI and IDN. This ensures application compatibility with prior versions of the .NET Framework.
 
- The configuration settings for IRI and IDN can be retrieved using the <xref:System.Configuration.UriSection> class.
+The configuration settings for IRI and IDN can be retrieved using the <xref:System.Configuration.UriSection> class.
 
  ]]></format>
     </remarks>
-    <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/">Network Settings Schema</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -77,7 +75,6 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The existing <xref:System.Uri?displayProperty=nameWithType> class has been extended to provide support for International Resource Identifiers (IRI) and Internationalized Domain Names. Users upgrading from .NET Framework 2.0  won't see any change in behavior unless they specifically enable IRI and IDN. This ensures application compatibility with prior versions of the .NET Framework.
 
  The configuration settings for IRI and IDN can be retrieved using the <xref:System.Configuration.UriSection> class.
 
@@ -128,11 +125,10 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The existing <xref:System.Uri?displayProperty=nameWithType> class has been extended to provide support for International Resource Identifiers (IRI) and Internationalized Domain Names. Users upgrading from .NET Framework 2.0  won't see any change in behavior unless they specifically enable IRI and IDN. This ensures application compatibility with prior versions of the .NET Framework.
 
  The configuration settings for IRI and IDN can be retrieved using the <xref:System.Configuration.UriSection> class. The <xref:System.Configuration.UriSection.Idn> property returns the configuration setting for IDN processing in the <xref:System.Uri?displayProperty=nameWithType> class.
 
- IRI processing must be enabled for IDN processing to be possible. If IRI processing is disabled, then IDN processing will be set to the default setting where the .NET Framework 2.0 behavior is used for compatibility and IDN names are not used.
+ IRI processing must be enabled for IDN processing to be possible. If IRI processing is disabled, then IDN processing will be set to the default setting where IDN names are not used.
 
  The Internationalized Domain Name (IDN) attribute only controls IDN processing. All other IRI processing (character normalization, for example) is performed by default.
 
@@ -145,7 +141,6 @@
         <altmember cref="T:System.Configuration.IdnElement" />
         <altmember cref="T:System.Configuration.IriParsingElement" />
         <altmember cref="T:System.Uri" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/">Network Settings Schema</related>
       </Docs>
     </Member>
     <Member MemberName="IriParsing">
@@ -189,11 +184,10 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The existing <xref:System.Uri?displayProperty=nameWithType> class has been extended to provide support for International Resource Identifiers (IRI) and Internationalized Domain Names. Users upgrading from .NET Framework 2.0  won't see any change in behavior unless they specifically enable IRI and IDN. This ensures application compatibility with prior versions of the .NET Framework.
 
  The configuration settings for IRI and IDN can be retrieved using the <xref:System.Configuration.UriSection> class. The <xref:System.Configuration.UriSection.IriParsing> property returns the configuration setting for IRI parsing in the <xref:System.Uri?displayProperty=nameWithType> class.
 
- IRI processing must be enabled for IDN processing to be possible. If IRI processing is disabled, then IDN processing will be set to the default setting where the .NET Framework 2.0 behavior is used for compatibility and IDN names are not used.
+ IRI processing must be enabled for IDN processing to be possible. If IRI processing is disabled, then IDN processing will be set to the default setting where IDN names are not used.
 
  The Internationalized Domain Name (IDN) attribute only controls IDN processing. All other IRI processing (character normalization, for example) is performed by default.
 
@@ -206,7 +200,6 @@
         <altmember cref="T:System.Configuration.IdnElement" />
         <altmember cref="T:System.Configuration.IriParsingElement" />
         <altmember cref="T:System.Uri" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/">Network Settings Schema</related>
       </Docs>
     </Member>
     <Member MemberName="Properties">
@@ -293,7 +286,6 @@
         <altmember cref="T:System.Configuration.SchemeSettingElement" />
         <altmember cref="T:System.Configuration.SchemeSettingElementCollection" />
         <altmember cref="T:System.GenericUriParserOptions" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/">Network Settings Schema</related>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
.NET Framework API ref has moved to its own repo (https://github.com/dotnet/dotnetfw-api-docs), so we can clean up .NET Framework remarks, exceptions, and code examples out of this repo. Contributes to #12513.

Removes remarks and examples related to:

- .NET Framework versions
- Code-access security
- Configuring apps via app.config file
- App domains

*Hide whitespace changes*