### PR TITLE
Remove .NET Framework remarks (System.Net/*)

### DIFF
--- a/xml/System.Net/AuthenticationManager.xml
+++ b/xml/System.Net/AuthenticationManager.xml
@@ -134,29 +134,8 @@
         <param name="credentials">The credentials associated with this request.</param>
         <summary>Calls each registered authentication module to find the first module that can respond to the authentication request.</summary>
         <returns>An instance of the <see cref="T:System.Net.Authorization" /> class containing the result of the authorization attempt. If there is no authentication module to respond to the challenge, this method returns <see langword="null" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.AuthenticationManager.Authenticate*> method calls the <xref:System.Net.IAuthenticationModule.Authenticate*?displayProperty=nameWithType> method on each registered authentication module until one of the module responds with an <xref:System.Net.Authorization> instance.
-
- The first <xref:System.Net.Authorization> instance returned is used to authenticate the request. If no authentication module can authenticate the request, the <xref:System.Net.AuthenticationManager.Authenticate*> method returns `null`.
-
- Authentication modules are called in the order in which they are registered with the <xref:System.Net.AuthenticationManager>.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.PlatformNotSupportedException">.NET Core and .NET 5+ only: In all cases.</exception>
-        <exception cref="T:System.ArgumentNullException">
-          <paramref name="challenge" /> is <see langword="null" />.
-
- -or-
-
- <paramref name="request" /> is <see langword="null" />.
-
- -or-
-
- <paramref name="credentials" /> is <see langword="null" />.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="CredentialPolicy">
@@ -349,19 +328,8 @@
         <param name="credentials">The credentials associated with the request.</param>
         <summary>Preauthenticates a request.</summary>
         <returns>An instance of the <see cref="T:System.Net.Authorization" /> class if the request can be preauthenticated; otherwise, <see langword="null" />. If <paramref name="credentials" /> is <see langword="null" />, this method returns <see langword="null" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If the authentication module can preauthenticate the request, the <xref:System.Net.AuthenticationManager.PreAuthenticate*> method returns an Authentication instance and sends the authorization information to the server preemptively instead of waiting for the resource to issue a challenge. This behavior is outlined in section 3.3 of RFC 2617 (HTTP Authentication: Basic and Digest Access Authentication). Authentication modules that support preauthentication allow clients to improve server efficiency by avoiding extra round trips caused by authentication challenges.
-
- Authorization modules that can preauthenticate requests set the <xref:System.Net.IAuthenticationModule.CanPreAuthenticate?displayProperty=nameWithType> property to `true`.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.PlatformNotSupportedException">.NET Core and .NET 5+ only: In all cases.</exception>
-        <exception cref="T:System.ArgumentNullException">
-          <paramref name="request" /> is <see langword="null" />.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="Register">

--- a/xml/System.Net/BindIPEndPoint.xml
+++ b/xml/System.Net/BindIPEndPoint.xml
@@ -67,7 +67,7 @@
 ## Remarks
  Specify that the <xref:System.Net.BindIPEndPoint> delegate is used by a <xref:System.Net.ServicePoint> by setting the <xref:System.Net.ServicePoint.BindIPEndPointDelegate?displayProperty=nameWithType> property with the delegate as an argument. This delegate should specify a local IP address and port number in the returned <xref:System.Net.IPEndPoint>.
 
- If the .NET Framework cannot bind the returned <xref:System.Net.IPEndPoint> to the <xref:System.Net.ServicePoint> after <xref:System.Int32.MaxValue?displayProperty=nameWithType> attempts, an <xref:System.OverflowException> is thrown.
+ If .NET cannot bind the returned <xref:System.Net.IPEndPoint> to the <xref:System.Net.ServicePoint> after <xref:System.Int32.MaxValue?displayProperty=nameWithType> attempts, an <xref:System.OverflowException> is thrown.
 
  If you want the delegate to give the service point control of the connection binding, the delegate should return `null`. If you want to abort the connection, the delegate must throw an exception.
 

--- a/xml/System.Net/Dns.xml
+++ b/xml/System.Net/Dns.xml
@@ -140,7 +140,7 @@
  The <xref:System.Net.Dns.BeginGetHostAddresses*> method asynchronously queries a DNS server for the IP addresses that are associated with a host name. If `hostNameOrAddress` is an IP address, this address is returned without querying the DNS server.
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  If an empty string is passed as the `hostNameOrAddress` argument, then this method returns the IPv4 and IPv6 addresses of the local host.
 
@@ -247,7 +247,7 @@
  For detailed information about using the asynchronous programming model, see [Calling Synchronous Methods Asynchronously](/dotnet/standard/asynchronous-programming-patterns/calling-synchronous-methods-asynchronously).
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -334,7 +334,7 @@
 ## Remarks
  The <xref:System.Net.Dns.BeginGetHostEntry*> method asynchronously queries a DNS server for the IP addresses and aliases associated with an IP address.
 
- **Note** This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+ **Note** This member emits trace information when you enable network tracing in your application.
 
  The asynchronous <xref:System.Net.Dns.BeginGetHostEntry*> operation must be completed by calling the <xref:System.Net.Dns.EndGetHostEntry*> method. Typically, the method is invoked by the `requestCallback` delegate.
 
@@ -426,7 +426,7 @@
 ## Remarks
  The <xref:System.Net.Dns.BeginGetHostEntry*> method queries a DNS server for the IP address that is associated with a host name or IP address.
 
- **Note** This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+ **Note** This member emits trace information when you enable network tracing in your application.
 
  The asynchronous <xref:System.Net.Dns.BeginGetHostEntry*> operation must be completed by calling the <xref:System.Net.Dns.EndGetHostEntry*> method. Typically, the method is invoked by the `requestCallback` delegate.
 
@@ -539,7 +539,7 @@
  For more information about using the asynchronous programming model, see [Calling Synchronous Methods Asynchronously](/dotnet/standard/asynchronous-programming-patterns/calling-synchronous-methods-asynchronously).
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -600,7 +600,7 @@
  If an empty string is passed as the `hostNameOrAddress` argument, then this method returns the IPv4 and IPv6 addresses of the local host.
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -674,7 +674,7 @@
  If the <xref:System.Net.Configuration.Ipv6Element.Enabled?displayProperty=nameWithType> property is set to `true`, the <xref:System.Net.IPHostEntry.Aliases> property of the <xref:System.Net.IPHostEntry> instance returned is not populated by this method and will always be empty.
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -736,7 +736,7 @@
  To perform this operation synchronously, use a <xref:System.Net.Dns.GetHostEntry*> method.
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -812,7 +812,7 @@
  To perform this operation synchronously, use the <xref:System.Net.Dns.Resolve*> method.
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -876,7 +876,7 @@
  This method is implemented using the underlying operating system's name resolution APIs (such as the Win32 API getaddrinfo on Windows, and equivalent APIs on other platforms).  If a host is described in the `hosts` file, the IP address or addresses there will be returned without querying the DNS server.
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
 
 
@@ -1139,7 +1139,7 @@
 ## Remarks
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -1211,7 +1211,7 @@
 ## Remarks
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -1290,7 +1290,7 @@
  If the <xref:System.Net.Configuration.Ipv6Element.Enabled?displayProperty=nameWithType> property is set to `true`, the <xref:System.Net.IPHostEntry.Aliases> property of the <xref:System.Net.IPHostEntry> instance returned is not populated by this method and will always be empty.
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -1363,7 +1363,7 @@
  The <xref:System.Net.IPHostEntry.Aliases> property of the <xref:System.Net.IPHostEntry> instance returned is not populated by this method and will always be empty.
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example uses the <xref:System.Net.Dns.GetHostEntry*> method to resolve an IP address to an <xref:System.Net.IPHostEntry> instance.
@@ -1453,7 +1453,7 @@
  The <xref:System.Net.IPHostEntry.Aliases> property of the <xref:System.Net.IPHostEntry> instance returned is not populated by this method and will always be empty.
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
 
 
@@ -1571,7 +1571,7 @@
  The <xref:System.Net.IPHostEntry.Aliases> property of the <xref:System.Net.IPHostEntry> instance returned is not populated by this method and will always be empty.
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Dns.GetHostEntry(System.Net.IPAddress)>.
 
@@ -1661,7 +1661,7 @@
  This method is implemented using the underlying operating system's name resolution APIs (such as the Win32 API getaddrinfo on Windows, and equivalent APIs on other platforms).  If a host is described in the `hosts` file, the IP address or addresses there will be returned without querying the DNS server.
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Dns.GetHostEntry(System.String)>.
 
@@ -1869,7 +1869,7 @@
  If the <xref:System.Net.Configuration.Ipv6Element.Enabled?displayProperty=nameWithType> property is set to `true`, the <xref:System.Net.IPHostEntry.Aliases> property of the <xref:System.Net.IPHostEntry> instance returned is not populated by this method and will always be empty.
 
 > [!NOTE]
-> This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member emits trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>

--- a/xml/System.Net/DnsPermission.xml
+++ b/xml/System.Net/DnsPermission.xml
@@ -50,8 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The default permissions allow all local and Intranet zone applications to access DNS services, and no DNS permission for Internet zone applications.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.SecurityZone" />
@@ -89,14 +87,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Creates a new instance of the <see cref="T:System.Net.DnsPermission" /> class that either allows unrestricted DNS access or disallows DNS access.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If `state` is <xref:System.Security.Permissions.PermissionState.Unrestricted>, the <xref:System.Net.DnsPermission> instance passes all demands. If `state` contains any other value, the <xref:System.Net.DnsPermission> instance fails all demands.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="state" /> is not a valid <see cref="T:System.Security.Permissions.PermissionState" /> value.</exception>
       </Docs>
@@ -134,14 +125,7 @@
       <Docs>
         <summary>Creates an identical copy of the current permission instance.</summary>
         <returns>A new instance of the <see cref="T:System.Net.DnsPermission" /> class that is an identical copy of the current instance.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a <xref:System.Net.DnsPermission> instance provides the same access to DNS servers as the original permission instance.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -179,16 +163,7 @@
       <Docs>
         <param name="securityElement">The XML encoding to use to reconstruct the <see cref="T:System.Net.DnsPermission" /> instance.</param>
         <summary>Reconstructs a <see cref="T:System.Net.DnsPermission" /> instance from an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.DnsPermission.FromXml*> method reconstructs a <xref:System.Net.DnsPermission> instance from an XML encoding defined by the <xref:System.Security.SecurityElement> class.
-
- Use the <xref:System.Net.DnsPermission.ToXml*> method to XML-encode the <xref:System.Net.DnsPermission> instance, including state information.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="securityElement" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
@@ -232,14 +207,7 @@
         <param name="target">The <see cref="T:System.Net.DnsPermission" /> instance to intersect with the current instance.</param>
         <summary>Creates a permission instance that is the intersection of the current permission instance and the specified permission instance.</summary>
         <returns>A <see cref="T:System.Net.DnsPermission" /> instance that represents the intersection of the current <see cref="T:System.Net.DnsPermission" /> instance with the specified <see cref="T:System.Net.DnsPermission" /> instance, or <see langword="null" /> if the intersection is empty. If both the current instance and <paramref name="target" /> are unrestricted, this method returns a new <see cref="T:System.Net.DnsPermission" /> instance that is unrestricted; otherwise, it returns <see langword="null" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.DnsPermission.Intersect*> method returns a <xref:System.Net.DnsPermission> instance that allows the access defined by both the current <xref:System.Net.DnsPermission> instance and the specified <xref:System.Net.DnsPermission> instance. Any demand must pass both permissions to pass their intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is neither a <see cref="T:System.Net.DnsPermission" /> nor <see langword="null" />.</exception>
       </Docs>
@@ -281,16 +249,7 @@
         <summary>Determines whether the current permission instance is a subset of the specified permission instance.</summary>
         <returns>
           <see langword="false" /> if the current instance is unrestricted and <paramref name="target" /> is either <see langword="null" /> or unrestricted; otherwise, <see langword="true" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current <xref:System.Net.DnsPermission> instance is a subset of the specified <xref:System.Net.DnsPermission> instance if the current <xref:System.Net.DnsPermission> instance specifies a set of operations that is wholly contained by the specified <xref:System.Net.DnsPermission> instance.
-
- If the <xref:System.Net.DnsPermission.IsSubsetOf*> method returns `true`, the current <xref:System.Net.DnsPermission> instance allows no more access to DNS servers than does the specified <xref:System.Net.DnsPermission> instance.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is neither a <see cref="T:System.Net.DnsPermission" /> nor <see langword="null" />.</exception>
       </Docs>
@@ -368,16 +327,7 @@
       <Docs>
         <summary>Creates an XML encoding of a <see cref="T:System.Net.DnsPermission" /> instance and its current state.</summary>
         <returns>A <see cref="T:System.Security.SecurityElement" /> instance that contains an XML-encoded representation of the security object, including state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.DnsPermission.ToXml*> method creates a <xref:System.Security.SecurityElement> instance to XML-encode a representation of the <xref:System.Net.DnsPermission> instance, including state information.
-
- Use the <xref:System.Net.DnsPermission.FromXml*> method to restore the state information from a <xref:System.Security.SecurityElement> instance.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -416,14 +366,7 @@
         <param name="target">The <see cref="T:System.Net.DnsPermission" /> instance to combine with the current instance.</param>
         <summary>Creates a permission instance that is the union of the current permission instance and the specified permission instance.</summary>
         <returns>A <see cref="T:System.Net.DnsPermission" /> instance that represents the union of the current <see cref="T:System.Net.DnsPermission" /> instance with the specified <see cref="T:System.Net.DnsPermission" /> instance. If <paramref name="target" /> is <see langword="null" />, this method returns a copy of the current instance. If the current instance or <paramref name="target" /> is unrestricted, this method returns a <see cref="T:System.Net.DnsPermission" /> instance that is unrestricted; otherwise, it returns a <see cref="T:System.Net.DnsPermission" /> instance that is restricted.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.DnsPermission.Union*> method returns a <xref:System.Net.DnsPermission> instance that allows the access defined by either the current <xref:System.Net.DnsPermission> instance or the specified <xref:System.Net.DnsPermission> instance. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is neither a <see cref="T:System.Net.DnsPermission" /> nor <see langword="null" />.</exception>
       </Docs>

--- a/xml/System.Net/DnsPermissionAttribute.xml
+++ b/xml/System.Net/DnsPermissionAttribute.xml
@@ -50,17 +50,8 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The security information declared by <xref:System.Net.DnsPermissionAttribute> is stored in the metadata of the attribute target, which is the class to which the <xref:System.Net.DnsPermissionAttribute> is applied. The system then accesses this information at run time. The <xref:System.Security.Permissions.SecurityAction> that is passed to the constructor determines the allowable DNS targets.
-
- These security attributes are used only for Declarative Security. For Imperative Security, use the corresponding <xref:System.Net.DnsPermission> class.
-
- Security access is either fully restricted or fully unrestricted. Set the <xref:System.Security.Permissions.PermissionState.Unrestricted> property to `true` to grant access, or `false` for no access. Set this property as a named parameter.
-
- For more information about using attributes, see [Attributes](/dotnet/standard/attributes/).
-
  ]]></format>
     </remarks>
-    <altmember cref="T:System.Security.Permissions.CodeAccessSecurityAttribute" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -95,14 +86,7 @@
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.DnsPermissionAttribute" /> class with the specified <see cref="T:System.Security.Permissions.SecurityAction" /> value.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.SecurityAction> value that is passed to this constructor specifies the allowable <xref:System.Net.DnsPermissionAttribute> targets.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="action" /> parameter is not a valid <see cref="T:System.Security.Permissions.SecurityAction" />.</exception>
         <altmember cref="T:System.Security.Permissions.SecurityAction" />
       </Docs>
@@ -140,16 +124,7 @@
       <Docs>
         <summary>Creates and returns a new instance of the <see cref="T:System.Net.DnsPermission" /> class.</summary>
         <returns>A <see cref="T:System.Net.DnsPermission" /> that corresponds to the security declaration.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The `CreatePermission` method is called by the security system, not by application code.
-
- The security information described by <xref:System.Net.DnsPermissionAttribute> is stored in the metadata of the attribute target, which is the class to which <xref:System.Net.DnsPermissionAttribute> is applied. The system then accesses the information at run time and calls <xref:System.Net.DnsPermissionAttribute.CreatePermission*>. The system uses the returned <xref:System.Security.IPermission> to enforce the specified security requirements.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Net/FileWebRequest.xml
+++ b/xml/System.Net/FileWebRequest.xml
@@ -67,10 +67,8 @@
 
  When you want to write data to a file, the <xref:System.Net.FileWebRequest.GetRequestStream*> method returns a <xref:System.IO.Stream> instance to write to. The <xref:System.Net.FileWebRequest.BeginGetRequestStream*> and <xref:System.Net.FileWebRequest.EndGetRequestStream*> methods provide asynchronous access to the write data stream.
 
- The <xref:System.Net.FileWebRequest> class relies on the <xref:System.IO.File> class for error handling and code access security.
-
-
-
+ The <xref:System.Net.FileWebRequest> class relies on the <xref:System.IO.File> class for error handling.
+ 
 ## Examples
  The following code example uses the <xref:System.Net.FileWebRequest> class to access a file system resource.
 
@@ -196,7 +194,7 @@
 ## Remarks
  The <xref:System.Net.FileWebRequest.Abort*> method cancels a request to a resource. After a request is canceled, calling the <xref:System.Net.FileWebRequest.GetResponse*>, <xref:System.Net.FileWebRequest.BeginGetResponse*>, <xref:System.Net.FileWebRequest.EndGetResponse*>, <xref:System.Net.FileWebRequest.GetRequestStream*>, <xref:System.Net.FileWebRequest.BeginGetRequestStream*>, or <xref:System.Net.FileWebRequest.EndGetRequestStream*> method causes a <xref:System.Net.WebException> with the <xref:System.Net.WebException.Status> property set to <xref:System.Net.WebExceptionStatus.RequestCanceled>.
 
- **Note** This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>

--- a/xml/System.Net/FileWebResponse.xml
+++ b/xml/System.Net/FileWebResponse.xml
@@ -65,7 +65,7 @@
 
  The <xref:System.Net.FileWebResponse.GetResponseStream*> method returns a <xref:System.IO.Stream> instance that provides read-only access to a file system resource.
 
- The <xref:System.Net.FileWebResponse> class relies on the <xref:System.IO.File> class for error handling and code access security.
+ The <xref:System.Net.FileWebResponse> class relies on the <xref:System.IO.File> class for error handling.
 
  ]]></format>
     </remarks>
@@ -587,14 +587,7 @@
         <summary>Gets a value that indicates whether the <see cref="P:System.Net.FileWebResponse.Headers" /> property is supported by the <see cref="T:System.Net.FileWebResponse" /> instance.</summary>
         <value>
           <see langword="true" /> if the <see cref="P:System.Net.FileWebResponse.Headers" /> property is supported by the <see cref="T:System.Net.FileWebResponse" /> instance; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property is always true for .NET Framework 4.5.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Runtime.Serialization.ISerializable.GetObjectData">

--- a/xml/System.Net/FtpWebRequest.xml
+++ b/xml/System.Net/FtpWebRequest.xml
@@ -60,7 +60,7 @@
 
  To obtain an instance of <xref:System.Net.FtpWebRequest>, use the <xref:System.Net.WebRequest.Create*> method. You can also use the <xref:System.Net.WebClient> class to upload and download information from an FTP server. Using either of these approaches, when you specify a network resource that uses the FTP scheme (for example, `"ftp://contoso.com"`) the <xref:System.Net.FtpWebRequest> class provides the ability to programmatically interact with FTP servers.
 
- The URI may be relative or absolute. If the URI is of the form `"ftp://contoso.com/%2fpath"` (%2f is an escaped '/'), then the URI is absolute, and the current directory is `/path`. If, however, the URI is of the form `"ftp://contoso.com/path"`, first the .NET Framework logs into the FTP server (using the user name and password set by the <xref:System.Net.FtpWebRequest.Credentials> property), then the current directory is set to `<UserLoginDirectory>/path`.
+ The URI can be relative or absolute. If the URI is of the form `"ftp://contoso.com/%2fpath"` (%2f is an escaped '/'), then the URI is absolute, and the current directory is `/path`. If, however, the URI is of the form `"ftp://contoso.com/path"`, first .NET logs into the FTP server (using the user name and password set by the <xref:System.Net.FtpWebRequest.Credentials> property), then the current directory is set to `<UserLoginDirectory>/path`.
 
  You must have a valid user name and password for the server or the server must allow anonymous logon. You can specify the credentials used to connect to the server by setting the <xref:System.Net.FtpWebRequest.Credentials> property or you can include them in the <xref:System.Uri.UserInfo*> portion of the URI passed to the <xref:System.Net.WebRequest.Create*> method. If you include <xref:System.Uri.UserInfo*> information in the URI, the <xref:System.Net.FtpWebRequest.Credentials> property is set to a new network credential with the specified user name and password information.
 
@@ -157,9 +157,7 @@
  If there is no operation in progress, this method does nothing. If a file transfer is in progress, this method terminates the transfer.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
+> This member emits trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates how the user can terminate an asynchronous upload of a file from the local directory to the server.
@@ -238,9 +236,7 @@
  For detailed information about using the asynchronous programming model, see [Calling Synchronous Methods Asynchronously](/dotnet/standard/asynchronous-programming-patterns/calling-synchronous-methods-asynchronously).
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
+> This member emits trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates beginning an asynchronous operation to get a request's stream. This code example is part of a larger example provided for the <xref:System.Net.FtpWebRequest> class overview.
@@ -326,9 +322,7 @@
 
  For more information about using the asynchronous programming model, see [Calling Synchronous Methods Asynchronously](/dotnet/standard/asynchronous-programming-patterns/calling-synchronous-methods-asynchronously).
 
- This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
+ This member emits trace information when you enable network tracing in your application.> [!NOTE]
 > If a <xref:System.Net.WebException> is thrown, use the <xref:System.Net.WebException.Response*> and <xref:System.Net.WebException.Status*> properties of the exception to determine the response from the server.
 
 
@@ -404,7 +398,7 @@
  Client certificates are used to authenticate the client during the initial SSL connection negotiation. For more information, see <xref:System.Net.FtpWebRequest.EnableSsl*>.
 
 > [!NOTE]
-> The .NET Framework caches SSL sessions as they are created and attempts to reuse a cached session for a new request, if possible. When attempting to reuse an SSL session, the .NET Framework uses the first element of <xref:System.Net.HttpWebRequest.ClientCertificates*> (if there is one), or tries to reuse an anonymous session if <xref:System.Net.HttpWebRequest.ClientCertificates*> is empty.
+> .NET caches SSL sessions as they are created and attempts to reuse a cached session for a new request, if possible. When attempting to reuse an SSL session, .NET uses the first element of <xref:System.Net.HttpWebRequest.ClientCertificates*> (if there is one), or tries to reuse an anonymous session if <xref:System.Net.HttpWebRequest.ClientCertificates*> is empty.
 
  ]]></format>
         </remarks>
@@ -460,13 +454,11 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Connection groups associate a set of requests with a particular connection or set of connections. The connections in a connection group can be reused only by requests originating in the same application domain, when the credentials on the request are the same and the request specifies the connection group name. When a request does not specify a connection group name, any existing connection to the requested server that is not associated with a connection group can be used. When the credentials are not the same, the existing connection is closed and the new request must be reauthenticated.
+ Connection groups associate a set of requests with a particular connection or set of connections. The connections in a connection group can be reused only by requests that have the same credentials and that specify the connection group name. When a request does not specify a connection group name, any existing connection to the requested server that is not associated with a connection group can be used. When the credentials are not the same, the existing connection is closed and the new request must be reauthenticated.
 
  Using connection groups can improve performance because this allows all of the requests for a user to reuse the connection authenticated with the user's credentials.
 
  Changing the <xref:System.Net.FtpWebRequest.ConnectionGroupName> property after calling the <xref:System.Net.FtpWebRequest.GetRequestStream*>, <xref:System.Net.FtpWebRequest.BeginGetRequestStream*>, <xref:System.Net.FtpWebRequest.GetResponse*>, or <xref:System.Net.FtpWebRequest.BeginGetResponse*> method causes an <xref:System.InvalidOperationException> exception.
-
-
 
 ## Examples
  The following code example retrieves the value of this property.
@@ -782,7 +774,6 @@
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The caller tried to set this property to <see langword="null" />.</exception>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/defaultftpcachepolicy-element-network-settings">defaultFtpCachePolicy (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="EnableSsl">
@@ -903,9 +894,7 @@
  In addition to the exceptions noted in "Exceptions," <xref:System.Net.FtpWebRequest.EndGetRequestStream*> rethrows exceptions that were thrown while opening the stream for writing.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
+> This member emits trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates ending an asynchronous operation to get a request's stream. This code example is part of a larger example provided for the <xref:System.Net.FtpWebRequest> class overview.
@@ -978,9 +967,7 @@
  In addition to the exceptions noted in "Exceptions," <xref:System.Net.FtpWebRequest.EndGetResponse*> rethrows exceptions that were thrown while communicating with the server.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
+> This member emits trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates ending an asynchronous operation to get a response. This code example is part of a larger example provided for the <xref:System.Net.FtpWebRequest> class overview.
@@ -1057,9 +1044,7 @@
  <xref:System.Net.FtpWebRequest.GetRequestStream*> blocks while waiting for the stream. To prevent this, call the <xref:System.Net.FtpWebRequest.BeginGetRequestStream*> method in place of <xref:System.Net.FtpWebRequest.GetRequestStream*>.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
+> This member emits trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates copying a file to a request's data stream and sending a request to the server to upload the data and append it to a file.
@@ -1138,9 +1123,7 @@
 
  If a <xref:System.Net.WebException> is thrown, use the <xref:System.Net.WebException.Response*> and <xref:System.Net.WebException.Status*> properties of the exception to determine the response from the server.
 
- This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
+ This member emits trace information when you enable network tracing in your application.> [!NOTE]
 > Multiple calls to <xref:System.Net.FtpWebRequest.GetResponse*> return the same response object; the request is not reissued.
 
 
@@ -1464,32 +1447,19 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the proxy used to communicate with the FTP server.</summary>
-        <value>An <see cref="T:System.Net.IWebProxy" /> instance responsible for communicating with the FTP server. On .NET Core, its value is <see langword="null" />. </value>
+        <value>Always <see langword="null" />. </value>
         <remarks>
           <format type="text/markdown"><![CDATA[
+
 > [!NOTE]
-> This property is not supported on .NET Core, and setting it has no effect. Getting the property value returns `null`.
+> This property is not supported, and setting it has no effect. Getting the property value returns `null`.
 
 For more information about this API, see [Supplemental API remarks for System.Net.FtpWebRequest.Proxy](/dotnet/fundamentals/runtime-libraries/system-net-ftpwebrequest-proxy).
+
           ]]></format>
         </remarks>
-        <example>
-          <format type="text/markdown"><![CDATA[
-The following code example displays this property value.
-
-:::code language="csharp" source="~/snippets/csharp/System.Net/FtpStatusCode/Overview/ftptests.cs" id="Snippet16":::
-          ]]></format>
-        </example>
         <exception cref="T:System.ArgumentNullException">This property cannot be set to <see langword="null" />.</exception>
         <exception cref="T:System.InvalidOperationException">A new value was specified for this property for a request that is already in progress.</exception>
-        <altmember cref="T:System.Net.FtpWebResponse" />
-        <altmember cref="T:System.Net.FtpStatusCode" />
-        <altmember cref="T:System.Net.WebRequestMethods.Ftp" />
-        <altmember cref="T:System.Net.WebRequest" />
-        <altmember cref="T:System.Net.WebResponse" />
-        <altmember cref="T:System.Net.WebClient" />
-        <altmember cref="T:System.Net.WebProxy" />
-        <altmember cref="T:System.Net.GlobalProxySelection" />
       </Docs>
     </Member>
     <Member MemberName="ReadWriteTimeout">

--- a/xml/System.Net/FtpWebRequest.xml
+++ b/xml/System.Net/FtpWebRequest.xml
@@ -322,7 +322,9 @@
 
  For more information about using the asynchronous programming model, see [Calling Synchronous Methods Asynchronously](/dotnet/standard/asynchronous-programming-patterns/calling-synchronous-methods-asynchronously).
 
- This member emits trace information when you enable network tracing in your application.> [!NOTE]
+ This member emits trace information when you enable network tracing in your application.
+ 
+ > [!NOTE]
 > If a <xref:System.Net.WebException> is thrown, use the <xref:System.Net.WebException.Response*> and <xref:System.Net.WebException.Status*> properties of the exception to determine the response from the server.
 
 

--- a/xml/System.Net/FtpWebResponse.xml
+++ b/xml/System.Net/FtpWebResponse.xml
@@ -183,9 +183,7 @@
  The <xref:System.Net.FtpWebResponse.Close*> method closes the data stream returned by the <xref:System.Net.FtpWebResponse.GetResponseStream*> method if the <xref:System.Net.FtpWebRequest.KeepAlive> property is `false`. During the close, data might be sent to the server on the control connection.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example downloads data from a server, reads the data from the response stream, and then closes it.
@@ -783,17 +781,9 @@ This property is provided only for compatibility with other implementations of t
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the <see cref="P:System.Net.FtpWebResponse.Headers" /> property is supported by the <see cref="T:System.Net.FtpWebResponse" /> instance.</summary>
-        <value>Returns <see cref="T:System.Boolean" />.
-
- <see langword="true" /> if the <see cref="P:System.Net.FtpWebResponse.Headers" /> property is supported by the <see cref="T:System.Net.FtpWebResponse" /> instance; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property is always true for .NET Framework 4.5.
-
- ]]></format>
-        </remarks>
+        <value>
+          <see langword="true" /> if the <see cref="P:System.Net.FtpWebResponse.Headers" /> property is supported by the <see cref="T:System.Net.FtpWebResponse" /> instance; otherwise, <see langword="false" />.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="WelcomeMessage">

--- a/xml/System.Net/GlobalProxySelection.xml
+++ b/xml/System.Net/GlobalProxySelection.xml
@@ -75,7 +75,6 @@
 
  ]]></format>
     </remarks>
-    <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings">DefaultProxy Element (Network Settings)</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Net/HttpListener.xml
+++ b/xml/System.Net/HttpListener.xml
@@ -117,7 +117,7 @@
         </remarks>
         <exception cref="T:System.PlatformNotSupportedException">This class cannot be used on the current operating system. Windows Server 2003 or Windows XP SP2 is required to use instances of this class.</exception>
         <block subset="none" type="usage">
-          <para>Note: This member outputs trace information when you enable network tracing in your application. For more information, see <see href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</see>.</para>
+          <para>Note: This member outputs trace information when you enable network tracing in your application.</para>
         </block>
       </Docs>
     </Member>
@@ -178,7 +178,7 @@
  ]]></format>
         </remarks>
         <block subset="none" type="usage">
-          <para>This member outputs trace information when you enable network tracing in your application. For more information, see <see href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</see>.</para>
+          <para>This member outputs trace information when you enable network tracing in your application.</para>
         </block>
       </Docs>
     </Member>
@@ -406,7 +406,7 @@
         <exception cref="T:System.InvalidOperationException">This object has not been started or is currently stopped.</exception>
         <exception cref="T:System.ObjectDisposedException">This object is closed.</exception>
         <block subset="none" type="usage">
-          <para>This member outputs trace information when you enable network tracing in your application. For more information, see <see href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</see>.</para>
+          <para>This member outputs trace information when you enable network tracing in your application.</para>
         </block>
       </Docs>
     </Member>
@@ -466,7 +466,7 @@ The following code example demonstrates calling the `Close` method:
  ]]></format>
         </remarks>
         <block subset="none" type="usage">
-          <para>This member outputs trace information when you enable network tracing in your application. For more information, see <see href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</see>.</para>
+          <para>This member outputs trace information when you enable network tracing in your application.</para>
         </block>
       </Docs>
     </Member>
@@ -620,7 +620,7 @@ The following code example demonstrates calling the `Close` method:
         <exception cref="T:System.InvalidOperationException">The <see cref="M:System.Net.HttpListener.EndGetContext(System.IAsyncResult)" /> method was already called for the specified <paramref name="asyncResult" /> object.</exception>
         <exception cref="T:System.ObjectDisposedException">This object is closed.</exception>
         <block subset="none" type="usage">
-          <para>This member outputs trace information when you enable network tracing in your application. For more information, see <see href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</see>.</para>
+          <para>This member outputs trace information when you enable network tracing in your application.</para>
         </block>
       </Docs>
     </Member>
@@ -828,7 +828,7 @@ The following code example demonstrates calling the `Close` method:
  The <see cref="T:System.Net.HttpListener" /> does not have any Uniform Resource Identifier (URI) prefixes to respond to.</exception>
         <exception cref="T:System.ObjectDisposedException">This object is closed.</exception>
         <block subset="none" type="usage">
-          <para>This member outputs trace information when you enable network tracing in your application. For more information, see <see href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</see>.</para>
+          <para>This member outputs trace information when you enable network tracing in your application.</para>
         </block>
       </Docs>
     </Member>
@@ -1237,7 +1237,7 @@ The following code example demonstrates calling the `Close` method:
         <exception cref="T:System.Net.HttpListenerException">A Win32 function call failed. Check the exception's <see cref="P:System.Net.HttpListenerException.ErrorCode" /> property to determine the cause of the exception.</exception>
         <exception cref="T:System.ObjectDisposedException">This object is closed.</exception>
         <block subset="none" type="usage">
-          <para>This member outputs trace information when you enable network tracing in your application. For more information, see <see href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</see>.</para>
+          <para>This member outputs trace information when you enable network tracing in your application.</para>
         </block>
       </Docs>
     </Member>
@@ -1300,7 +1300,7 @@ The following code example demonstrates using the <xref:System.Net.HttpListener.
         </remarks>
         <exception cref="T:System.ObjectDisposedException">This object has been closed.</exception>
         <block subset="none" type="usage">
-          <para>This member outputs trace information when you enable network tracing in your application. For more information, see <see href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</see>.</para>
+          <para>This member outputs trace information when you enable network tracing in your application.</para>
         </block>
       </Docs>
     </Member>

--- a/xml/System.Net/HttpListenerContext.xml
+++ b/xml/System.Net/HttpListenerContext.xml
@@ -508,7 +508,7 @@
  ]]></format>
         </remarks>
         <block subset="none" type="usage">
-          <para>Note: This member outputs trace information when you enable network tracing in your application. For more information, see <see href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</see>.</para>
+          <para>Note: This member outputs trace information when you enable network tracing in your application.</para>
         </block>
       </Docs>
     </Member>

--- a/xml/System.Net/HttpListenerPrefixCollection.xml
+++ b/xml/System.Net/HttpListenerPrefixCollection.xml
@@ -220,7 +220,7 @@
         <exception cref="T:System.Net.HttpListenerException">A Windows function call failed. Check the exception's <see cref="P:System.Net.HttpListenerException.ErrorCode" /> property to determine the cause of the exception.</exception>
         <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.HttpListener" /> associated with this collection is closed.</exception>
         <block subset="none" type="usage">
-          <para>This member outputs trace information when you enable network tracing in your application. For more information, see <see href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</see>.</para>
+          <para>This member outputs trace information when you enable network tracing in your application.</para>
         </block>
         <altmember cref="T:System.Net.HttpListener" />
       </Docs>
@@ -719,7 +719,7 @@
         <exception cref="T:System.Net.HttpListenerException">A Windows function call failed. To determine the cause of the exception, check the exception's error code.</exception>
         <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.HttpListener" /> associated with this collection is closed.</exception>
         <block subset="none" type="usage">
-          <para>This member outputs trace information when you enable network tracing in your application. For more information, see <see href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</see>.</para>
+          <para>This member outputs trace information when you enable network tracing in your application.</para>
         </block>
         <altmember cref="T:System.Net.HttpListener" />
       </Docs>

--- a/xml/System.Net/HttpListenerRequest.xml
+++ b/xml/System.Net/HttpListenerRequest.xml
@@ -917,7 +917,7 @@
  ]]></format>
         </remarks>
         <block subset="none" type="usage">
-          <para>This member outputs trace information when you enable network tracing in your application. For more information, see <see href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</see>.</para>
+          <para>This member outputs trace information when you enable network tracing in your application.</para>
         </block>
         <altmember cref="T:System.Net.HttpListener" />
         <altmember cref="T:System.Net.HttpListenerContext" />
@@ -1817,8 +1817,6 @@
         <altmember cref="T:System.Net.HttpListener" />
         <altmember cref="T:System.Net.HttpListenerContext" />
         <altmember cref="T:System.Net.HttpListenerResponse" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/">Network Settings Schema</related>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/httplistener-element-network-settings">&lt;httpListener&gt; Element (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="UrlReferrer">

--- a/xml/System.Net/HttpListenerResponse.xml
+++ b/xml/System.Net/HttpListenerResponse.xml
@@ -195,7 +195,6 @@
  -or-
 
  <paramref name="name" /> or <paramref name="value" /> contains invalid characters.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">.NET Framework and .NET Core versions 2.0 - 3.1 only: The length of <paramref name="value" /> is greater than 65,535 characters.</exception>
         <altmember cref="T:System.Net.HttpListener" />
         <altmember cref="T:System.Net.HttpListenerContext" />
         <altmember cref="T:System.Net.HttpListenerRequest" />
@@ -330,8 +329,8 @@
 
  -or-
 
- <paramref name="name" /> or <paramref name="value" /> contains invalid characters.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">.NET Framework and .NET Core versions 2.0 - 3.1 only: The length of <paramref name="value" /> is greater than 65,535 characters.</exception>
+ <paramref name="name" /> or <paramref name="value" /> contains invalid characters.
+        </exception>
         <altmember cref="T:System.Net.HttpListener" />
         <altmember cref="T:System.Net.HttpListenerContext" />
         <altmember cref="T:System.Net.HttpListenerRequest" />

--- a/xml/System.Net/HttpWebRequest.xml
+++ b/xml/System.Net/HttpWebRequest.xml
@@ -68,124 +68,22 @@
 
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest> class provides support for the properties and methods defined in <xref:System.Net.WebRequest> and for additional properties and methods that enable the user to interact directly with servers using HTTP.
-
- Do not use the <xref:System.Net.HttpWebRequest.%23ctor*> constructor. Use the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method to initialize new <xref:System.Net.HttpWebRequest> objects. If the scheme for the Uniform Resource Identifier (URI) is `http://` or `https://`, <xref:System.Net.WebRequest.Create*> returns an <xref:System.Net.HttpWebRequest> object.
-
- The <xref:System.Net.HttpWebRequest.GetResponse*> method makes a synchronous request to the resource specified in the <xref:System.Net.HttpWebRequest.RequestUri> property and returns an <xref:System.Net.HttpWebResponse> that contains the response object. The response data can be received by using the stream returned by <xref:System.Net.HttpWebResponse.GetResponseStream*>. If the response object or the response stream is closed, remaining data will be forfeited. The remaining data will be drained and the socket will be re-used for subsequent requests when closing the response object or stream if the following conditions hold: it's a keep-alive or pipelined request, only a small amount of data needs to be received, or the remaining data is received in a small time interval. If none of the mentioned conditions hold or the drain time is exceeded, the socket will be closed. For keep-alive or pipelined connections, we strongly recommend that the application reads the streams until EOF. This ensures that the socket will be re-used for subsequent requests resulting in better performance and less resources used.
-
- When you want to send data to the resource, the <xref:System.Net.HttpWebRequest.GetRequestStream*> method returns a <xref:System.IO.Stream> object to use to send data. The <xref:System.Net.HttpWebRequest.BeginGetRequestStream*> and <xref:System.Net.HttpWebRequest.EndGetRequestStream*> methods provide asynchronous access to the send data stream.
-
- For client authentication with <xref:System.Net.HttpWebRequest>, the client certificate must be installed in the My certificate store of the current user.
-
- The <xref:System.Net.HttpWebRequest> class throws a <xref:System.Net.WebException> when errors occur while accessing a resource. The <xref:System.Net.WebException.Status?displayProperty=nameWithType> property contains a <xref:System.Net.WebExceptionStatus> value that indicates the source of the error. When <xref:System.Net.WebException.Status*?displayProperty=nameWithType> is <xref:System.Net.WebExceptionStatus.ProtocolError?displayProperty=nameWithType>, the <xref:System.Net.WebException.Response> property contains the <xref:System.Net.HttpWebResponse> received from the resource.
-
- <xref:System.Net.HttpWebRequest> exposes common HTTP header values sent to the Internet resource as properties, set by methods, or set by the system; the following table contains a complete list. You can set other headers in the <xref:System.Net.HttpWebRequest.Headers> property as name/value pairs. Note that servers and caches may change or add headers during the request.
-
- The following table lists the HTTP headers that are set either by properties or methods or the system.
-
-|Header|Set by|
-|------------|------------|
-|`Accept`|Set by the <xref:System.Net.HttpWebRequest.Accept> property.|
-|`Connection`|Set by the <xref:System.Net.HttpWebRequest.Connection> property, <xref:System.Net.HttpWebRequest.KeepAlive> property.|
-|`Content-Length`|Set by the <xref:System.Net.HttpWebRequest.ContentLength> property.|
-|`Content-Type`|Set by the <xref:System.Net.HttpWebRequest.ContentType> property.|
-|`Expect`|Set by the <xref:System.Net.HttpWebRequest.Expect> property.|
-|`Date`|Set by the system to current date.|
-|`Host`|Set by the system to current host information.|
-|`If-Modified-Since`|Set by the <xref:System.Net.HttpWebRequest.IfModifiedSince> property.|
-|`Range`|Set by the <xref:System.Net.HttpWebRequest.AddRange*> method.|
-|`Referer`|Set by the <xref:System.Net.HttpWebRequest.Referer> property.|
-|`Transfer-Encoding`|Set by the <xref:System.Net.HttpWebRequest.TransferEncoding> property (the <xref:System.Net.HttpWebRequest.SendChunked> property must be `true`).|
-|`User-Agent`|Set by the <xref:System.Net.HttpWebRequest.UserAgent> property.|
-
-> [!NOTE]
->  <xref:System.Net.HttpWebRequest> is registered automatically. You do not need to call the <xref:System.Net.WebRequest.RegisterPrefix*> method to register <xref:System.Net.HttpWebRequest?displayProperty=nameWithType> before using URIs beginning with `http://` or `https://`.
-
- The local computer or application config file may specify that a default proxy be used. If the <xref:System.Net.HttpWebRequest.Proxy> property is specified, then the proxy settings from the <xref:System.Net.HttpWebRequest.Proxy> property override the local computer or application config file and the <xref:System.Net.HttpWebRequest> instance will use the proxy settings specified. If no proxy is specified in a config file and the <xref:System.Net.HttpWebRequest.Proxy> property is unspecified, the <xref:System.Net.HttpWebRequest> class uses the proxy settings inherited from Internet options on the local computer. If there are no proxy settings in Internet options, the request is sent directly to the server.
-
-> [!NOTE]
-> The Framework caches SSL sessions as they are created and attempts to reuse a cached session for a new request, if possible. When attempting to reuse an SSL session, the Framework uses the first element of <xref:System.Net.HttpWebRequest.ClientCertificates*> (if there is one), or tries to reuse an anonymous sessions if <xref:System.Net.HttpWebRequest.ClientCertificates*> is empty.
-
-> [!NOTE]
-> For security reasons, cookies are disabled by default. If you want to use cookies, use the <xref:System.Net.HttpWebRequest.CookieContainer> property to enable cookies.
-
-For apps that use TLS/SSL through APIs such as HttpClient, HttpWebRequest, FTPClient, SmtpClient, and SsStream, .NET blocks insecure cipher and hashing algorithms for connections by default. You might need to opt out of this behavior to maintain interoperability with existing SSL3 services OR TLS w/ RC4 services. [Cannot connect to a server by using the ServicePointManager or SslStream APIs after upgrade to the .NET Framework 4.6](https://support.microsoft.com/kb/3069494) explains how to modify your code to disable this behavior, if necessary.
-
-## Examples
- The following code example creates an <xref:System.Net.HttpWebRequest> for the URI `http://www.contoso.com/`.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Overview/source.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Overview/source.vb" id="Snippet1":::
-
  ]]></format>
     </remarks>
-    <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings">DefaultProxy Element (Network Settings)</related>
-    <related type="Article" href="/dotnet/framework/network-programming/changes-to-ntlm-authentication-for-httpwebrequest-in-version-3-5-sp1">Changes to NTLM authentication for HTTPWebRequest in Version 3.5 SP1</related>
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
-        <summary>Initializes a new instance of the <see cref="T:System.Net.HttpWebRequest" /> class. These constructors are obsolete; see the Remarks section for details. </summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Net.HttpWebRequest" /> class. These constructors are obsolete.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
-Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not be used. Call the <xref:System.Net.WebRequest.CreateHttp*?displayProperty=nameWithType> method to initialize new <xref:System.Net.HttpWebRequest> objects.
-
-      ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </MemberGroup>
-    <Member MemberName=".ctor">
-      <MemberSignature Language="C#" Value="public HttpWebRequest ();" FrameworkAlternate="netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netframework-4.7.1;netframework-4.7.2;netframework-4.8;netframework-4.8.1" />
-      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" FrameworkAlternate="netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netframework-4.7.1;netframework-4.7.2;netframework-4.8;netframework-4.8.1" />
-      <MemberSignature Language="DocId" Value="M:System.Net.HttpWebRequest.#ctor" FrameworkAlternate="netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netframework-4.7.1;netframework-4.7.2;netframework-4.8;netframework-4.8.1" />
-      <MemberSignature Language="VB.NET" Value="Public Sub New ()" FrameworkAlternate="netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netframework-4.7.1;netframework-4.7.2;netframework-4.8;netframework-4.8.1" />
-      <MemberSignature Language="C++ CLI" Value="public:&#xA; HttpWebRequest();" FrameworkAlternate="netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netframework-4.7.1;netframework-4.7.2;netframework-4.8;netframework-4.8.1" />
-      <MemberType>Constructor</MemberType>
-      <AssemblyInfo>
-        <AssemblyName>System</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>System.Net.Requests</AssemblyName>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>netstandard</AssemblyName>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>System.Net</AssemblyName>
-      </AssemblyInfo>
-      <Attributes>
-        <Attribute FrameworkAlternate="netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netframework-4.7.1;netframework-4.7.2;netframework-4.8">
-          <AttributeName>System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)</AttributeName>
-        </Attribute>
-        <Attribute FrameworkAlternate="netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netframework-4.7.1;netframework-4.7.2;netframework-4.8">
-          <AttributeName>System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)</AttributeName>
-        </Attribute>
-        <Attribute FrameworkAlternate="netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netframework-4.7.1;netframework-4.7.2;netframework-4.8;netframework-4.8.1">
-          <AttributeName Language="C#">[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]</AttributeName>
-          <AttributeName Language="F#">[&lt;System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)&gt;]</AttributeName>
-        </Attribute>
-        <Attribute FrameworkAlternate="netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netframework-4.7.1;netframework-4.7.2;netframework-4.8;netframework-4.8.1">
-          <AttributeName Language="C#">[System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]</AttributeName>
-          <AttributeName Language="F#">[&lt;System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)&gt;]</AttributeName>
-        </Attribute>
-      </Attributes>
-      <Parameters />
-      <Docs>
-        <summary>Initializes a new instance of the <see cref="T:System.Net.HttpWebRequest" /> class. This constructor is obsolete. </summary>
-        <remarks>To be added.</remarks>
-      </Docs>
-    </Member>
     <Member MemberName=".ctor">
       <MemberSignature Language="C#" Value="protected HttpWebRequest (System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext);" />
       <MemberSignature Language="ILAsm" Value=".method familyhidebysig specialname rtspecialname instance void .ctor(class System.Runtime.Serialization.SerializationInfo serializationInfo, valuetype System.Runtime.Serialization.StreamingContext streamingContext) cil managed" />
@@ -249,16 +147,7 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <param name="serializationInfo">A <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object that contains the information required to serialize the new <see cref="T:System.Net.HttpWebRequest" /> object.</param>
         <param name="streamingContext">A <see cref="T:System.Runtime.Serialization.StreamingContext" /> object that contains the source and destination of the serialized stream associated with the new <see cref="T:System.Net.HttpWebRequest" /> object.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.HttpWebRequest" /> class from the specified instances of the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> and <see cref="T:System.Runtime.Serialization.StreamingContext" /> classes. This constructor is obsolete. </summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
- An application must run in full trust mode when using serialization.
-
- ]]></format>
-        </remarks>
-        <related type="Article" href="/dotnet/standard/serialization/xml-and-soap-serialization">XML and SOAP Serialization</related>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Abort">
@@ -304,25 +193,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.Abort*> method cancels a request to a resource. After a request is canceled, calling the <xref:System.Net.HttpWebRequest.GetResponse*>, <xref:System.Net.HttpWebRequest.BeginGetResponse*>, <xref:System.Net.HttpWebRequest.EndGetResponse*>, <xref:System.Net.HttpWebRequest.GetRequestStream*>, <xref:System.Net.HttpWebRequest.BeginGetRequestStream*>, or <xref:System.Net.HttpWebRequest.EndGetRequestStream*> method causes a <xref:System.Net.WebException> with the <xref:System.Net.WebException.Status> property set to <xref:System.Net.WebExceptionStatus.RequestCanceled>.
-
- The <xref:System.Net.HttpWebRequest.Abort*> method will synchronously execute the callback specified to the <xref:System.Net.HttpWebRequest.BeginGetRequestStream*> or <xref:System.Net.HttpWebRequest.BeginGetResponse*> methods if the <xref:System.Net.HttpWebRequest.Abort*> method is called while either of these operations are outstanding. This can lead to potential deadlock issues.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing](/dotnet/framework/network-programming/network-tracing).
-
-
-
-## Examples
- In the case of asynchronous requests, it is the responsibility of the client application to implement its own time-out mechanism. The following code example shows how to do this.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Abort/begingetresponse.cs" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -370,24 +243,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- To clear the `Accept` HTTP header, set the <xref:System.Net.HttpWebRequest.Accept> property to `null`.
-
-> [!NOTE]
-> The value for this property is stored in <xref:System.Net.WebHeaderCollection>. If WebHeaderCollection is set, the property value is lost.
-
-
-
-## Examples
- The following code example sets the <xref:System.Net.HttpWebRequest.Accept> property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Accept/httpwebrequest_accept.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Accept/httpwebrequest_accept.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -402,16 +260,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
-
- Since all HTTP entities are represented in HTTP messages as sequences of bytes, the concept of a byte range is meaningful for any HTTP entity. However, not all clients and servers need to support byte-range operations.
-
- The Range header on a request allows a client to request that it only wants to receive some part of the specified range of bytes in an HTTP entity. Servers are not required to support Range header requests.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </MemberGroup>
@@ -460,43 +311,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.AddRange*?displayProperty=nameWithType> method adds a byte range header to the request.
-
- If `range` is positive, the `range` parameter specifies the starting point of the range. The server should start sending data from the `range` parameter specified to the end of the data in the HTTP entity.
-
- If `range` is negative, the `range` parameter specifies the ending point of the range. The server should start sending data from the start of the data in the HTTP entity to the `range` parameter specified.
-
- Since all HTTP entities are represented in HTTP messages as sequences of bytes, the concept of a byte range is meaningful for any HTTP entity. However, not all clients and servers need to support byte-range operations.
-
- The Range header on a request allows a client to request that it only wants to receive some part of the specified range of bytes in an HTTP entity. Servers are not required to support Range header requests.
-
- An example of a Range header in an HTTP protocol request that requests the server send the first 100 bytes (from the start to byte position 99) would be the following:
-
- `Range: bytes=0-99\r\n\r\n`
-
- For this example, the `range` parameter would be -99.
-
- A HTTP server indicates support for Range headers with the Accept-Ranges header. An example of the Accept-Ranges header from a server that supports byte-ranges would be as follows:
-
- `Accept-Ranges: bytes\r\n\r\n`
-
- If an Accept-Ranges header is not received in the header of the response from the server, then the server does not support Range headers. An example of the Accept-Ranges header from a server that does not support ranges, but recognizes the Accept-Ranges header, would be as follows:
-
- `Accept-Ranges: none\r\n\r\n`
-
- When receiving the response from a range request, only the HTTP headers associated with the entire request are parsed and made available via properties on the <xref:System.Net.HttpWebResponse> class. Headers associated with each range are returned in the response.
-
-## Examples
- The following code example adds a range header to the request.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/AddRange/source.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/VS_Snippets_Misc/system.net.httpwebrequest.addrange/vb/source.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="range" /> is invalid.</exception>
@@ -547,37 +364,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.AddRange*?displayProperty=nameWithType> method adds a byte range header to the request.
-
- If `range` is positive, the `range` parameter specifies the starting point of the range. The server should start sending data from the `range` parameter specified to the end of the data in the HTTP entity.
-
- If `range` is negative, the `range` parameter specifies the ending point of the range. The server should start sending data from the start of the data in the HTTP entity to the `range` parameter specified.
-
- Since all HTTP entities are represented in HTTP messages as sequences of bytes, the concept of a byte range is meaningful for any HTTP entity. However, not all clients and servers need to support byte-range operations.
-
- The Range header on a request allows a client to request that it only wants to receive some part of the specified range of bytes in an HTTP entity. Servers are not required to support Range header requests.
-
- An example of a Range header in an HTTP protocol request that requests the server send the first 100 bytes (from the start to byte position 99) would be the following:
-
- `Range: bytes=0-99\r\n\r\n`
-
- For this example, the `range` parameter would be -99.
-
- A HTTP server indicates support for Range headers with the Accept-Ranges header. An example of the Accept-Ranges header from a server that supports byte-ranges would be as follows:
-
- `Accept-Ranges: bytes\r\n\r\n`
-
- If an Accept-Ranges header is not received in the header of the response from the server, then the server does not support Range headers. An example of the Accept-Ranges header from a server that does not support ranges, but recognizes the Accept-Ranges header, would be as follows:
-
- `Accept-Ranges: none\r\n\r\n`
-
- When receiving the response from a range request, only the HTTP headers associated with the entire request are parsed and made available via properties on the <xref:System.Net.HttpWebResponse> class. Headers associated with each range are returned in the response.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="range" /> is invalid.</exception>
@@ -632,39 +421,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.AddRange*?displayProperty=nameWithType> method adds a byte range header to the request.
-
- Since all HTTP entities are represented in HTTP messages as sequences of bytes, the concept of a byte range is meaningful for any HTTP entity. However, not all clients and servers need to support byte-range operations.
-
- The Range header on a request allows a client to request that it only wants to receive some part of the specified range of bytes in an HTTP entity. Servers are not required to support Range header requests.
-
- An example of a Range header in an HTTP protocol request that requests the first 100 bytes would be would be the following:
-
- `Range: bytes=0-99\r\n\r\n`
-
- For this example, the `from` parameter would be specified as 0 and the `to` parameter would be specified as 99. The range specifier is automatically set as "bytes" by this method.
-
- A HTTP server indicates support for Range headers with the Accept-Ranges header. An example of the Accept-Ranges header from a server that supports byte-ranges would be as follows:
-
- `Accept-Ranges: bytes\r\n\r\n`
-
- If an Accept-Ranges header is not received in the header of the response from the server, then the server does not support Range headers. An example of the Accept-Ranges header from a server that does not support ranges, but recognizes the Accept-Ranges header, would be as follows:
-
- `Accept-Ranges: none\r\n\r\n`
-
- When receiving the response from a range request, only the HTTP headers associated with the entire request are parsed and made available via properties on the <xref:System.Net.HttpWebResponse> class. Headers associated with each range are returned in the response.
-
-## Examples
- The following code example adds a range header to the request.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/AddRange/source1.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/VS_Snippets_Misc/system.net.httpwebrequest.addrange2/vb/source.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="from" /> is greater than <paramref name="to" />
@@ -721,33 +480,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.AddRange*?displayProperty=nameWithType> method adds a byte range header to the request.
-
- Since all HTTP entities are represented in HTTP messages as sequences of bytes, the concept of a byte range is meaningful for any HTTP entity. However, not all clients and servers need to support byte-range operations.
-
- The Range header on a request allows a client to request that it only wants to receive some part of the specified range of bytes in an HTTP entity. Servers are not required to support Range header requests.
-
- An example of a Range header in an HTTP protocol request that requests the first 100 bytes would be would be the following:
-
- `Range: bytes=0-99\r\n\r\n`
-
- For this example, the `from` parameter would be specified as 0 and the `to` parameter would be specified as 99. The range specifier is automatically set as "bytes" by this method.
-
- A HTTP server indicates support for Range headers with the Accept-Ranges header. An example of the Accept-Ranges header from a server that supports byte-ranges would be as follows:
-
- `Accept-Ranges: bytes\r\n\r\n`
-
- If an Accept-Ranges header is not received in the header of the response from the server, then the server does not support Range headers. An example of the Accept-Ranges header from a server that does not support ranges, but recognizes the Accept-Ranges header, would be as follows:
-
- `Accept-Ranges: none\r\n\r\n`
-
- When receiving the response from a range request, only the HTTP headers associated with the entire request are parsed and made available via properties on the <xref:System.Net.HttpWebResponse> class. Headers associated with each range are returned in the response.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="from" /> is greater than <paramref name="to" />
@@ -806,39 +541,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.AddRange*?displayProperty=nameWithType> method adds a Range header to the request.
-
- If `range` is positive, the `range` parameter specifies the starting point of the range. The server should start sending data from the `range` parameter specified to the end of the data in the HTTP entity.
-
- If `range` is negative, the `range` parameter specifies the ending point of the range. The server should start sending data from the start of the data in the HTTP entity to the `range` parameter specified.
-
- Since all HTTP entities are represented in HTTP messages as sequences of bytes, the concept of a byte range is meaningful for any HTTP entity. However, not all clients and servers need to support byte-range operations.
-
- The Range header on a request allows a client to request that it only wants to receive some part of the specified range of bytes in an HTTP entity. Servers are not required to support Range header requests.
-
- The `rangeSpecifier` parameter would normally be specified as a "bytes", since this is the only range specifier recognized by most HTTP servers. Setting the `rangeSpecifier` parameter to some other string allows support for custom range specifiers other than bytes (the byte-range specifier defined in RFC 2616 by the IETF).
-
- An example of a Range header in an HTTP protocol request that requests the first 100 bytes would be would be the following:
-
- `Range: bytes=-99\r\n\r\n`
-
- For this example, the `rangeSpecifier` parameter would be specified as "bytes" and the `range` parameter would be -99.
-
- A HTTP server indicates support for Range headers with the Accept-Ranges header in the response. An example of the Accept-Ranges header from a server that supports byte-ranges would be as follows:
-
- `Accept-Ranges: bytes\r\n\r\n`
-
- If an Accept-Ranges header is not received in the header of the response from the server, then the server does not support Range headers. An example of the Accept-Ranges header from a server that does not support ranges, but recognizes the Accept-Ranges header, would be as follows:
-
- `Accept-Ranges: none\r\n\r\n`
-
- When receiving the response from a range request, only the HTTP headers associated with the entire request are parsed and made available via properties on the <xref:System.Net.HttpWebResponse> class. Headers associated with each range are returned in the response.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="rangeSpecifier" /> is <see langword="null" />.</exception>
@@ -893,39 +598,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.AddRange*?displayProperty=nameWithType> method adds a Range header to the request.
-
- If `range` is positive, the `range` parameter specifies the starting point of the range. The server should start sending data from the `range` parameter specified to the end of the data in the HTTP entity.
-
- If `range` is negative, the `range` parameter specifies the ending point of the range. The server should start sending data from the start of the data in the HTTP entity to the `range` parameter specified.
-
- Since all HTTP entities are represented in HTTP messages as sequences of bytes, the concept of a byte range is meaningful for any HTTP entity. However, not all clients and servers need to support byte-range operations.
-
- The Range header on a request allows a client to request that it only wants to receive some part of the specified range of bytes in an HTTP entity. Servers are not required to support Range header requests.
-
- The `rangeSpecifier` parameter would normally be specified as a "bytes", since this is the only range specifier recognized by most HTTP servers. Setting the `rangeSpecifier` parameter to some other string allows support for custom range specifiers other than bytes (the byte-range specifier defined in RFC 2616 by the IETF).
-
- An example of a Range header in an HTTP protocol request that requests the first 100 bytes would be would be the following:
-
- `Range: bytes=-99\r\n\r\n`
-
- For this example, the `rangeSpecifier` parameter would be specified as "bytes" and the `range` parameter would be -99.
-
- A HTTP server indicates support for Range headers with the Accept-Ranges header in the response. An example of the Accept-Ranges header from a server that supports byte-ranges would be as follows:
-
- `Accept-Ranges: bytes\r\n\r\n`
-
- If an Accept-Ranges header is not received in the header of the response from the server, then the server does not support Range headers. An example of the Accept-Ranges header from a server that does not support ranges, but recognizes the Accept-Ranges header, would be as follows:
-
- `Accept-Ranges: none\r\n\r\n`
-
- When receiving the response from a range request, only the HTTP headers associated with the entire request are parsed and made available via properties on the <xref:System.Net.HttpWebResponse> class. Headers associated with each range are returned in the response.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="rangeSpecifier" /> is <see langword="null" />.</exception>
@@ -984,37 +659,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.AddRange*?displayProperty=nameWithType> method adds a Range header to the request.
-
- Since all HTTP entities are represented in HTTP messages as sequences of bytes, the concept of a byte range is meaningful for any HTTP entity. However, not all clients and servers need to support byte-range operations.
-
- The Range header on a request allows a client to request that it only wants to receive some part of the specified range of bytes in an HTTP entity. Servers are not required to support Range header requests.
-
- The `rangeSpecifier` parameter would normally be specified as a "bytes", since this is the only range specifier recognized by most HTTP servers. Setting the `rangeSpecifier` parameter to some other string allows support for custom range specifiers other than bytes (the byte-range specifier defined in RFC 2616 by the IETF).
-
- An example of a Range header in an HTTP protocol request that requests the first 100 bytes would be would be the following:
-
- `Range: bytes=0-99\r\n\r\n`
-
- For this example, the `rangeSpecifier` parameter would be specified as a "bytes", the `from` parameter would be 0, and the `to` parameter would be 99.
-
- A HTTP server indicates support for Range headers with the Accept-Ranges header in the response. An example of the Accept-Ranges header from a server that supports byte-ranges would be as follows:
-
- `Accept-Ranges: bytes\r\n\r\n`
-
- The string specified in the Accept-Ranges header is the range-specifier that would be by specified in the `rangeSpecifier` parameter for this method.
-
- If an Accept-Ranges header is not received in the header of the response from the server, then the server does not support Range headers. An example of the Accept-Ranges header from a server that does not support ranges, but recognizes the Accept-Ranges header, would be as follows:
-
- `Accept-Ranges: none\r\n\r\n`
-
- When receiving the response from a range request, only the HTTP headers associated with the entire request are parsed and made available via properties on the <xref:System.Net.HttpWebResponse> class. Headers associated with each range are returned in the response.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="rangeSpecifier" /> is <see langword="null" />.</exception>
@@ -1077,37 +724,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.AddRange*?displayProperty=nameWithType> method adds a Range header to the request.
-
- Since all HTTP entities are represented in HTTP messages as sequences of bytes, the concept of a byte range is meaningful for any HTTP entity. However, not all clients and servers need to support byte-range operations.
-
- The Range header on a request allows a client to request that it only wants to receive some part of the specified range of bytes in an HTTP entity. Servers are not required to support Range header requests.
-
- The `rangeSpecifier` parameter would normally be specified as a "bytes", since this is the only range specifier recognized by most HTTP servers. Setting the `rangeSpecifier` parameter to some other string allows support for custom range specifiers other than bytes (the byte-range specifier defined in RFC 2616 by the IETF).
-
- An example of a Range header in an HTTP protocol request that requests the first 100 bytes would be would be the following:
-
- `Range: bytes=0-99\r\n\r\n`
-
- For this example, the `rangeSpecifier` parameter would be specified as a "bytes", the `from` parameter would be 0, and the `to` parameter would be 99.
-
- A HTTP server indicates support for Range headers with the Accept-Ranges header in the response. An example of the Accept-Ranges header from a server that supports byte-ranges would be as follows:
-
- `Accept-Ranges: bytes\r\n\r\n`
-
- The string specified in the Accept-Ranges header is the range-specifier that would be by specified in the `rangeSpecifier` parameter for this method.
-
- If an Accept-Ranges header is not received in the header of the response from the server, then the server does not support Range headers. An example of the Accept-Ranges header from a server that does not support ranges, but recognizes the Accept-Ranges header, would be as follows:
-
- `Accept-Ranges: none\r\n\r\n`
-
- When receiving the response from a range request, only the HTTP headers associated with the entire request are parsed and made available via properties on the <xref:System.Net.HttpWebResponse> class. Headers associated with each range are returned in the response.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="rangeSpecifier" /> is <see langword="null" />.</exception>
@@ -1171,23 +790,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.Address> property is set to the URI after any redirections that happen during the request are complete.
-
- The URI of the original request is kept in the <xref:System.Net.HttpWebRequest.RequestUri> property.
-
-
-
-## Examples
- The following code example checks to see if the <xref:System.Net.HttpWebRequest> object `req` was redirected to another location to fulfill the request, and sets the value of the `hasChanged` variable to `true` if the request was redirected; otherwise `hasChanged` is set to `false`.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Address/source.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Address/source.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1234,25 +839,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Set <xref:System.Net.HttpWebRequest.AllowAutoRedirect*> to `true` if you want the request to automatically follow HTTP redirection headers to the new location of the resource. The maximum number of redirections to follow is set by the <xref:System.Net.HttpWebRequest.MaximumAutomaticRedirections> property.
-
- If <xref:System.Net.HttpWebRequest.AllowAutoRedirect*> is set to `false`, all responses with an HTTP status code from 300 to 399 is returned to the application.
-
- The Authorization header is cleared on auto-redirects and <xref:System.Net.HttpWebRequest> automatically tries to re-authenticate to the redirected location. In practice, this means that an application can't put custom authentication information into the Authorization header if it is possible to encounter redirection. Instead, the application must implement and register a custom authentication module. The <xref:System.Net.AuthenticationManager?displayProperty=nameWithType> and related class are used to implement a custom authentication module. The <xref:System.Net.AuthenticationManager.Register*?displayProperty=nameWithType> method registers a custom authentication module.
-
-
-
-## Examples
- The following code example uses the <xref:System.Net.HttpWebRequest.AllowAutoRedirect> property to allow the request to follow redirection responses.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/AllowAutoRedirect/httpwebrequest_allowautoredirect.cs" id="Snippet2":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/AllowAutoRedirect/httpwebrequest_allowautoredirect.vb" id="Snippet2":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1341,19 +930,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- When <xref:System.Net.HttpWebRequest.AllowWriteStreamBuffering*> is `true`, the data is buffered in memory so it is ready to be resent in the event of redirections or authentication requests.
-
-## Examples
- The following code example uses the <xref:System.Net.HttpWebRequest.AllowWriteStreamBuffering> property to disable data buffering.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/AllowWriteStreamBuffering/httpwebrequest_allowwritestreambuffering.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/AllowWriteStreamBuffering/httpwebrequest_allowwritestreambuffering.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>Setting <see cref="P:System.Net.HttpWebRequest.AllowWriteStreamBuffering" /> to <see langword="true" /> might cause performance problems when uploading large datasets because the data buffer could use all available memory.</para>
@@ -1458,31 +1037,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.BeginGetRequestStream*> method starts an asynchronous request for a stream used to send data for the <xref:System.Net.HttpWebRequest>. The asynchronous callback method uses the <xref:System.Net.HttpWebRequest.EndGetRequestStream*> method to return the actual stream.
-
- The <xref:System.Net.HttpWebRequest.BeginGetRequestStream*> method requires some synchronous setup tasks to complete (DNS resolution, proxy detection, and TCP socket connection, for example) before this method becomes asynchronous. As a result, this method should never be called on a user interface (UI) thread because it might take considerable time (up to several minutes depending on network settings) to complete the initial synchronous setup tasks before an exception for an error is thrown or the method succeeds.
-
- To learn more about the thread pool, see [The managed thread pool](/dotnet/standard/threading/the-managed-thread-pool).
-
-> [!NOTE]
-> Your application cannot mix synchronous and asynchronous methods for a particular request. If you call the <xref:System.Net.HttpWebRequest.BeginGetRequestStream*> method, you must use the <xref:System.Net.HttpWebRequest.BeginGetResponse*> method to retrieve the response.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
-## Examples
- The following code example uses the <xref:System.Net.HttpWebRequest.BeginGetRequestStream*> method to make an asynchronous request for a stream instance.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/BeginGetRequestStream/httpwebrequest_begingetrequeststream.cs" id="Snippet2":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/BeginGetRequestStream/httpwebrequest_begingetrequeststream.vb" id="Snippet2":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.Net.ProtocolViolationException">The <see cref="P:System.Net.HttpWebRequest.Method" /> property is GET or HEAD.
 
@@ -1502,7 +1059,6 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <exception cref="T:System.Net.WebException">
           <see cref="M:System.Net.HttpWebRequest.Abort" /> was previously called.</exception>
         <exception cref="T:System.ObjectDisposedException">In a .NET Compact Framework application, a request stream with zero content length was not obtained and closed correctly.</exception>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings">DefaultProxy Element (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="BeginGetResponse">
@@ -1561,37 +1117,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.BeginGetResponse*> method starts an asynchronous request for a response from the Internet resource. The asynchronous callback method uses the <xref:System.Net.HttpWebRequest.EndGetResponse*> method to return the actual <xref:System.Net.WebResponse>.
-
- A <xref:System.Net.ProtocolViolationException> is thrown in several cases when the properties set on the <xref:System.Net.HttpWebRequest> class are conflicting. This exception occurs if an application sets the <xref:System.Net.HttpWebRequest.ContentLength> property and the <xref:System.Net.HttpWebRequest.SendChunked> property to `true`, and then sends an HTTP GET request. This exception occurs if an application tries to send chunked to a server that only supports HTTP 1.0 protocol, where this is not supported. This exception occurs if an application tries to send data without setting the <xref:System.Net.HttpWebRequest.ContentLength> property or the <xref:System.Net.HttpWebRequest.SendChunked*> is `false` when buffering is disabled and on a keepalive connection (the <xref:System.Net.HttpWebRequest.KeepAlive> property is `true`)`.`
-
- If a <xref:System.Net.WebException> is thrown, use the <xref:System.Net.WebException.Response*> and <xref:System.Net.WebException.Status*> properties of the exception to determine the response from the server.
-
- The <xref:System.Net.HttpWebRequest.BeginGetResponse*> method requires some synchronous setup tasks to complete (DNS resolution, proxy detection, and TCP socket connection, for example) before this method becomes asynchronous. As a result, this method should never be called on a user interface (UI) thread because it might take considerable time (up to several minutes depending on network settings) to complete the initial synchronous setup tasks before an exception for an error is thrown or the method succeeds.
-
- To learn more about the thread pool, see [The managed thread pool](/dotnet/standard/threading/the-managed-thread-pool).
-
-> [!NOTE]
-> Your application cannot mix synchronous and asynchronous methods for a particular request. If you call the <xref:System.Net.HttpWebRequest.BeginGetRequestStream*> method, you must use the <xref:System.Net.HttpWebRequest.BeginGetResponse*> method to retrieve the response.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
-## Examples
- The following code example uses the <xref:System.Net.HttpWebRequest.BeginGetResponse*> method to make an asynchronous request for an Internet resource.
-
-> [!NOTE]
-> In the case of asynchronous requests, it is the responsibility of the client application to implement its own time-out mechanism. The following code example shows how to do it.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Abort/begingetresponse.cs" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The stream is already in use by a previous call to <see cref="M:System.Net.HttpWebRequest.BeginGetResponse(System.AsyncCallback,System.Object)" />
 
@@ -1618,7 +1146,6 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
  The <see cref="P:System.Net.HttpWebRequest.ContentLength" /> is greater than zero, but the application does not write all of the promised data.</exception>
         <exception cref="T:System.Net.WebException">
           <see cref="M:System.Net.HttpWebRequest.Abort" /> was previously called.</exception>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings">DefaultProxy Element (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="ClientCertificates">
@@ -1669,21 +1196,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- An application can add a certificate to a collection, but might not have access rights to it. To use a certificate contained in the collection, the application must have the same access rights as the entity that issued the certificate.
-
-> [!NOTE]
-> The Framework caches SSL sessions as they are created and attempts to reuse a cached session for a new request, if possible. When attempting to reuse an SSL session, the Framework uses the first element of <xref:System.Net.HttpWebRequest.ClientCertificates*> (if there is one), or tries to reuse an anonymous sessions if <xref:System.Net.HttpWebRequest.ClientCertificates*> is empty.
-
-> [!NOTE]
-> For performance reasons, you shouldn't add a client certificate to a <xref:System.Net.HttpWebRequest> unless you know the server will ask for it.
->
-> For a code example illustrating how to enumerate the certificates in the client certificate store, see the <xref:System.Security.Cryptography.X509Certificates.X509Certificate2Collection> class.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The value specified for a set operation is <see langword="null" />.</exception>
       </Docs>
@@ -1731,28 +1246,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The request sends the <xref:System.Net.HttpWebRequest.Connection> property to the Internet resource as the `Connection` HTTP header. If the value of the <xref:System.Net.HttpWebRequest.KeepAlive> property is `true`, the value "Keep-alive" is appended to the end of the `Connection` header.
-
- To clear the `Connection` HTTP header, set the <xref:System.Net.HttpWebRequest.Connection> property to `null`.
-
- Changing the <xref:System.Net.HttpWebRequest.Connection> property after the request has been started by calling the <xref:System.Net.HttpWebRequest.GetRequestStream*>, <xref:System.Net.HttpWebRequest.BeginGetRequestStream*>, <xref:System.Net.HttpWebRequest.GetResponse*>, or <xref:System.Net.HttpWebRequest.BeginGetResponse*> method throws an <xref:System.InvalidOperationException>.
-
-> [!NOTE]
-> The value for this property is stored in <xref:System.Net.WebHeaderCollection>. If WebHeaderCollection is set, the property value is lost.
-
-
-
-## Examples
- The following code example uses the <xref:System.Net.HttpWebRequest.Connection> property to set the value of the Connection HTTP Header.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Connection/httpwebrequest_connection.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Connection/httpwebrequest_connection.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentException">The value of <see cref="P:System.Net.HttpWebRequest.Connection" /> is set to Keep-alive or Close.</exception>
       </Docs>
@@ -1800,13 +1296,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.ConnectionGroupName> property enables you to associate a request with a connection group. This is useful when your application makes requests to one server for different users, such as a web site that retrieves customer information from a database server.
-
- ]]></format>
+]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>Each connection group creates additional connections for a server. This may result in exceeding the number of connections set by the <see cref="P:System.Net.ServicePoint.ConnectionLimit" /> property for that server.</para>
@@ -1857,28 +1349,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.ContentLength> property contains the value to send as the `Content-length` HTTP header with the request.
-
- Any value other than -1 in the <xref:System.Net.HttpWebRequest.ContentLength> property indicates that the request uploads data and that only methods that upload data are allowed to be set in the <xref:System.Net.HttpWebRequest.Method> property.
-
- After the <xref:System.Net.HttpWebRequest.ContentLength> property is set to a value, that number of bytes must be written to the request stream that is returned by calling the <xref:System.Net.HttpWebRequest.GetRequestStream*> method or both the <xref:System.Net.HttpWebRequest.BeginGetRequestStream*> and the <xref:System.Net.HttpWebRequest.EndGetRequestStream*> methods.
-
-> [!NOTE]
-> The value for this property is stored in <xref:System.Net.WebHeaderCollection>. If WebHeaderCollection is set, the property value is lost.
-
-
-
-## Examples
- The following code example sets the <xref:System.Net.HttpWebRequest.ContentLength> property to the length of the string being posted.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ContentLength/httpwebrequest_contentlength.cs" id="Snippet4":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ContentLength/httpwebrequest_contentlength.vb" id="Snippet4":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The request has been started by calling the <see cref="M:System.Net.HttpWebRequest.GetRequestStream" />, <see cref="M:System.Net.HttpWebRequest.BeginGetRequestStream(System.AsyncCallback,System.Object)" />, <see cref="M:System.Net.HttpWebRequest.GetResponse" />, or <see cref="M:System.Net.HttpWebRequest.BeginGetResponse(System.AsyncCallback,System.Object)" /> method.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">The new <see cref="P:System.Net.HttpWebRequest.ContentLength" /> value is less than 0.</exception>
@@ -1928,26 +1401,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.ContentType> property contains the media type of the request. Values assigned to the <xref:System.Net.HttpWebRequest.ContentType> property replace any existing contents when the request sends the `Content-type` HTTP header.
-
- To clear the `Content-type` HTTP header, set the <xref:System.Net.HttpWebRequest.ContentType> property to `null`.
-
-> [!NOTE]
-> The value for this property is stored in <xref:System.Net.WebHeaderCollection> . If <xref:System.Net.WebHeaderCollection> is set, the property value is lost.
-
-
-
-## Examples
- The following code example sets the <xref:System.Net.HttpWebRequest.ContentType> property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ContentLength/httpwebrequest_contentlength.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ContentLength/httpwebrequest_contentlength.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1994,15 +1450,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.ContinueDelegate> property specifies the callback method to call when the client receives a 100-Continue response.
-
- When the <xref:System.Net.HttpWebRequest.ContinueDelegate> property is set, the client calls the delegate whenever protocol responses of type <xref:System.Net.HttpStatusCode.Continue?displayProperty=nameWithType> (100) are received. This is useful if you want the client to display the status of the data being received from the Internet resource.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -2047,13 +1497,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- If the 100-Continue response is received before the timeout expires, the entity body can be sent.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -2101,26 +1547,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.CookieContainer> property provides an instance of the <xref:System.Net.CookieContainer> class that contains the cookies associated with this request.
-
- <xref:System.Net.HttpWebRequest.CookieContainer*> is `null` by default. You must assign a <xref:System.Net.CookieContainer> object to the property to have cookies returned in the <xref:System.Net.HttpWebResponse.Cookies> property of the <xref:System.Net.HttpWebResponse> returned by the <xref:System.Net.HttpWebRequest.GetResponse*> method.
-
-> [!NOTE]
-> For security reasons, cookies are disabled by default. If you want to use cookies, use the <xref:System.Net.HttpWebRequest.CookieContainer> property to enable cookies.
-
-
-
-## Examples
- The following code example sends a request to a URL and displays the cookies returned in the response.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/Cookie/Overview/cookiessnippets.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/Cookie/Overview/cookiessnippets.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <altmember cref="T:System.Net.CookieContainer" />
       </Docs>
@@ -2169,32 +1598,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.Credentials> property contains authentication information to identify the maker of the request. The <xref:System.Net.HttpWebRequest.Credentials> property can be either a <xref:System.Net.NetworkCredential>, in which case the user, password, and domain information contained in the <xref:System.Net.NetworkCredential> object is used to authenticate the request, or it can be a <xref:System.Net.CredentialCache>, in which case the Uniform Resource Identifier (URI) of the request is used to determine the user, password, and domain information to use to authenticate the request.
-
- In most client scenarios, you should use the <xref:System.Net.CredentialCache.DefaultCredentials> property, which contains the credentials of the currently logged on user. To do this, set the <xref:System.Net.WebClient.UseDefaultCredentials> property to `true` instead of setting this property.
-
- If the <xref:System.Net.HttpWebRequest> class is being used in a middle-tier application, such as an ASP.NET application, the credentials in the <xref:System.Net.CredentialCache.DefaultCredentials> property belong to the account running the ASP page (the server-side credentials). Typically, you would set this property to the credentials of the client on whose behalf the request is made.
-
-> [!NOTE]
-> The NTLM authentication scheme cannot be used to impersonate another user. Kerberos must be specially configured to support impersonation.
-
- To restrict HttpWebRequest to one or more authentication methods, use the <xref:System.Net.CredentialCache> class and bind your credentials to one or more authentication schemes
-
- Supported authentication schemes include Digest, Negotiate, Kerberos, NTLM, and Basic.
-
- For security reasons, when automatically following redirects, store the credentials that you want to be included in the redirect in a <xref:System.Net.CredentialCache> and assign it to this property. This property will automatically be set to `null` upon redirection if it contains anything except a <xref:System.Net.CredentialCache>. Having this property value be automatically set to `null` under those conditions prevents credentials from being sent to any unintended destination.
-
-## Examples
- The following code example sets the credentials for a request.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Credentials/httpwebrequest1.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Credentials/httpwebrequest1.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -2238,26 +1644,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- If the Date header is `null`, then the return value will be set to <xref:System.DateTime.MinValue?displayProperty=nameWithType>.
-
- The <xref:System.Net.HttpWebRequest.Date> property is a standard <xref:System.DateTime?displayProperty=nameWithType> object and can contain a <xref:System.DateTimeKind?displayProperty=nameWithType> field of <xref:System.DateTimeKind.Local?displayProperty=nameWithType>, <xref:System.DateTimeKind.Utc?displayProperty=nameWithType>, or <xref:System.DateTimeKind.Unspecified?displayProperty=nameWithType>. Any kind of time can be set when using the <xref:System.Net.HttpWebRequest.Date> property. If <xref:System.DateTimeKind.Unspecified?displayProperty=nameWithType> is set or retrieved, the <xref:System.Net.HttpWebRequest.Date> property is assumed to be <xref:System.DateTimeKind.Local?displayProperty=nameWithType> (local time).
-
- The classes in the <xref:System.Net> namespace always write it out the <xref:System.Net.HttpWebRequest.Date> property on the wire during transmission in standard form using GMT (Utc) format.
-
- If the <xref:System.Net.HttpWebRequest.Date> property is set to <xref:System.DateTime.MinValue?displayProperty=nameWithType>, then the `Date` HTTP header is removed from the <xref:System.Net.HttpWebRequest.Headers> property and the <xref:System.Net.WebHeaderCollection>.
-
- If the <xref:System.Net.HttpWebRequest.Date> property is <xref:System.DateTime.MinValue?displayProperty=nameWithType>, this indicates that the `Date` HTTP header is not included in the <xref:System.Net.HttpWebRequest.Headers> property and the <xref:System.Net.WebHeaderCollection>.
-
-> [!NOTE]
-> The value for this property is stored in <xref:System.Net.WebHeaderCollection>. If WebHeaderCollection is set, the property value is lost.
-
- If the <xref:System.Net.HttpWebRequest.Date*> is set and an attempt is made to send a <xref:System.Net.HttpWebRequest> with no body, then a <xref:System.Net.ProtocolViolationException?displayProperty=nameWithType> will be thrown by the <xref:System.Net.HttpWebRequest.BeginGetResponse*>, <xref:System.Net.HttpWebRequest.GetResponse*>, and <xref:System.Net.HttpWebRequest.EndGetResponse*> methods.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -2302,23 +1691,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Setting this property registers the specified policy for the HTTP and HTTPS schemes. This policy is used for this request if:
-
- There is no <xref:System.Net.WebRequest.CachePolicy?displayProperty=nameWithType> property specified for this request.
-
--or-
-
- The machine and application configuration files do not specify a cache policy that is applicable to the Uniform Resource Identifier (URI) used to create this request.
-
- The cache policy determines whether the requested resource can be taken from a cache instead of sending the request to the resource host computer.
-
- A copy of a resource is only added to the cache if the response stream for the resource is retrieved and read to the end of the stream. So another request for the same resource could use a cached copy, depending on the cache policy level for this request.
-
- ]]></format>
+]]></format>
         </remarks>
         <altmember cref="T:System.Net.Cache.RequestCachePolicy" />
         <altmember cref="T:System.Net.Cache.HttpRequestCacheLevel" />
@@ -2410,15 +1785,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The length of the response header received the response status line and any extra control characters that are received as part of HTTP protocol. A value of 0 means that all requests fail.
-
- This value can also be changed in the configuration file. The impact of this property can be overridden by setting the <xref:System.Net.HttpWebRequest.MaximumResponseHeadersLength> property on an instance of the <xref:System.Net.HttpWebRequest> class.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The value is less than zero.</exception>
       </Docs>
@@ -2480,26 +1849,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.EndGetRequestStream*> method completes an asynchronous request for a stream that was started by the <xref:System.Net.HttpWebRequest.BeginGetRequestStream*> method. After the <xref:System.IO.Stream> object has been returned, you can send data with the <xref:System.Net.HttpWebRequest> by using the <xref:System.IO.Stream.Write*?displayProperty=nameWithType> method.
-
-> [!NOTE]
->  - You must set the value of the <xref:System.Net.HttpWebRequest.ContentLength> property before writing data to the stream.
->  - You must call the <xref:System.IO.Stream.Close*?displayProperty=nameWithType> method to close the stream and release the connection for reuse. Failure to close the stream causes your application to run out of connections.
->  - This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
-## Examples
- The following code example uses the <xref:System.Net.HttpWebRequest.EndGetRequestStream*> method to end an asynchronous request for a stream instance.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/BeginGetRequestStream/httpwebrequest_begingetrequeststream.cs" id="Snippet2":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/BeginGetRequestStream/httpwebrequest_begingetrequeststream.vb" id="Snippet2":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="asyncResult" /> is <see langword="null" />.</exception>
@@ -2570,20 +1922,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.EndGetRequestStream*> method completes an asynchronous request for a stream that was started by the <xref:System.Net.HttpWebRequest.BeginGetRequestStream*> method and outputs the <xref:System.Net.TransportContext> associated with the stream. After the <xref:System.IO.Stream> object has been returned, you can send data with the <xref:System.Net.HttpWebRequest> by using the <xref:System.IO.Stream.Write*?displayProperty=nameWithType> method.
-
- Some applications that use integrated Windows authentication with extended protection may need to be able to query the transport layer used by <xref:System.Net.HttpWebRequest> in order to retrieve the channel binding token (CBT) from the underlying TLS channel. The <xref:System.Net.HttpWebRequest.GetRequestStream*> method provides access to this information for HTTP methods which have a request body (`POST` and `PUT` requests). This is only needed if the application is implementing its own authentication and needs access to the CBT.
-
-> [!NOTE]
->  - If you need to set the value of the <xref:System.Net.HttpWebRequest.ContentLength> property before writing data to the stream.
->  - You must call the <xref:System.IO.Stream.Close*?displayProperty=nameWithType> method to close the stream and release the connection for reuse. Failure to close the stream causes your application to run out of connections.
->  - This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="asyncResult" /> was not returned by the current instance from a call to <see cref="M:System.Net.HttpWebRequest.BeginGetRequestStream(System.AsyncCallback,System.Object)" />.</exception>
@@ -2651,26 +1992,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.EndGetResponse*> method completes an asynchronous request for an Internet resource that was started by calling the <xref:System.Net.HttpWebRequest.BeginGetResponse*> method.
-
-> [!CAUTION]
-> You must call the <xref:System.Net.HttpWebResponse.Close*> method to close the stream and release the connection. Failure to do so may cause your application to run out of connections.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
-## Examples
- The following code example uses the <xref:System.Net.HttpWebRequest.EndGetResponse*> method to end an asynchronous request for an Internet resource.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Abort/begingetresponse.cs" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="asyncResult" /> is <see langword="null" />.</exception>
@@ -2732,7 +2056,6 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>The value for this property is stored in <see cref="T:System.Net.WebHeaderCollection" />. If WebHeaderCollection is set, the property value is lost.</remarks>
         <exception cref="T:System.ArgumentException">
           <see langword="Expect" /> is set to a string that contains "100-continue" as a substring.</exception>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings">DefaultProxy Element (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="GetObjectData">
@@ -2856,31 +2179,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.GetRequestStream*> method returns a stream to use to send data for the <xref:System.Net.HttpWebRequest>. After the <xref:System.IO.Stream> object has been returned, you can send data with the <xref:System.Net.HttpWebRequest> by using the <xref:System.IO.Stream.Write*?displayProperty=nameWithType> method.
-
- If an application needs to set the value of the <xref:System.Net.HttpWebRequest.ContentLength> property, then this must be done before retrieving the stream.
-
- You must call the <xref:System.IO.Stream.Close*?displayProperty=nameWithType> method to close the stream and release the connection for reuse. Failure to close the stream causes your application to run out of connections.
-
-> [!NOTE]
-> Your application cannot mix synchronous and asynchronous methods for a particular request. If you call the <xref:System.Net.HttpWebRequest.GetRequestStream*> method, you must use the <xref:System.Net.HttpWebRequest.GetResponse*> method to retrieve the response.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
-## Examples
- The following code example uses the <xref:System.Net.HttpWebRequest.GetRequestStream*> method to return a stream instance.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ContentLength/httpwebrequest_contentlength.cs" id="Snippet4":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ContentLength/httpwebrequest_contentlength.vb" id="Snippet4":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.Net.ProtocolViolationException">The <see cref="P:System.Net.HttpWebRequest.Method" /> property is GET or HEAD.
 
@@ -2904,7 +2205,6 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
 
  An error occurred while processing the request.</exception>
         <exception cref="T:System.ObjectDisposedException">In a .NET Compact Framework application, a request stream with zero content length was not obtained and closed correctly.</exception>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings">DefaultProxy Element (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="GetRequestStream">
@@ -2960,25 +2260,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.GetRequestStream*> method returns a stream to use to send data for the <xref:System.Net.HttpWebRequest> and outputs the <xref:System.Net.TransportContext> associated with the stream. After the <xref:System.IO.Stream> object has been returned, you can send data with the <xref:System.Net.HttpWebRequest> by using the <xref:System.IO.Stream.Write*?displayProperty=nameWithType> method.
-
- Some applications that use integrated Windows authentication with extended protection may need to be able to query the transport layer used by <xref:System.Net.HttpWebRequest> in order to retrieve the channel binding token (CBT) from the underlying TLS channel. The <xref:System.Net.HttpWebRequest.GetRequestStream*> method provides access to this information for HTTP methods which have a request body (`POST` and `PUT` requests). This is only needed if the application is implementing its own authentication and needs access to the CBT.
-
- If an application needs to set the value of the <xref:System.Net.HttpWebRequest.ContentLength> property, then this must be done before retrieving the stream.
-
- You must call the <xref:System.IO.Stream.Close*?displayProperty=nameWithType> method to close the stream and release the connection for reuse. Failure to close the stream causes your application to run out of connections.
-
-> [!NOTE]
-> Your application cannot mix synchronous and asynchronous methods for a particular request. If you call the <xref:System.Net.HttpWebRequest.GetRequestStream*> method, you must use the <xref:System.Net.HttpWebRequest.GetResponse*> method to retrieve the response.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.Exception">The <see cref="M:System.Net.HttpWebRequest.GetRequestStream" /> method was unable to obtain the <see cref="T:System.IO.Stream" />.</exception>
         <exception cref="T:System.InvalidOperationException">The <see cref="M:System.Net.HttpWebRequest.GetRequestStream" /> method is called more than once.
@@ -3052,43 +2336,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.GetResponse*> method returns a <xref:System.Net.WebResponse> object that contains the response from the Internet resource. The actual instance returned is an <xref:System.Net.HttpWebResponse>, and can be typecast to that class to access HTTP-specific properties.
-
- A <xref:System.Net.ProtocolViolationException> is thrown in several cases when the properties set on the <xref:System.Net.HttpWebRequest> class are conflicting. This exception occurs if an application sets the <xref:System.Net.HttpWebRequest.ContentLength> property and the <xref:System.Net.HttpWebRequest.SendChunked> property to `true`, and then sends an HTTP GET request. This exception occurs if an application tries to send chunked to a server that only supports HTTP 1.0 protocol, where this is not supported. This exception occurs if an application tries to send data without setting the <xref:System.Net.HttpWebRequest.ContentLength> property or the <xref:System.Net.HttpWebRequest.SendChunked*> is `false` when buffering is disabled and on a keepalive connection (the <xref:System.Net.HttpWebRequest.KeepAlive> property is `true`)`.`
-
-> [!CAUTION]
-> You must call the <xref:System.Net.HttpWebResponse.Close*> method to close the stream and release the connection. Failure to do so may cause your application to run out of connections.
-
- When using the POST method, you must get the request stream, write the data to be posted, and close the stream. This method blocks waiting for content to post; if there is no time-out set and you do not provide content, the calling thread blocks indefinitely.
-
-> [!NOTE]
-> Multiple calls to <xref:System.Net.HttpWebRequest.GetResponse*> return the same response object; the request is not reissued.
-
-> [!NOTE]
-> Your application cannot mix synchronous and asynchronous methods for a particular request. If you call the <xref:System.Net.HttpWebRequest.GetRequestStream*> method, you must use the <xref:System.Net.HttpWebRequest.GetResponse*> method to retrieve the response.
-
-> [!NOTE]
-> If a <xref:System.Net.WebException> is thrown, use the <xref:System.Net.WebException.Response*> and <xref:System.Net.WebException.Status*> properties of the exception to determine the response from the server.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
-> For security reasons, cookies are disabled by default. If you wish to use cookies, use the <xref:System.Net.HttpWebRequest.CookieContainer> property to enable cookies.
-
-
-
-## Examples
- The following code example gets the response for a request.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Credentials/httpwebrequest1.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Credentials/httpwebrequest1.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The stream is already in use by a previous call to <see cref="M:System.Net.HttpWebRequest.BeginGetResponse(System.AsyncCallback,System.Object)" />.
 
@@ -3121,7 +2371,6 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
 
  An error occurred while processing the request.</exception>
         <altmember cref="P:System.Net.HttpWebRequest.Timeout" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings">DefaultProxy Element (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="HaveResponse">
@@ -3227,42 +2476,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.Headers*> collection contains the protocol headers associated with the request. The following table lists the HTTP headers that are not stored in the <xref:System.Net.HttpWebRequest.Headers*> collection but are either set by the system or set by properties or methods.
-
-|Header|Set by|
-|------------|------------|
-|Accept|Set by the <xref:System.Net.HttpWebRequest.Accept> property.|
-|Connection|Set by the <xref:System.Net.HttpWebRequest.Connection> property and <xref:System.Net.HttpWebRequest.KeepAlive> property.|
-|Content-Length|Set by the <xref:System.Net.HttpWebRequest.ContentLength> property.|
-|Content-Type|Set by the <xref:System.Net.HttpWebRequest.ContentType> property.|
-|Expect|Set by the <xref:System.Net.HttpWebRequest.Expect> property.|
-|Date|Set by the <xref:System.Net.HttpWebRequest.Date> property.|
-|Host|Set by the <xref:System.Net.HttpWebRequest.Host> property.|
-|If-Modified-Since|Set by the <xref:System.Net.HttpWebRequest.IfModifiedSince> property.|
-|Range|Set by the <xref:System.Net.HttpWebRequest.AddRange*> method.|
-|Referer|Set by the <xref:System.Net.HttpWebRequest.Referer> property.|
-|Transfer-Encoding|Set by the <xref:System.Net.HttpWebRequest.TransferEncoding> property (the <xref:System.Net.HttpWebRequest.SendChunked> property must be true).|
-|User-Agent|Set by the <xref:System.Net.HttpWebRequest.UserAgent> property.|
-
- The <xref:System.Net.WebHeaderCollection.Add*> method throws an <xref:System.ArgumentException> if you try to set one of these protected headers.
-
- Changing the <xref:System.Net.HttpWebRequest.Headers> property after the request has been started by calling <xref:System.Net.HttpWebRequest.GetRequestStream*>, <xref:System.Net.HttpWebRequest.BeginGetRequestStream*>, <xref:System.Net.HttpWebRequest.GetResponse*>, or <xref:System.Net.HttpWebRequest.BeginGetResponse*> method throws an <xref:System.InvalidOperationException>.
-
- You should not assume that the header values will remain unchanged, because Web servers and caches may change or add headers to a Web request.
-
-
-
-## Examples
- The following code example uses the <xref:System.Net.HttpWebRequest.Headers> property to print the HTTP header name/value pairs to the console.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Headers/httpwebrequest_headers.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Headers/httpwebrequest_headers.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The request has been started by calling the <see cref="M:System.Net.HttpWebRequest.GetRequestStream" />, <see cref="M:System.Net.HttpWebRequest.BeginGetRequestStream(System.AsyncCallback,System.Object)" />, <see cref="M:System.Net.HttpWebRequest.GetResponse" />, or <see cref="M:System.Net.HttpWebRequest.BeginGetResponse(System.AsyncCallback,System.Object)" /> method.</exception>
       </Docs>
@@ -3313,21 +2529,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.Host> property can be used to set the Host header value to use in an HTTP request independent from the request URI. The <xref:System.Net.HttpWebRequest.Host> property can consist of a hostname and an optional port number. A Host header without port information implies the default port for the service requested (port 80 for an HTTP URL, for example).
-
- The format for specifying a host and port must follow the rules in section 14.23 of RFC2616 published by the IETF. An example complying with these requirements that specifies a port of 8080 would be the following value for the <xref:System.Net.HttpWebRequest.Host> property:
-
- `www.contoso.com:8080`
-
- Using the <xref:System.Net.HttpWebRequest.Host> property to explicitly specify a custom Host header value also affects areas caching, cookies, and authentication. When an application provides credentials for a specific URI prefix, the applications needs to make sure to use the URI containing the value of the Host header, not the target server in the URI. The key used when caching resources, uses the Host header value rather than the request URI. Cookies are stored in a <xref:System.Net.CookieContainer> and logically grouped by the server domain name. If the application specifies a Host header, then this value will be used as domain.
-
- If the <xref:System.Net.HttpWebRequest.Host> property is not set, then the Host header value to use in an HTTP request is based on the request URI.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The Host header cannot be set to <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The Host header cannot be set to an invalid value.</exception>
@@ -3376,34 +2580,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- If the `If-Modified-Since` header is `null`, then the return value will be set to <xref:System.DateTime.MinValue?displayProperty=nameWithType>.
-
- The <xref:System.Net.HttpWebRequest.IfModifiedSince> property is a standard <xref:System.DateTime?displayProperty=nameWithType> object and can contain a <xref:System.DateTimeKind?displayProperty=nameWithType> field of <xref:System.DateTimeKind.Local?displayProperty=nameWithType>, <xref:System.DateTimeKind.Utc?displayProperty=nameWithType>, or <xref:System.DateTimeKind.Unspecified?displayProperty=nameWithType>. Any kind of time can be set when using the <xref:System.Net.HttpWebRequest.IfModifiedSince> property. If <xref:System.DateTimeKind.Unspecified?displayProperty=nameWithType> is set or retrieved, the <xref:System.Net.HttpWebRequest.IfModifiedSince> property is assumed to be <xref:System.DateTimeKind.Local?displayProperty=nameWithType> (local time).
-
- The classes in the <xref:System.Net> namespace always write it out the <xref:System.Net.HttpWebRequest.IfModifiedSince> property on the wire during transmission in standard form using GMT (Utc) format.
-
- If the <xref:System.Net.HttpWebRequest.IfModifiedSince> property is set to <xref:System.DateTime.MinValue?displayProperty=nameWithType>, then the `If-Modified-Since` HTTP header is removed from the <xref:System.Net.HttpWebRequest.Headers> property and the <xref:System.Net.WebHeaderCollection>.
-
- If the <xref:System.Net.HttpWebRequest.IfModifiedSince> property is <xref:System.DateTime.MinValue?displayProperty=nameWithType>, this indicates that the `If-Modified-Since` HTTP header is not included in the <xref:System.Net.HttpWebRequest.Headers> property and the <xref:System.Net.WebHeaderCollection>.
-
-> [!NOTE]
-> The value for this property is stored in <xref:System.Net.WebHeaderCollection>. If WebHeaderCollection is set, the property value is lost.
-
- If the <xref:System.Net.HttpWebRequest.IfModifiedSince> property is set and 304 (Not Modified) status code is returned, then a <xref:System.Net.WebException?displayProperty=nameWithType> will be thrown by the <xref:System.Net.HttpWebRequest.BeginGetResponse*>, <xref:System.Net.HttpWebRequest.GetResponse*>, and <xref:System.Net.HttpWebRequest.EndGetResponse*> methods.
-
-
-
-## Examples
- The following code example checks the <xref:System.Net.HttpWebRequest.IfModifiedSince> property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/IfModifiedSince/httpwebrequest_ifmodifiedsince.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/IfModifiedSince/httpwebrequest_ifmodifiedsince.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -3450,24 +2629,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Set this property to `true` to send a `Connection` HTTP header with the value Keep-alive. An application uses <xref:System.Net.HttpWebRequest.KeepAlive*> to indicate a preference for persistent connections. When the <xref:System.Net.HttpWebRequest.KeepAlive> property is `true`, the application makes persistent connections to the servers that support them.
-
-> [!NOTE]
-> When using HTTP/1.1, Keep-Alive is on by default. Setting <xref:System.Net.HttpWebRequest.KeepAlive*> to `false` may result in sending a `Connection: Close` header to the server.
-
-
-
-## Examples
- The following code example sets the <xref:System.Net.HttpWebRequest.KeepAlive> property to `false` to avoid establishing a persistent connection with the Internet resource.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Connection/httpwebrequest_connection.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Connection/httpwebrequest_connection.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -3513,21 +2677,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.MaximumAutomaticRedirections> property sets the maximum number of redirections for the request to follow if the <xref:System.Net.HttpWebRequest.AllowAutoRedirect> property is `true`.
-
-
-
-## Examples
- The following code example sets the value of this property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Credentials/httpwebrequest1.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Credentials/httpwebrequest1.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentException">The value is set to 0 or less.</exception>
       </Docs>
@@ -3574,25 +2726,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The length of the response header includes the response status line and any extra control characters that are received as part of HTTP protocol. A value of 0 means that all requests fail.
-
- If the <xref:System.Net.HttpWebRequest.MaximumResponseHeadersLength> property is not explicitly set, it defaults to the value of the <xref:System.Net.HttpWebRequest.DefaultMaximumResponseHeadersLength> property.
-
- If the length of the response header received exceeds the value of the <xref:System.Net.HttpWebRequest.MaximumResponseHeadersLength> property, the <xref:System.Net.HttpWebRequest.EndGetResponse*> or <xref:System.Net.HttpWebRequest.GetResponse*> methods will throw a <xref:System.Net.WebException> with the <xref:System.Net.WebException.Status> property set to <xref:System.Net.WebExceptionStatus.MessageLengthLimitExceeded>.
-
-
-
-## Examples
- The following code example sets the value of this property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Credentials/httpwebrequest1.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Credentials/httpwebrequest1.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The property is set after the request has already been submitted.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">The value is less than 0.</exception>
@@ -3641,13 +2777,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The value of the <xref:System.Net.HttpWebRequest.MediaType> property affects the <xref:System.Net.HttpWebResponse.CharacterSet> property. When you set the <xref:System.Net.HttpWebRequest.MediaType*> in the request, the corresponding media type is chosen from the list of character sets returned in the response `Content-type` HTTP header.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -3700,23 +2832,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.Method> property can be set to any of the HTTP 1.1 protocol verbs: GET, HEAD, POST, PUT, DELETE, TRACE, or OPTIONS.
-
- If the <xref:System.Net.HttpWebRequest.ContentLength> property is set to any value other than -1, the <xref:System.Net.HttpWebRequest.Method> property must be set to a protocol property that uploads data.
-
-
-
-## Examples
- The following code example sets the <xref:System.Net.HttpWebRequest.Method> property to POST.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ContentLength/httpwebrequest_contentlength.cs" id="Snippet4":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ContentLength/httpwebrequest_contentlength.vb" id="Snippet4":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentException">No method is supplied.
 
@@ -3768,23 +2886,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- An application uses the <xref:System.Net.HttpWebRequest.Pipelined> property to indicate a preference for pipelined connections. When <xref:System.Net.HttpWebRequest.Pipelined*> is `true`, an application makes pipelined connections to the servers that support them.
-
- Pipelined connections are made only when the <xref:System.Net.HttpWebRequest.KeepAlive> property is also `true`.
-
-
-
-## Examples
- The following code example prints the value of the <xref:System.Net.HttpWebRequest.Pipelined> property to the console.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Pipelined/httpwebrequest_pipelined.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Pipelined/httpwebrequest_pipelined.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -3831,73 +2935,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- After a client request to a specific <xref:System.Uri> is successfully authenticated, if <xref:System.Net.HttpWebRequest.PreAuthenticate*> is `true` and credentials are supplied, the Authorization header is sent with each request to any <xref:System.Uri> that matches the specific <xref:System.Uri> up to the last forward slash. So if the client request successfully authenticated to a specific <xref:System.Uri> that contains the following:
-
- `http://www.contoso.com/firstpath/`
-
- Then the Authorization header for preauthentication is sent with each request to any of the following <xref:System.Uri> instances:
-
- `http://www.contoso.com/firstpath/`
-
- `http://www.contoso.com/firstpath/default`
-
- `http://www.contoso.com/firstpath/default.html`
-
- `http://www.contoso.com/firstpath/sample.html`
-
- However, the Authorization header is not sent with requests to any of the following <xref:System.Uri> instances:
-
- `http://www.contoso.com/`
-
- `http://www.contoso.com/firstpath`
-
- `http://www.contoso.com/secondpath/`
-
- `http://www.contoso.com/firstpath/thirdpath/`
-
- If the client request to a specific <xref:System.Uri> is not successfully authenticated, the request uses standard authentication procedures.
-
- With the exception of the first request, the <xref:System.Net.WebRequest.PreAuthenticate> property indicates whether to send authentication information with subsequent requests to a <xref:System.Uri> that matches the specific <xref:System.Uri> up to the last forward slash without waiting to be challenged by the server.
-
- The following dialog between client and server illustrates the effect of this property. The dialog assumes that basic authentication is in use.
-
- <xref:System.Net.HttpWebRequest.PreAuthenticate*> is `false`:
-
- Client: GET someUrl
-
- Server: 401 WWW-Authenticate Basic
-
- Client: GET with Authorization headers
-
- Server: 200 OK
-
- Client: GET someUrl
-
- Server: 401 WWW-Authenticate Basic
-
- Client: GET with Authorization headers
-
- Server: 200 OK
-
- <xref:System.Net.HttpWebRequest.PreAuthenticate*> is `true`:
-
- Client: GET someUrl
-
- Server: 401 WWW-Authenticate Basic
-
- Client: GET with Authorization headers
-
- Server: 200 OK
-
- Client: GET someUrl with Authorization headers
-
- If the authentication scheme does not support preauthentication, the value of this property is ignored.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -3949,24 +2989,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest> class supports only versions 1.0 and 1.1 of HTTP. Setting <xref:System.Net.HttpWebRequest.ProtocolVersion*> to a different version throws an exception.
-
-> [!NOTE]
-> To set the HTTP version of the current request, use the <xref:System.Net.HttpVersion.Version10> and <xref:System.Net.HttpVersion.Version11> fields of the <xref:System.Net.HttpVersion> class.
-
-
-
-## Examples
- The following code example sets the <xref:System.Net.HttpWebRequest.ProtocolVersion> property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ProtocolVersion/httpwebrequest_protocolversion.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ProtocolVersion/httpwebrequest_protocolversion.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentException">The HTTP version is set to a value other than 1.0 or 1.1.</exception>
       </Docs>
@@ -4014,39 +3039,14 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.Proxy> property identifies the <xref:System.Net.WebProxy> object to use to process requests to Internet resources. To specify that no proxy should be used, set the <xref:System.Net.HttpWebRequest.Proxy> property to the proxy instance returned by the <xref:System.Net.GlobalProxySelection.GetEmptyWebProxy*?displayProperty=nameWithType> method.
-
- The local computer or application config file may specify that a default proxy be used. If the <xref:System.Net.HttpWebRequest.Proxy> property is specified, then the proxy settings from the <xref:System.Net.HttpWebRequest.Proxy> property override the local computer or application config file and the <xref:System.Net.HttpWebRequest> instance will use the proxy settings specified. If no proxy is specified in a config file and the <xref:System.Net.HttpWebRequest.Proxy> property is unspecified, the <xref:System.Net.HttpWebRequest> class uses the proxy settings inherited from Internet options on the local computer. If there are no proxy settings in Internet options, the request is sent directly to the server.
-
- The <xref:System.Net.HttpWebRequest> class supports local proxy bypass. The class considers a destination to be local if any of the following conditions are met:
-
-- The destination contains a flat name (no dots in the URL).
-
-- The destination contains a loopback address (<xref:System.Net.IPAddress.Loopback> or <xref:System.Net.IPAddress.IPv6Loopback>) or the destination contains an <xref:System.Net.IPAddress> assigned to the local computer.
-
-- The domain suffix of the destination matches the local computer's domain suffix (<xref:System.Net.NetworkInformation.IPGlobalProperties.DomainName*>).
-
- Changing the <xref:System.Net.HttpWebRequest.Proxy> property after the request has been started by calling the <xref:System.Net.HttpWebRequest.GetRequestStream*>, <xref:System.Net.HttpWebRequest.BeginGetRequestStream*>, <xref:System.Net.HttpWebRequest.GetResponse*>, or <xref:System.Net.HttpWebRequest.BeginGetResponse*> method throws an <xref:System.InvalidOperationException>. For information on the proxy element see [\&lt;defaultProxy\&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings).
-
-
-
-## Examples
- The following code example uses the <xref:System.Net.HttpWebRequest.Proxy*> method to get the proxy information for the request.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Proxy/httpwebrequest_proxy.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Proxy/httpwebrequest_proxy.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <see cref="P:System.Net.HttpWebRequest.Proxy" /> is set to <see langword="null" />.</exception>
         <exception cref="T:System.InvalidOperationException">The request has been started by calling <see cref="M:System.Net.HttpWebRequest.GetRequestStream" />, <see cref="M:System.Net.HttpWebRequest.BeginGetRequestStream(System.AsyncCallback,System.Object)" />, <see cref="M:System.Net.HttpWebRequest.GetResponse" />, or <see cref="M:System.Net.HttpWebRequest.BeginGetResponse(System.AsyncCallback,System.Object)" />.</exception>
         <exception cref="T:System.Security.SecurityException">The caller does not have permission for the requested operation.</exception>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings">DefaultProxy Element (Network Settings)</related>
         <related type="Article" href="/dotnet/framework/network-programming/configuring-internet-applications">Configuring Internet Applications</related>
         <related type="Article" href="/dotnet/framework/network-programming/proxy-configuration">Proxy Configuration</related>
         <related type="Article" href="/dotnet/framework/network-programming/automatic-proxy-detection">Automatic Proxy Detection</related>
@@ -4094,24 +3094,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.HttpWebRequest.ReadWriteTimeout> property is used when writing to the stream returned by the <xref:System.Net.HttpWebRequest.GetRequestStream*> method or reading from the stream returned by the <xref:System.Net.HttpWebResponse.GetResponseStream*> method.
-
- Specifically, the <xref:System.Net.HttpWebRequest.ReadWriteTimeout> property controls the time-out for the <xref:System.IO.Stream.Read*> method, which is used to read the stream returned by the <xref:System.Net.HttpWebResponse.GetResponseStream*> method, and for the <xref:System.IO.Stream.Write*> method, which is used to write to the stream returned by the <xref:System.Net.HttpWebRequest.GetRequestStream*> method.
-
- To specify the amount of time to wait for the request to complete, use the <xref:System.Net.HttpWebRequest.Timeout> property.
-
-
-
-## Examples
- The following code example shows how to set the <xref:System.Net.HttpWebRequest.ReadWriteTimeout> property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Overview/source.cs" id="Snippet2":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The request has already been sent.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">The value specified for a set operation is less than or equal to zero and is not equal to <see cref="F:System.Threading.Timeout.Infinite" /></exception>
@@ -4161,24 +3146,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- To clear the `Referer` HTTP header, set the <xref:System.Net.HttpWebRequest.Referer> property to `null`.
-
-> [!NOTE]
-> The value for this property is stored in <xref:System.Net.WebHeaderCollection>. If WebHeaderCollection is set, the property value is lost.
-
-
-
-## Examples
- The following code example sets the <xref:System.Net.HttpWebRequest.Referer> property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Referer/httpwebrequest_referer.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Referer/httpwebrequest_referer.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -4231,23 +3201,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Uri> object passed to <xref:System.Net.HttpWebRequest> by the call to <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType>.
-
- Following a redirection header does not change the <xref:System.Net.HttpWebRequest.RequestUri> property. To get the actual URI that responded to the request, examine the <xref:System.Net.HttpWebRequest.Address> property.
-
-
-
-## Examples
- The following code example checks to see if the <xref:System.Net.HttpWebRequest> object `req` was redirected to another location to fulfill the request, and sets the value of the `hasChanged` variable to `true` if the request was redirected; otherwise, `hasChanged` is set to `false`.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Address/source.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Address/source.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -4294,23 +3250,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- When <xref:System.Net.HttpWebRequest.SendChunked*> is `true`, the request sends data to the Internet resource in segments. The Internet resource must support receiving chunked data.
-
- Changing the <xref:System.Net.HttpWebRequest.SendChunked> property after the request has been started by calling the <xref:System.Net.HttpWebRequest.GetRequestStream*>, <xref:System.Net.HttpWebRequest.BeginGetRequestStream*>, <xref:System.Net.HttpWebRequest.GetResponse*>, or <xref:System.Net.HttpWebRequest.BeginGetResponse*> method throws an <xref:System.InvalidOperationException>.
-
-
-
-## Examples
- The following code example sets the <xref:System.Net.HttpWebRequest.SendChunked> property to `true` so that data can be sent in segments to the Internet resource.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/SendChunked/httpwebrequest_sendchunked.cs" id="Snippet2":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/SendChunked/httpwebrequest_sendchunked.vb" id="Snippet2":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The request has been started by calling the <see cref="M:System.Net.HttpWebRequest.GetRequestStream" />, <see cref="M:System.Net.HttpWebRequest.BeginGetRequestStream(System.AsyncCallback,System.Object)" />, <see cref="M:System.Net.HttpWebRequest.GetResponse" />, or <see cref="M:System.Net.HttpWebRequest.BeginGetResponse(System.AsyncCallback,System.Object)" /> method.</exception>
       </Docs>
@@ -4356,13 +3298,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The default is that no callback function is set and the <xref:System.Net.HttpWebRequest.ServerCertificateValidationCallback> property is `null`.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -4414,19 +3352,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.ServicePoint.Address?displayProperty=nameWithType> property may be different from <xref:System.Net.HttpWebRequest.Address*?displayProperty=nameWithType> if the request is redirected.
-
-
-
-## Examples
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ServicePoint/servicepoint.cs" id="Snippet6":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ServicePoint/servicepoint.vb" id="Snippet6":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -4587,32 +3515,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- <xref:System.Net.HttpWebRequest.Timeout*> is the number of milliseconds that a subsequent synchronous request made with the <xref:System.Net.HttpWebRequest.GetResponse*> method waits for a response, and the <xref:System.Net.HttpWebRequest.GetRequestStream*> method waits for a stream. The <xref:System.Net.HttpWebRequest.Timeout*> applies to the entire request and response, not individually to the <xref:System.Net.HttpWebRequest.GetRequestStream*> and <xref:System.Net.HttpWebRequest.GetResponse*> method calls. If the resource is not returned within the time-out period, the request throws a <xref:System.Net.WebException> with the <xref:System.Net.WebException.Status> property set to <xref:System.Net.WebExceptionStatus.Timeout?displayProperty=nameWithType>.
-
- The <xref:System.Net.HttpWebRequest.Timeout> property must be set before the <xref:System.Net.HttpWebRequest.GetRequestStream*> or <xref:System.Net.HttpWebRequest.GetResponse*> method is called. Changing the <xref:System.Net.HttpWebRequest.Timeout> property after calling the <xref:System.Net.HttpWebRequest.GetRequestStream*> or <xref:System.Net.HttpWebRequest.GetResponse*> method has no effect
-
- The <xref:System.Net.HttpWebRequest.Timeout> property has no effect on asynchronous requests made with the <xref:System.Net.HttpWebRequest.BeginGetResponse*> or <xref:System.Net.HttpWebRequest.BeginGetRequestStream*> method.
-
-> [!CAUTION]
-> In the case of asynchronous requests, the client application implements its own time-out mechanism. Refer to the example in the <xref:System.Net.HttpWebRequest.BeginGetResponse*> method.
-
- To specify the amount of time to wait before a read or write operation times out, use the <xref:System.Net.HttpWebRequest.ReadWriteTimeout> property.
-
- A Domain Name System (DNS) query may take up to 15 seconds to return or time out. If your request contains a host name that requires resolution and you set <xref:System.Net.FileWebRequest.Timeout*> to a value less than 15 seconds, it may take 15 seconds or more before a <xref:System.Net.WebException> is thrown to indicate a timeout on your request.
-
-
-
-## Examples
- The following code example sets the <xref:System.Net.HttpWebRequest.Timeout> property of the <xref:System.Net.HttpWebRequest> object.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Timeout/httpwebrequest_timeout.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/Timeout/httpwebrequest_timeout.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The value specified is less than zero and is not <see cref="F:System.Threading.Timeout.Infinite" />.</exception>
         <altmember cref="P:System.Net.HttpWebRequest.ReadWriteTimeout" />
@@ -4661,18 +3566,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Before you can set the <xref:System.Net.HttpWebRequest.TransferEncoding> property, you must first set the <xref:System.Net.HttpWebRequest.SendChunked> property to `true`. Clearing <xref:System.Net.HttpWebRequest.TransferEncoding*> by setting it to `null` has no effect on the value of <xref:System.Net.HttpWebRequest.SendChunked*>.
-
- Values assigned to the <xref:System.Net.HttpWebRequest.TransferEncoding> property replace any existing contents.
-
-> [!NOTE]
-> The value for this property is stored in <xref:System.Net.WebHeaderCollection>. If WebHeaderCollection is set, the property value is lost.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">
           <see cref="P:System.Net.HttpWebRequest.TransferEncoding" /> is set when <see cref="P:System.Net.HttpWebRequest.SendChunked" /> is <see langword="false" />.</exception>
@@ -4723,31 +3619,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The default value for this property is `false`, which causes the current connection to be closed after a request is completed. Your application must go through the authentication sequence every time it issues a new request.
-
- If this property is set to `true`, the connection used to retrieve the response remains open after the authentication has been performed. In this case, other requests that have this property set to `true` may use the connection without re-authenticating. In other words, if a connection has been authenticated for user A, user B may reuse A's connection; user B's request is fulfilled based on the credentials of user A.
-
-> [!CAUTION]
-> Because it is possible for an application to use the connection without being authenticated, you need to be sure that there is no administrative vulnerability in your system when setting this property to `true`. If your application sends requests for multiple users (impersonates multiple user accounts) and relies on authentication to protect resources, do not set this property to `true` unless you use connection groups as described below.
-
- You may want to consider enabling this mechanism if your are having performance problems and your application is running on a Web server with integrated Windows authentication.
-
- Enabling this setting opens the system to security risks. If you set the <xref:System.Net.HttpWebRequest.UnsafeAuthenticatedConnectionSharing> property to `true` be sure to take the following precautions:
-
-- Use the <xref:System.Net.HttpWebRequest.ConnectionGroupName> property to manage connections for different users. This avoids the potential use of the connection by non-authenticated applications. For example, user A should have a unique connection group name that is different from user B. This provides a layer of isolation for each user account.
-
-- Run your application in a protected environment to help avoid possible connection exploits.
-
- If you control the back-end server, as an alternative you might consider turning off authentication persistence. This increases performance to a lesser degree, but it is safer.
-
-> [!NOTE]
-> If both <xref:System.Net.WebRequest.PreAuthenticate*> and <xref:System.Net.HttpWebRequest.UnsafeAuthenticatedConnectionSharing*> are set to `true`, each request is sent using a connection from the unsafe pool, but with an Authorization header.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -4794,13 +3668,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Set this property to `true` when requests made by this <xref:System.Net.HttpWebRequest> object should, if requested by the server, be authenticated using the credentials of the currently logged on user. For client applications, this is the desired behavior in most scenarios. For middle-tier applications, such as ASP.NET applications, instead of using this property, you would typically set the <xref:System.Net.HttpWebRequest.Credentials> property to the credentials of the client on whose behalf the request is made.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">You attempted to set this property after the request was sent.</exception>
       </Docs>
@@ -4848,19 +3718,9 @@ Both <xref:System.Net.HttpWebRequest> constructors are obsolete and should not b
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
-The value for this property is stored in <xref:System.Net.WebHeaderCollection>. If `WebHeaderCollection` is set, the property value is lost.
-
-## Examples
- The following code example sets the <xref:System.Net.HttpWebRequest.UserAgent> property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/UserAgent/httpwebrequest_useragent.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/UserAgent/httpwebrequest_useragent.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>

--- a/xml/System.Net/HttpWebResponse.xml
+++ b/xml/System.Net/HttpWebResponse.xml
@@ -332,14 +332,12 @@ The contents of the response from the Internet resource are returned as a <xref:
 ## Remarks
  The <xref:System.Net.HttpWebResponse.Close*> method closes the response stream and releases the connection to the resource for reuse by other requests.
 
- You should not access any properties of the <xref:System.Net.HttpWebResponse> object after the call to the `Close` method. On .NET Core, an <xref:System.ObjectDisposedException> is thrown.
+ You should not access any properties of the <xref:System.Net.HttpWebResponse> object after the call to the `Close` method. If you do, an <xref:System.ObjectDisposedException> is thrown.
 
  You must call either the <xref:System.IO.Stream.Close*?displayProperty=nameWithType> or the <xref:System.Net.HttpWebResponse.Close*?displayProperty=nameWithType> method to close the stream and release the connection for reuse. It is not necessary to call both <xref:System.IO.Stream.Close*?displayProperty=nameWithType> and <xref:System.Net.HttpWebResponse.Close*?displayProperty=nameWithType>, but doing so does not cause an error. Failure to close the stream can cause your application to run out of connections.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following example demonstrates how to close a <xref:System.Net.HttpWebResponse>.
@@ -349,7 +347,7 @@ The contents of the response from the Internet resource are returned as a <xref:
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">**.NET Core only:** This <see cref="T:System.Net.HttpWebResponse" /> object has been disposed.</exception>
+        <exception cref="T:System.ObjectDisposedException">This <see cref="T:System.Net.HttpWebResponse" /> object has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="ContentEncoding">
@@ -646,9 +644,7 @@ The contents of the response from the Internet resource are returned as a <xref:
  When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.WebResponse> references. This method invokes the `Dispose()` method of each referenced object.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+> This member outputs trace information when you enable network tracing in your application. ]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>
@@ -838,9 +834,7 @@ The contents of the response from the Internet resource are returned as a <xref:
 > You must call one of the <xref:System.IO.Stream.Close*?displayProperty=nameWithType>, <xref:System.IO.Stream.Dispose*?displayProperty=nameWithType>, <xref:System.Net.HttpWebResponse.Close*?displayProperty=nameWithType>, or <xref:System.Net.HttpWebResponse.Dispose*?displayProperty=nameWithType> methods to close the stream and release the connection for reuse. It's not necessary to close or dispose both <xref:System.IO.Stream> and <xref:System.Net.HttpWebResponse> instances, but doing so doesn't cause an error. Failure to close or dispose the stream will cause your application to run out of connections.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following example demonstrates how to use <xref:System.Net.HttpWebResponse.GetResponseStream*> to return the <xref:System.IO.Stream> instance used to read the response from the server.

--- a/xml/System.Net/HttpWebResponse.xml
+++ b/xml/System.Net/HttpWebResponse.xml
@@ -644,7 +644,8 @@ The contents of the response from the Internet resource are returned as a <xref:
  When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.WebResponse> references. This method invokes the `Dispose()` method of each referenced object.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. ]]></format>
+> This member outputs trace information when you enable network tracing in your application.
+ ]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>

--- a/xml/System.Net/ICredentialPolicy.xml
+++ b/xml/System.Net/ICredentialPolicy.xml
@@ -49,13 +49,11 @@
  The credential policy determines whether to send credentials when sending a <xref:System.Net.WebRequest> for a network resource, such as the content of a Web page. If credentials are sent, servers that require client authentication can attempt to authenticate the client when the request is received instead of sending a response that indicates that the client's credentials are required. While this saves a round trip to the server, this performance gain must be balanced against the security risk inherent in sending credentials across the network. When the destination server does not require client authentication, it is best not to send credentials.
 
 > [!NOTE]
->  <xref:System.Net.ICredentialPolicy> policies are invoked only if the <xref:System.Net.WebRequest> or the <xref:System.Net.WebProxy> that is associated with the request has credentials that are not `null`. Setting this policy has no effect on requests that do not specify credentials.
+> <xref:System.Net.ICredentialPolicy> policies are invoked only if the <xref:System.Net.WebRequest> or the <xref:System.Net.WebProxy> that is associated with the request has credentials that are not `null`. Setting this policy has no effect on requests that do not specify credentials.
 
  Use the <xref:System.Net.AuthenticationManager.CredentialPolicy?displayProperty=nameWithType> property to set an <xref:System.Net.ICredentialPolicy> policy. The <xref:System.Net.IAuthenticationModule> that handles authentication for the request will invoke the <xref:System.Net.ICredentialPolicy.ShouldSendCredential*> method before performing the authentication. If the method returns `false`, authentication is not performed.
 
- An <xref:System.Net.ICredentialPolicy> policy affects all instances of <xref:System.Net.WebRequest> with non-null credentials in the current application domain. The policy cannot be overridden on individual requests.
-
-
+ An <xref:System.Net.ICredentialPolicy> policy affects all instances of <xref:System.Net.WebRequest> with non-null credentials. The policy cannot be overridden on individual requests.
 
 ## Examples
  The following code example shows an implementation of this interface that permits credentials to be sent only for requests that target specific hosts.

--- a/xml/System.Net/IWebProxyScript.xml
+++ b/xml/System.Net/IWebProxyScript.xml
@@ -181,19 +181,8 @@
         <param name="url">Internal only.</param>
         <param name="host">Internal only.</param>
         <summary>Runs a script.</summary>
-        <returns>A <see cref="T:System.String" />.  
-  
- An internal-only value returned.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- When the <xref:System.Net.HttpWebRequest> object is run, it may need to run the WPAD (Web Proxy Automatic Detection) protocol to detect whether a proxy is required for reaching the destination URL. During this process, the system downloads and compiles the PAC (Proxy Auto-Configuration) script in memory and tries to execute the FindProxyForURL function as per the PAC specification.  
-  
- When doing so, the system creates an internal application domain inside the application which runs with minimal permissions, and, most importantly, it does not grant the UI permission to this new application domain. The evaluation of a proxy and running the FindProxyForURL javascript function happens in the context of this new application domain and during this process the system may need to run several helper functions as per the PAC specification.  
-  
- ]]></format>
-        </remarks>
+        <returns>An internal-only value.</returns>
+        <remarks>To be added.</remarks>
         <forInternalUseOnly />
       </Docs>
     </Member>

--- a/xml/System.Net/SecurityProtocolType.xml
+++ b/xml/System.Net/SecurityProtocolType.xml
@@ -60,13 +60,12 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This enumeration defines the set of values that you can use to specify which transport security protocol to use. It is the enumerated type for the <xref:System.Net.ServicePointManager.SecurityProtocol> property. Use this enumeration to determine your transport security protocol policy when you're using HTTP APIs in the .NET Framework such as <xref:System.Net.WebClient>, <xref:System.Net.HttpWebRequest>, <xref:System.Net.Http.HttpClient>, and <xref:System.Net.Mail.SmtpClient> (when using TLS/SSL).
+ This enumeration defines the set of values that you can use to specify which transport security protocol to use. It is the enumerated type for the <xref:System.Net.ServicePointManager.SecurityProtocol> property. Use this enumeration to determine your transport security protocol policy when you're using HTTP APIs such as <xref:System.Net.WebClient>, <xref:System.Net.HttpWebRequest>, <xref:System.Net.Http.HttpClient>, and <xref:System.Net.Mail.SmtpClient> (when using TLS/SSL).
 
 The Transport Layer Security (TLS) protocols assume that a connection-oriented protocol, typically TCP, is in use.
 
  ]]></format>
     </remarks>
-    <related type="Article" href="/dotnet/framework/network-programming/tls">Transport Layer Security (TLS) best practices with the .NET Framework</related>
   </Docs>
   <Members>
     <Member MemberName="Ssl3">

--- a/xml/System.Net/ServicePoint.xml
+++ b/xml/System.Net/ServicePoint.xml
@@ -64,24 +64,6 @@
 
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.ServicePoint> class handles connections to an Internet resource based on the host information passed in the resource's Uniform Resource Identifier (URI). The initial connection to the resource determines the information that the <xref:System.Net.ServicePoint> object maintains, which is then shared by all subsequent requests to that resource.
-
- <xref:System.Net.ServicePoint> objects are managed by the <xref:System.Net.ServicePointManager> class and are created, if necessary, by the <xref:System.Net.ServicePointManager.FindServicePoint*?displayProperty=nameWithType> method. <xref:System.Net.ServicePoint> objects are never created directly but are always created and managed by the <xref:System.Net.ServicePointManager> class. The maximum number of <xref:System.Net.ServicePoint> objects that can be created is set by the <xref:System.Net.ServicePointManager.MaxServicePoints?displayProperty=nameWithType> property.
-
- Each <xref:System.Net.ServicePoint> object maintains its connection to an Internet resource until it has been idle longer than the time specified in the <xref:System.Net.ServicePoint.MaxIdleTime> property. When a <xref:System.Net.ServicePoint> exceeds the <xref:System.Net.ServicePoint.MaxIdleTime> value, it can be recycled to another connection. The default value of <xref:System.Net.ServicePoint.MaxIdleTime> is set by the <xref:System.Net.ServicePointManager.MaxServicePointIdleTime?displayProperty=nameWithType> property.
-
- When the <xref:System.Net.ServicePoint.ConnectionLeaseTimeout> property is set to a value other than -1, and after the specified time elapses, an active <xref:System.Net.ServicePoint> connection is closed after it services the next request. This is useful for applications that do not require active connections that are opened indefinitely, as they are by default.
-
-> [!NOTE]
-> In high load conditions, some applications may run out of free threads in the ThreadPool, which may lead to poor system performance (such as high and variable transaction times).
-
-
-## Examples
- The following code example creates a <xref:System.Net.ServicePoint> object that connects to the URI `www.contoso.com`.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ServicePoint/servicepoint.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ServicePoint/servicepoint.vb" id="Snippet1":::
-
  ]]></format>
     </remarks>
   </Docs>
@@ -193,16 +175,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Some load balancing techniques require a client to use a specific local IP address and port number, rather than <xref:System.Net.IPAddress.Any?displayProperty=nameWithType> (or <xref:System.Net.IPAddress.IPv6Any?displayProperty=nameWithType> for Internet Protocol Version 6) and an ephemeral port. Your <xref:System.Net.ServicePoint.BindIPEndPointDelegate> can satisfy this requirement.
-
-> [!NOTE]
-> Since .NET 9, <xref:System.Net.HttpWebRequest> uses <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback?displayProperty=nameWithType> to bind the underlying socket to the endpoint from this delegate.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -258,22 +233,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
-Although a <xref:System.Net.ServicePoint> object can make multiple connections to an Internet resource, it can maintain only one certificate.
-
-> [!NOTE]
-> Since .NET 9, returns the remote certificate retrieved via <xref:System.Net.Security.SslClientAuthenticationOptions.RemoteCertificateValidationCallback> on <xref:System.Net.Http.SocketsHttpHandler.SslOptions?displayProperty=nameWithType>.
-
-## Examples
- The following code example displays the value of this property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ServicePoint/servicepoint.cs" id="Snippet5":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ServicePoint/servicepoint.vb" id="Snippet5":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -391,13 +353,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Connection groups associate a set of requests with a particular connection or set of connections. This method removes and closes all connections that belong to the specified connection group.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -445,30 +403,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- You can use this property to ensure that a <xref:System.Net.ServicePoint> object's active connections do not remain open indefinitely. This property is intended for scenarios where connections should be dropped and reestablished periodically, such as load balancing scenarios.
-
- By default, when <xref:System.Net.HttpWebRequest.KeepAlive> is `true` for a request, the <xref:System.Net.ServicePoint.MaxIdleTime> property sets the time-out for closing <xref:System.Net.ServicePoint> connections due to inactivity. If the <xref:System.Net.ServicePoint> has active connections, <xref:System.Net.ServicePoint.MaxIdleTime> has no effect and the connections remain open indefinitely.
-
- When the <xref:System.Net.ServicePoint.ConnectionLeaseTimeout> property is set to a value other than -1, and after the specified time elapses, an active <xref:System.Net.ServicePoint> connection is closed after servicing a request by setting <xref:System.Net.HttpWebRequest.KeepAlive> to `false` in that request.
-
- Setting this value affects all connections managed by the <xref:System.Net.ServicePoint> object.
-
-
-> [!NOTE]
-> Since .NET 9, this property maps to <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionLifetime?displayProperty=nameWithType>. However, handlers are not being reused between requests so it doesn't have any meaningful impact.
-
-
-## Examples
- The following code example sets the value of this property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/ServicePoint/ConnectionLeaseTimeout/nclservicepoint.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/ServicePoint/ConnectionLeaseTimeout/nclservicepoint.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The value specified for a set operation is a negative number less than -1.</exception>
         <altmember cref="P:System.Net.HttpWebRequest.KeepAlive" />
@@ -521,25 +458,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.ServicePoint.ConnectionLimit> property sets the maximum number of connections that the <xref:System.Net.ServicePoint> object can make to an Internet resource. The value of the <xref:System.Net.ServicePoint.ConnectionLimit> property is set to the value of the <xref:System.Net.ServicePointManager.DefaultConnectionLimit?displayProperty=nameWithType> property when the <xref:System.Net.ServicePoint> object is created; subsequent changes to <xref:System.Net.ServicePointManager.DefaultConnectionLimit> have no effect on existing <xref:System.Net.ServicePoint> objects.
-
- The connection limit doesn't apply to proxied connections or proxy tunnels.
-
-> [!NOTE]
-> Since .NET 9, this property maps to <xref:System.Net.Http.SocketsHttpHandler.MaxConnectionsPerServer?displayProperty=nameWithType>. However, handlers are not being reused between requests so it doesn't have any meaningful impact.
-
-
-## Examples
- The following code example uses the <xref:System.Net.ServicePoint.ConnectionLimit> property to check the maximum number of connections that the <xref:System.Net.ServicePoint> object can make to the specified Uniform Resource Identifier (URI).
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ServicePoint/servicepoint.cs" id="Snippet4":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ServicePoint/servicepoint.vb" id="Snippet4":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The connection limit is equal to or less than 0.</exception>
         <related type="Article" href="/dotnet/framework/network-programming/managing-connections">Managing Connections</related>
@@ -590,21 +511,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- If the <xref:System.Net.ServicePoint> object was constructed by calling a <xref:System.Net.ServicePointManager.FindServicePoint*> overload with a <xref:System.Uri> argument, then the <xref:System.Net.ServicePoint.ConnectionName> property represents the <xref:System.Uri.Scheme> property of the <xref:System.Uri> object used.
-
- If the <xref:System.Net.ServicePoint> object was constructed from a network host and port, the <xref:System.Net.ServicePoint.ConnectionName> property contains a string that represents the host and the network port. If the <xref:System.Net.ServicePoint.ConnectionName> property is set when constructed from a host and port, only <xref:System.Net.WebRequest> objects with the same <xref:System.Net.WebRequest.ConnectionGroupName> value can use this <xref:System.Net.ServicePoint> object.
-
-
-
-## Examples
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ServicePoint/servicepoint.cs" id="Snippet4":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ServicePoint/servicepoint.vb" id="Snippet4":::
-
- ]]></format>
+]]></format>
         </remarks>
         <related type="Article" href="/dotnet/framework/network-programming/connection-grouping">Connection Grouping</related>
       </Docs>
@@ -654,22 +563,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.ServicePoint.CurrentConnections> property contains the number of open Internet connections associated with this <xref:System.Net.ServicePoint> object. The value of <xref:System.Net.ServicePoint.CurrentConnections> cannot exceed that of <xref:System.Net.ServicePoint.ConnectionLimit>.
-
-> [!NOTE]
-> This property is only implemented on .NET Framework.
-
-## Examples
- The following code example uses the <xref:System.Net.ServicePoint.CurrentConnections> property to determine the number of open Internet connections associated with this <xref:System.Net.ServicePoint> object.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ServicePoint/servicepoint.cs" id="Snippet2":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ServicePoint/servicepoint.vb" id="Snippet2":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -719,30 +615,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- When this property is set to `true`, client requests that use the `POST` method expect to receive a 100-Continue response from the server to indicate that the client should send the data to be posted. This mechanism allows clients to avoid sending large amounts of data over the network when the server, based on the request headers, intends to reject the request.
-
- For example, assume the <xref:System.Net.ServicePoint.Expect100Continue> property is `false`. When the request is sent to the server, it includes the data. If, after reading the request headers, the server requires authentication and sends a 401 response, the client must resend the data with proper authentication headers.
-
- If the <xref:System.Net.ServicePoint.Expect100Continue> property is `true`, the request headers are sent to the server. If the server has not rejected the request, it sends a 100-Continue response signaling that the data can be transmitted. If, as in the preceding example, the server requires authentication, it sends the 401 response and the client has not unnecessarily transmitted the data.
-
- Changing the value of this property does not affect existing connections. Only new connections created after the change are affected.
-
- The Expect 100-Continue behavior is fully described in IETF RFC 2616 Section 10.1.1.
-
-> [!NOTE]
-> Since .NET 9, this property sets <xref:System.Net.Http.Headers.HttpRequestHeaders.ExpectContinue?displayProperty=nameWithType> on the <xref:System.Net.Http.HttpRequestMessage.Headers?displayProperty=nameWithType>.
-
-## Examples
- The following code example displays the value of this property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ServicePoint/servicepoint.cs" id="Snippet9":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ServicePoint/servicepoint.vb" id="Snippet9":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -791,20 +666,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.ServicePoint.IdleSince> property records the last date and time at which a service point was disconnected from a host. When the difference between the current time and <xref:System.Net.ServicePoint.IdleSince> exceeds the value of <xref:System.Net.ServicePoint.MaxIdleTime>, the <xref:System.Net.ServicePoint> object is available for recycling to another connection.
-
-
-## Examples
- The following code example uses the <xref:System.Net.ServicePoint.IdleSince> property to set and retrieve the date and time that the <xref:System.Net.ServicePoint> object was last connected to a host.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ServicePoint/servicepoint.cs" id="Snippet3":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ServicePoint/servicepoint.vb" id="Snippet3":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -853,26 +717,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- You can set <xref:System.Net.ServicePoint.MaxIdleTime> to <xref:System.Threading.Timeout.Infinite?displayProperty=nameWithType> to indicate that a connection associated with the <xref:System.Net.ServicePoint> object should never time out.
-
- The default value of the <xref:System.Net.ServicePoint.MaxIdleTime> property is the value of the <xref:System.Net.ServicePointManager.MaxServicePointIdleTime?displayProperty=nameWithType> property when the <xref:System.Net.ServicePoint> object is created. Subsequent changes to the <xref:System.Net.ServicePointManager.MaxServicePointIdleTime> property have no effect on existing <xref:System.Net.ServicePoint> objects.
-
- When the <xref:System.Net.ServicePoint.MaxIdleTime> for a connection associated with a <xref:System.Net.ServicePoint> is exceeded, the connection remains open until the application tries to use the connection. At that time, the Framework closes the connection and creates a new connection to the remote host.
-
-> [!NOTE]
-> Since .NET 9, this property maps to <xref:System.Net.Http.SocketsHttpHandler.PooledConnectionIdleTimeout?displayProperty=nameWithType>. However, handlers are not being reused between requests so it doesn't have any meaningful impact.
-
-## Examples
- The following code example uses the <xref:System.Net.ServicePoint.MaxIdleTime> property to set and retrieve the <xref:System.Net.ServicePoint> idle time.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ServicePoint/servicepoint.cs" id="Snippet3":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ServicePoint/servicepoint.vb" id="Snippet3":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <see cref="P:System.Net.ServicePoint.MaxIdleTime" /> is set to less than <see cref="F:System.Threading.Timeout.Infinite" /> or greater than <see cref="F:System.Int32.MaxValue">Int32.MaxValue</see>.</exception>
@@ -923,22 +770,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The HTTP protocol versions are HTTP/1.0 and HTTP/1.1.
-
-> [!NOTE]
-> Since .NET 9, this property returns <xref:System.Net.HttpWebRequest.ProtocolVersion?displayProperty=nameWithType>.
-
-## Examples
- The following code example displays the value of this property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ServicePoint/servicepoint.cs" id="Snippet5":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ServicePoint/servicepoint.vb" id="Snippet5":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -986,22 +820,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- For additional information, see <xref:System.Net.Sockets.Socket.ReceiveBufferSize>.
-
-> [!NOTE]
-> Since .NET 9, <xref:System.Net.HttpWebRequest> uses <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback?displayProperty=nameWithType> to set <xref:System.Net.Sockets.Socket.ReceiveBufferSize?displayProperty=nameWithType> to the value of this property.
-
-## Examples
- The following code example sets the value of this property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/ServicePoint/ConnectionLeaseTimeout/nclservicepoint.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/ServicePoint/ConnectionLeaseTimeout/nclservicepoint.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The value specified for a set operation is greater than <see cref="F:System.Int32.MaxValue">Int32.MaxValue</see>.</exception>
       </Docs>
@@ -1065,22 +886,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- An application can request that a TCP/IP provider enable the use of keep-alive packets on a TCP connection. The default is that the use of keep-alive packets on a TCP connection is disabled.
-
- The default settings when a TCP socket is initialized sets the keep-alive timeout to 2 hours and the keep-alive interval to 1 second. The `keepAliveTime` parameter specifies the timeout, in milliseconds, with no activity until the first keep-alive packet is sent. The `keepAliveInterval` parameter specifies the interval, in milliseconds, between when successive keep-alive packets are sent if no acknowledgement is received. The number of keep-alive probes cannot be changed and is set to 10.
-
- If a TCP connection is dropped as the result of keep-alives, a <xref:System.Net.Sockets.SocketError> of <xref:System.Net.Sockets.SocketError.NetworkReset> is returned to any calls in progress on the socket, and any subsequent calls will fail with a <xref:System.Net.Sockets.SocketError> of <xref:System.Net.Sockets.SocketError.NotConnected>.
-
- This method is not thread-safe. Any new connection created at the same time might see partially changed values for the TCP keep-alive.
-
-> [!NOTE]
-> Since .NET 9, <xref:System.Net.HttpWebRequest> uses <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback?displayProperty=nameWithType> to set TCP keep alive options on the underlying socket to the values provided to this method.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The value specified for <paramref name="keepAliveTime" /> or <paramref name="keepAliveInterval" /> parameter is less than or equal to 0.</exception>
       </Docs>
@@ -1131,24 +939,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Pipelining allows clients to send multiple requests across a persistent connection without waiting for each response from the server. The server sends the responses in the same order as the requests were received.
-
- Pipelining is described in detail in IETF RFC 2616 section 8.1.2.2.
-
-> [!NOTE]
-> This property is only implemented on .NET Framework.
-
-## Examples
- The following code example displays the value of this property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ServicePoint/servicepoint.cs" id="Snippet5":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ServicePoint/servicepoint.vb" id="Snippet5":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1198,26 +991,9 @@ Although a <xref:System.Net.ServicePoint> object can make multiple connections t
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The Nagle algorithm is used to buffer small packets of data and transmit them as a single packet. This process, referred to as "nagling," is widely used because it reduces the number of packets transmitted and lowers the overhead per packet.
-
- Changing the value of this property does not affect existing connections. Only new connections created after the change are affected.
-
- The Nagle algorithm is fully described in IETF RFC 896.
-
-> [!NOTE]
-> Since .NET 9, <xref:System.Net.HttpWebRequest> uses <xref:System.Net.Http.SocketsHttpHandler.ConnectCallback?displayProperty=nameWithType> to set <xref:System.Net.Sockets.Socket.NoDelay?displayProperty=nameWithType> to the opposite value than this property.
-
-## Examples
- The following code example displays the value of this property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/ServicePoint/servicepoint.cs" id="Snippet9":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/HttpWebRequest/ServicePoint/servicepoint.vb" id="Snippet9":::
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>

--- a/xml/System.Net/ServicePointManager.xml
+++ b/xml/System.Net/ServicePointManager.xml
@@ -1049,7 +1049,7 @@ The default value of this property is <xref:System.Net.SecurityProtocolType.Syst
 
  Your code should never implicitly depend on using a particular protection level, or on the assumption that a given security level is used by default. If your app depends on the use of a particular security level, you must explicitly specify that level and then check to be sure that it is actually in use on the established connection. Further, your code should be designed to be robust in the face of changes to which protocols are supported, as such changes are often made with little advance notice in order to mitigate emerging threats.
 
-To opt out of the behavior that blocks insecure cipher and hashing algorithms for connections in order to maintain interoperability with your existing SSL3 services OR TLS w/ RC4 services, see [Cannot connect to a server by using the ServicePointManager or SslStream APIs after upgrade to the .NET Framework 4.6](https://support.microsoft.com/kb/3069494).
+To opt out of the behavior that blocks insecure cipher and hashing algorithms for connections in order to maintain interoperability with your existing SSL3, or TLS with RC4, services, see [Cannot connect to a server by using the ServicePointManager or SslStream APIs after upgrade to the .NET Framework 4.6](https://support.microsoft.com/kb/3069494).
 
 > [!NOTE]
 > Since .NET 9, this property maps to <xref:System.Net.Security.SslClientAuthenticationOptions.EnabledSslProtocols> on <xref:System.Net.Http.SocketsHttpHandler.SslOptions?displayProperty=nameWithType>.

--- a/xml/System.Net/ServicePointManager.xml
+++ b/xml/System.Net/ServicePointManager.xml
@@ -69,9 +69,7 @@
 
  When an application requests a connection to an Internet resource Uniform Resource Identifier (URI) through the <xref:System.Net.ServicePointManager> object, the <xref:System.Net.ServicePointManager> returns a <xref:System.Net.ServicePoint> object that contains connection information for the host and scheme identified by the URI. If there is an existing <xref:System.Net.ServicePoint> object for that host and scheme, the <xref:System.Net.ServicePointManager> object returns the existing <xref:System.Net.ServicePoint> object; otherwise, the <xref:System.Net.ServicePointManager> object creates a new <xref:System.Net.ServicePoint> object.
 
- The .NET Framework 4.6 includes a security feature that blocks insecure cipher and hashing algorithms for connections. Applications using TLS/SSL through APIs such as <xref:System.Net.Http.HttpClient>, <xref:System.Net.HttpWebRequest>, <xref:System.Net.FtpWebRequest>, <xref:System.Net.Mail.SmtpClient>, and <xref:System.Net.Security.SslStream> and targeting .NET Framework 4.6 or later get the more-secure behavior by default.
-
- Developers may want to opt out of this behavior in order to maintain interoperability with their existing SSL3 services or TLS w/ RC4 services. [This article](https://support.microsoft.com/kb/3069494) explains how to modify your code so that the new behavior is disabled.
+To opt out of the behavior that blocks insecure cipher and hashing algorithms for connections in order to maintain interoperability with your existing SSL3 services or TLS w/ RC4 services, see [Cannot connect to a server by using the ServicePointManager or SslStream APIs after upgrade to the .NET Framework 4.6](https://support.microsoft.com/kb/3069494).
 
 > [!IMPORTANT]
 > We don't recommend that you use the `ServicePointManager` class for new development. Instead, use the <xref:System.Net.Http.HttpClient?displayProperty=nameWithType> class.
@@ -85,7 +83,6 @@
  ]]></format>
     </remarks>
     <altmember cref="T:System.Net.ServicePoint" />
-    <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/servicepointmanager-element-network-settings">ServicePointManager Element (Network Settings)</related>
   </Docs>
   <Members>
     <Member MemberName="CheckCertificateRevocationList">
@@ -263,7 +260,7 @@
       </ReturnValue>
       <MemberValue>4</MemberValue>
       <Docs>
-        <summary>The default number of non-persistent connections (4) allowed on a <see cref="T:System.Net.ServicePoint" /> object connected to an HTTP/1.0 or later server. This field is constant but is no longer used as of .NET Framework 2.0.</summary>
+        <summary>The default number of non-persistent connections (4) allowed on a <see cref="T:System.Net.ServicePoint" /> object connected to an HTTP/1.0 or later server. This field is constant but is no longer used.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -504,7 +501,6 @@
         </remarks>
         <altmember cref="T:System.Net.ServicePoint" />
         <altmember cref="T:System.Net.Security.EncryptionPolicy" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/servicepointmanager-element-network-settings">ServicePointManager Element (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="Expect100Continue">
@@ -1042,22 +1038,18 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the security protocol used by the <see cref="T:System.Net.ServicePoint" /> objects managed by the <see cref="T:System.Net.ServicePointManager" /> object.</summary>
-        <value>One of the values defined in the <see cref="T:System.Net.SecurityProtocolType" /> enumeration.</value>
+        <value>One of the values defined in the <see cref="T:System.Net.SecurityProtocolType" /> enumeration. The default value is <see cref="F:System.Net.SecurityProtocolType.SystemDefault" />.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
 This property selects the version of the Secure Sockets Layer (SSL) or Transport Layer Security (TLS) protocol to use for new connections; existing connections aren't changed.
 
-Starting with the .NET Framework 4.7, the default value of this property is <xref:System.Net.SecurityProtocolType.SystemDefault?displayProperty=nameWithType>. This allows .NET Framework networking APIs based on <xref:System.Net.Security.SslStream> (such as FTP, HTTP, and SMTP) to inherit the default security protocols from the operating system or from any custom configurations performed by a system administrator. For information about which SSL/TLS protocols are enabled by default on each version of the Windows operating system, see [Protocols in TLS/SSL (Schannel SSP)](/windows/win32/secauthn/protocols-in-tls-ssl--schannel-ssp-).
-
-For versions of the .NET Framework through the .NET Framework 4.6.2, no default value is listed for this property. The security landscape changes constantly, and default protocols and protection levels are changed over time in order to avoid known weaknesses. Defaults vary depending on individual machine configuration, installed software, and applied patches.
+The default value of this property is <xref:System.Net.SecurityProtocolType.SystemDefault?displayProperty=nameWithType>, which allows networking APIs based on <xref:System.Net.Security.SslStream> (such as FTP, HTTP, and SMTP) to inherit the default security protocols from the operating system or from any custom configurations performed by a system administrator. For information about which SSL/TLS protocols are enabled by default on each version of the Windows operating system, see [Protocols in TLS/SSL (Schannel SSP)](/windows/win32/secauthn/protocols-in-tls-ssl--schannel-ssp-).
 
  Your code should never implicitly depend on using a particular protection level, or on the assumption that a given security level is used by default. If your app depends on the use of a particular security level, you must explicitly specify that level and then check to be sure that it is actually in use on the established connection. Further, your code should be designed to be robust in the face of changes to which protocols are supported, as such changes are often made with little advance notice in order to mitigate emerging threats.
 
- The .NET Framework 4.6 includes a security feature that blocks insecure cipher and hashing algorithms for connections. Applications using TLS/SSL through APIs such as HttpClient, HttpWebRequest, FTPClient, SmtpClient, and SslStream and targeting .NET Framework 4.6 get the more-secure behavior by default.
-
- Developers may want to opt out of this behavior in order to maintain interoperability with their existing SSL3 services OR TLS w/ RC4 services. [This article](https://support.microsoft.com/kb/3069494) explains how to modify your code so that the new behavior is disabled.
+To opt out of the behavior that blocks insecure cipher and hashing algorithms for connections in order to maintain interoperability with your existing SSL3 services OR TLS w/ RC4 services, see [Cannot connect to a server by using the ServicePointManager or SslStream APIs after upgrade to the .NET Framework 4.6](https://support.microsoft.com/kb/3069494).
 
 > [!NOTE]
 > Since .NET 9, this property maps to <xref:System.Net.Security.SslClientAuthenticationOptions.EnabledSslProtocols> on <xref:System.Net.Http.SocketsHttpHandler.SslOptions?displayProperty=nameWithType>.

--- a/xml/System.Net/SocketPermission.xml
+++ b/xml/System.Net/SocketPermission.xml
@@ -51,11 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- <xref:System.Net.SocketPermission> instances control permission to accept connections or initiate <xref:System.Net.Sockets.Socket> connections. A <xref:System.Net.Sockets.Socket> permission can be established for a host name or IP address, a port number, and a transport protocol.
-
-> [!NOTE]
-> Avoid creating socket permissions using host names, as these names have to be resolved to IP addresses, and this might block the stack.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -103,14 +98,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.SocketPermission" /> class that allows unrestricted access to the <see cref="T:System.Net.Sockets.Socket" /> or disallows access to the <see cref="T:System.Net.Sockets.Socket" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If the <xref:System.Net.SocketPermission> instance is created with the `Unrestricted` value from <xref:System.Security.Permissions.PermissionState> then the <xref:System.Net.SocketPermission> instance passes all demands. Any other value for `state` results in a <xref:System.Net.SocketPermission> instance that fails all demands unless a transport address permission is added with <xref:System.Net.SocketPermission.AddPermission*>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -152,18 +140,7 @@
         <param name="hostName">The host name for the transport address.</param>
         <param name="portNumber">The port number for the transport address.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.SocketPermission" /> class for the given transport address with the specified permission.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor creates a <xref:System.Net.SocketPermission> that controls access to the specified `hostName` and `portNumber` using the specified `transport`.
-
- The `hostName` can be a DNS name, an IP address, or a specified IP subnet, such as 192.168.1.*.
-
- The `portNumber` can be any valid port number defined by the transport, or <xref:System.Net.SocketPermission.AllPorts?displayProperty=nameWithType>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="hostName" /> is <see langword="null" />.</exception>
       </Docs>
@@ -246,14 +223,7 @@
         <param name="hostName">The host name for the transport address.</param>
         <param name="portNumber">The port number for the transport address.</param>
         <summary>Adds a permission to the set of permissions for a transport address.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The `hostName` can be a DNS name, an IP address, or a specified IP subnet, such as 192.168.1.*.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="hostName" /> is <see langword="null" />.</exception>
       </Docs>
@@ -291,14 +261,7 @@
       <MemberValue>-1</MemberValue>
       <Docs>
         <summary>Defines a constant that represents all ports.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This field is read-only. The value of this field is -1.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ConnectList">
@@ -371,14 +334,7 @@
       <Docs>
         <summary>Creates a copy of a <see cref="T:System.Net.SocketPermission" /> instance.</summary>
         <returns>A new instance of the <see cref="T:System.Net.SocketPermission" /> class that is a copy of the current instance.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The object returned by this method represents the same level of access as the current instance. This method overrides <xref:System.Security.CodeAccessPermission.Copy*> and is implemented to support the <xref:System.Security.IPermission> interface.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -417,16 +373,7 @@
       <Docs>
         <param name="securityElement">The XML encoding used to reconstruct the <see cref="T:System.Net.SocketPermission" /> instance.</param>
         <summary>Reconstructs a <see cref="T:System.Net.SocketPermission" /> instance for an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.SocketPermission.FromXml*> method reconstructs a <xref:System.Net.SocketPermission> instance from an XML encoding defined by the <xref:System.Security.SecurityElement> class.
-
- Use the <xref:System.Net.SocketPermission.ToXml*> method to encode the <xref:System.Net.SocketPermission> instance, including state information, in XML.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="securityElement" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <paramref name="securityElement" /> is not a permission element for this type.</exception>
       </Docs>
@@ -468,14 +415,7 @@
         <param name="target">The <see cref="T:System.Net.SocketPermission" /> instance to intersect with the current instance.</param>
         <summary>Returns the logical intersection between two <see cref="T:System.Net.SocketPermission" /> instances.</summary>
         <returns>The <see cref="T:System.Net.SocketPermission" /> instance that represents the intersection of two <see cref="T:System.Net.SocketPermission" /> instances. If the intersection is empty, the method returns <see langword="null" />. If the <paramref name="target" /> parameter is a null reference, the method returns <see langword="null" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that helps to protect the resources and operations protected by both permissions. Specifically, it represents the minimum permission such that any demand that passes both permissions also passes their intersection. This method overrides <xref:System.Security.CodeAccessPermission.Intersect*> and is implemented to support the <xref:System.Security.IPermission> interface.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not a <see cref="T:System.Net.SocketPermission" />.</exception>
         <exception cref="T:System.Security.SecurityException">
           <see cref="T:System.Net.DnsPermission" /> is not granted to the method caller.</exception>
@@ -518,16 +458,7 @@
         <param name="target">A <see cref="T:System.Net.SocketPermission" /> that is to be tested for the subset relationship.</param>
         <summary>Determines if the current permission is a subset of the specified permission.</summary>
         <returns>If <paramref name="target" /> is <see langword="null" />, this method returns <see langword="true" /> if the current instance defines no permissions; otherwise, <see langword="false" />. If <paramref name="target" /> is not <see langword="null" />, this method returns <see langword="true" /> if the current instance defines a subset of <paramref name="target" /> permissions; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission.
-
- For example, a permission that represents access to 192.168.1.1:80 is a subset of a permission that represents access to 192.168.1.1:Any. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not a <see cref="T:System.Net.Sockets.SocketException" />.</exception>
         <exception cref="T:System.Security.SecurityException">
@@ -609,16 +540,7 @@
       <Docs>
         <summary>Creates an XML encoding of a <see cref="T:System.Net.SocketPermission" /> instance and its current state.</summary>
         <returns>A <see cref="T:System.Security.SecurityElement" /> instance that contains an XML-encoded representation of the <see cref="T:System.Net.SocketPermission" /> instance, including state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.SocketPermission.ToXml*> method creates a <xref:System.Security.SecurityElement> instance to encode a representation of the <xref:System.Net.SocketPermission> instance, including state information, in XML.
-
- Use the <xref:System.Net.SocketPermission.FromXml*> method to restore the state information from a <xref:System.Security.SecurityElement> instance.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -658,14 +580,7 @@
         <param name="target">The <see cref="T:System.Net.SocketPermission" /> instance to combine with the current instance.</param>
         <summary>Returns the logical union between two <see cref="T:System.Net.SocketPermission" /> instances.</summary>
         <returns>The <see cref="T:System.Net.SocketPermission" /> instance that represents the union of two <see cref="T:System.Net.SocketPermission" /> instances. If <paramref name="target" /> parameter is <see langword="null" />, it returns a copy of the current instance.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Net.SocketPermission.Union*> is a permission that represents all of the access to <xref:System.Net.Sockets.Socket> connections represented by the current instance as well as the access represented by `target`. Any demand that passes either the current instance or `target` passes their union. This method overrides <xref:System.Security.CodeAccessPermission.Union*> and is implemented to support the <xref:System.Security.IPermission> interface.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not a <see cref="T:System.Net.SocketPermission" />.</exception>
       </Docs>

--- a/xml/System.Net/SocketPermissionAttribute.xml
+++ b/xml/System.Net/SocketPermissionAttribute.xml
@@ -51,14 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- To use this attribute, your <xref:System.Net.Sockets.Socket> connection must conform to the properties that are specified in your <xref:System.Net.SocketPermissionAttribute>. For example, to apply the permission to a <xref:System.Net.Sockets.Socket> connection on port 80, set the <xref:System.Net.SocketPermissionAttribute.Port> property of the <xref:System.Net.SocketPermissionAttribute> to "80". The security information that is specified in <xref:System.Net.SocketPermissionAttribute> is stored in the metadata of the attribute target, which is the class to which the <xref:System.Net.SocketPermissionAttribute> is applied. The system then accesses the information at run time. The <xref:System.Security.Permissions.SecurityAction> that is passed to the constructor determines the allowable <xref:System.Net.SocketPermissionAttribute> targets.
-
-> [!NOTE]
-> The properties of a <xref:System.Net.SocketPermissionAttribute> must have values that are not `null`. Also, once set, the values of the properties cannot be changed.
-
-> [!NOTE]
-> For more information about using attributes, see [Attributes](/dotnet/standard/attributes/).
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Net.SocketPermission" />
@@ -97,14 +89,7 @@
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.SocketPermissionAttribute" /> class with the specified <see cref="T:System.Security.Permissions.SecurityAction" /> value.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.SecurityAction> value that is passed to this constructor specifies the allowable <xref:System.Net.SocketPermissionAttribute> targets.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="action" /> is not a valid <see cref="T:System.Security.Permissions.SecurityAction" /> value.</exception>
       </Docs>
@@ -142,14 +127,7 @@
       <Docs>
         <summary>Gets or sets the network access method that is allowed by this <see cref="T:System.Net.SocketPermissionAttribute" />.</summary>
         <value>A string that contains the network access method that is allowed by this instance of <see cref="T:System.Net.SocketPermissionAttribute" />. Valid values are "Accept" and "Connect."</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property is write-once. Valid values for this property correspond to <xref:System.Net.NetworkAccess> enumeration values.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <see cref="P:System.Net.SocketPermissionAttribute.Access" /> property is not <see langword="null" /> when you attempt to set the value. To specify more than one Access method, use an additional attribute declaration statement.</exception>
       </Docs>
     </Member>
@@ -187,14 +165,7 @@
       <Docs>
         <summary>Creates and returns a new instance of the <see cref="T:System.Net.SocketPermission" /> class.</summary>
         <returns>An instance of the <see cref="T:System.Net.SocketPermission" /> class that corresponds to the security declaration.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.SocketPermissionAttribute.CreatePermission*> method is called by the security system, not by the application code. The security information described by <xref:System.Net.SocketPermissionAttribute> is stored in the metadata of the attribute target, which is the class to which the <xref:System.Net.SocketPermissionAttribute> is applied. The system then accesses the information at run-time and calls <xref:System.Net.SocketPermissionAttribute.CreatePermission*>. The system uses the returned <xref:System.Security.IPermission> to enforce the specified security requirements.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">One or more of the current instance's <see cref="P:System.Net.SocketPermissionAttribute.Access" />, <see cref="P:System.Net.SocketPermissionAttribute.Host" />, <see cref="P:System.Net.SocketPermissionAttribute.Transport" />, or <see cref="P:System.Net.SocketPermissionAttribute.Port" /> properties is <see langword="null" />.</exception>
         <altmember cref="T:System.Net.SocketPermission" />
       </Docs>
@@ -232,14 +203,7 @@
       <Docs>
         <summary>Gets or sets the DNS host name or IP address that is specified by this <see cref="T:System.Net.SocketPermissionAttribute" />.</summary>
         <value>A string that contains the DNS host name or IP address that is associated with this instance of <see cref="T:System.Net.SocketPermissionAttribute" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property is write-once and specifies the Domain Name Services (DNS) host name to which this permission applies.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <see cref="P:System.Net.SocketPermissionAttribute.Host" /> is not <see langword="null" /> when you attempt to set the value. To specify more than one host, use an additional attribute declaration statement.</exception>
       </Docs>
@@ -277,14 +241,7 @@
       <Docs>
         <summary>Gets or sets the port number that is associated with this <see cref="T:System.Net.SocketPermissionAttribute" />.</summary>
         <value>A string that contains the port number that is associated with this instance of <see cref="T:System.Net.SocketPermissionAttribute" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property is write-once and specifies the port number to which this permission applies. The valid values are a string-encoded integer or the string "All".
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <see cref="P:System.Net.SocketPermissionAttribute.Port" /> property is <see langword="null" /> when you attempt to set the value. To specify more than one port, use an additional attribute declaration statement.</exception>
       </Docs>
     </Member>
@@ -321,14 +278,7 @@
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Net.TransportType" /> that is specified by this <see cref="T:System.Net.SocketPermissionAttribute" />.</summary>
         <value>A string that contains the <see cref="T:System.Net.TransportType" /> that is associated with this <see cref="T:System.Net.SocketPermissionAttribute" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Possible string values of this property are <xref:System.Net.TransportType.All>, <xref:System.Net.TransportType.Connectionless>, <xref:System.Net.TransportType.ConnectionOriented>, <xref:System.Net.TransportType.Tcp>, and <xref:System.Net.TransportType.Udp>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <see cref="P:System.Net.SocketPermissionAttribute.Transport" /> is not <see langword="null" /> when you attempt to set the value. To specify more than one transport type, use an additional attribute declaration statement.</exception>
       </Docs>

--- a/xml/System.Net/WebClient.xml
+++ b/xml/System.Net/WebClient.xml
@@ -58,54 +58,6 @@
 
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient> class provides common methods for sending data to or receiving data from any local, intranet, or Internet resource identified by a URI.
-
- The <xref:System.Net.WebClient> class uses the <xref:System.Net.WebRequest> class to provide access to resources. <xref:System.Net.WebClient> instances can access data with any <xref:System.Net.WebRequest> descendant registered with the <xref:System.Net.WebRequest.RegisterPrefix*?displayProperty=nameWithType> method.
-
-> [!NOTE]
-> By default, .NET Framework supports URIs that begin with `http:`, `https:`, `ftp:`, and `file:` scheme identifiers.
-
- The following table describes <xref:System.Net.WebClient> methods for uploading data to a resource.
-
-|Method|Description|
-|------------|-----------------|
-|<xref:System.Net.WebClient.OpenWrite*>|Retrieves a <xref:System.IO.Stream> used to send data to the resource.|
-|<xref:System.Net.WebClient.OpenWriteAsync*>|Retrieves a <xref:System.IO.Stream> used to send data to the resource, without blocking the calling thread.|
-|<xref:System.Net.WebClient.UploadData*>|Sends a byte array to the resource and returns a <xref:System.Byte> array containing any response.|
-|<xref:System.Net.WebClient.UploadDataAsync*>|Sends a <xref:System.Byte> array to the resource, without blocking the calling thread.|
-|<xref:System.Net.WebClient.UploadFile*>|Sends a local file to the resource and returns a <xref:System.Byte> array containing any response.|
-|<xref:System.Net.WebClient.UploadFileAsync*>|Sends a local file to the resource, without blocking the calling thread.|
-|<xref:System.Net.WebClient.UploadValues*>|Sends a <xref:System.Collections.Specialized.NameValueCollection> to the resource and returns a <xref:System.Byte> array containing any response.|
-|<xref:System.Net.WebClient.UploadValuesAsync*>|Sends a <xref:System.Collections.Specialized.NameValueCollection> to the resource and returns a <xref:System.Byte> array containing any response, without blocking the calling thread.|
-|<xref:System.Net.WebClient.UploadString*>|Sends a <xref:System.String> to the resource and returns a <xref:System.String> containing any response.|
-|<xref:System.Net.WebClient.UploadStringAsync*>|Sends a <xref:System.String> to the resource, without blocking the calling thread.|
-
- The following table describes <xref:System.Net.WebClient> methods for downloading data from a resource.
-
-|Method|Description|
-|------------|-----------------|
-|<xref:System.Net.WebClient.OpenRead*>|Returns the data from a resource as a <xref:System.IO.Stream>.|
-|<xref:System.Net.WebClient.OpenReadAsync*>|Returns the data from a resource, without blocking the calling thread.|
-|<xref:System.Net.WebClient.DownloadData*>|Downloads data from a resource and returns a <xref:System.Byte> array.|
-|<xref:System.Net.WebClient.DownloadDataAsync*>|Downloads data from a resource and returns a <xref:System.Byte> array, without blocking the calling thread.|
-|<xref:System.Net.WebClient.DownloadFile*>|Downloads data from a resource to a local file.|
-|<xref:System.Net.WebClient.DownloadFileAsync*>|Downloads data from a resource to a local file, without blocking the calling thread.|
-|<xref:System.Net.WebClient.DownloadString*>|Downloads a <xref:System.String> from a resource and returns a <xref:System.String>.|
-|<xref:System.Net.WebClient.DownloadStringAsync*>|Downloads a <xref:System.String> from a resource, without blocking the calling thread.|
-
- You can use the <xref:System.Net.WebClient.CancelAsync*> method to attempt to cancel asynchronous operations.
-
- A <xref:System.Net.WebClient> instance does not send optional HTTP headers by default. If your request requires an optional header, you must add the header to the <xref:System.Net.WebClient.Headers*> collection. For example, to retain queries in the response, you must add a user-agent header. Also, servers may return 500 (Internal Server Error) if the user agent header is missing.
-
- <xref:System.Net.HttpWebRequest.AllowAutoRedirect*> is set to `true` in <xref:System.Net.WebClient> instances.
-
-## Examples
- The following code example takes the URI of a resource, retrieves it, and displays the response.
-
- [!code-cpp[NCLWebClientUserAgent#1](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientUserAgent/CPP/useragent.cpp#1)]
- [!code-csharp[NCLWebClientUserAgent#1](~/snippets/csharp/System.Net/WebClient/Overview/useragent.cs#1)]
- [!code-vb[NCLWebClientUserAgent#1](~/snippets/visualbasic/System.Net/WebClient/Overview/useragent.vb#1)]
-
  ]]></format>
     </remarks>
     <block subset="none" type="overrides">
@@ -225,13 +177,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- When the <xref:System.Net.WebClient.AllowReadStreamBuffering> property is `true`, the data is buffered in memory so it is ready to be read by the app.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -334,24 +282,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.BaseAddress> property contains a base URI that is combined with a relative address. When you call a method that uploads or downloads data, the <xref:System.Net.WebClient> object combines this base URI with the relative address you specify in the method call. If you specify an absolute URI, <xref:System.Net.WebClient> does not use the <xref:System.Net.WebClient.BaseAddress> property value.
-
- To remove a previously set value, set this property to `null` or an empty string ("").
-
-
-
-## Examples
- The following code example downloads data from an Internet server and displays it on the console. It assumes that the server's address (such as http://www.contoso.com) is in `hostUri` and that the path to the resource (such as /default.htm) is in `uriSuffix`.
-
- [!code-cpp[WebClient_BaseAddress_ResponseHeaders#1](~/snippets/cpp/VS_Snippets_Remoting/WebClient_BaseAddress_ResponseHeaders/CPP/webclient_baseaddress_responseheaders.cpp#1)]
- [!code-csharp[WebClient_BaseAddress_ResponseHeaders#1](~/snippets/csharp/System.Net/WebClient/BaseAddress/webclient_baseaddress_responseheaders.cs#1)]
- [!code-vb[WebClient_BaseAddress_ResponseHeaders#1](~/snippets/visualbasic/System.Net/WebClient/BaseAddress/webclient_baseaddress_responseheaders.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentException">
           <see cref="P:System.Net.WebClient.BaseAddress" /> is set to an invalid URI. The inner exception may contain information that will help you locate the error.</exception>
@@ -450,15 +383,6 @@
 
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- If an operation is pending, this method calls <xref:System.Net.WebRequest.Abort*> on the underlying <xref:System.Net.WebRequest>.
-
- > [!NOTE]
- > Starting in .NET Core 2.0, <xref:System.Net.WebClient.CancelAsync*> doesn't cancel the request immediately if the response has started to fetch. For optimum cancellation behavior, use the <xref:System.Net.Http.HttpClient> class instead of <xref:System.Net.WebClient>.
-
- When you call <xref:System.Net.WebClient.CancelAsync*>, your application still receives the completion event associated with the operation. For example, when you call <xref:System.Net.WebClient.CancelAsync*> to cancel a <xref:System.Net.WebClient.DownloadStringAsync*> operation, if you have specified an event handler for the <xref:System.Net.WebClient.DownloadStringCompleted> event, your event handler receives notification that the operation has ended. To learn whether the operation completed successfully, check the <xref:System.ComponentModel.AsyncCompletedEventArgs.Cancelled> property on the base class of <xref:System.Net.DownloadDataCompletedEventArgs> in the event data object passed to the event handler.
-
- If no asynchronous operation is in progress, this method does nothing.
-
  ]]></format>
         </remarks>
       </Docs>
@@ -512,24 +436,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.Credentials> property contains the authentication credentials used to access a resource on a host. In most client-side scenarios, you should use the <xref:System.Net.CredentialCache.DefaultCredentials*>, which are the credentials of the currently logged on user. To do this, set the <xref:System.Net.WebClient.UseDefaultCredentials> property to `true` instead of setting this property.
-
- If the <xref:System.Net.WebClient> class is being used in a middle tier application, such as an ASP.NET application, the <xref:System.Net.CredentialCache.DefaultCredentials*> belong to the account running the ASP page (the server-side credentials). Typically, you would set this property to the credentials of the client on whose behalf the request is made.
-
- For security reasons, when automatically following redirects, store the credentials that you want to be included in the redirect in a <xref:System.Net.CredentialCache> and assign it to this property. This property will automatically be set to `null` upon redirection if it contains anything except a <xref:System.Net.CredentialCache>. Having this property value be automatically set to `null` under those conditions prevents credentials from being sent to any unintended destination.
-
-## Examples
- The following code example uses the user's system credentials to authenticate a request.
-
- [!code-cpp[WebClientAuthentication#1](~/snippets/cpp/VS_Snippets_Remoting/WebClientAuthentication/CPP/webclientauth.cpp#1)]
- [!code-csharp[WebClientAuthentication#1](~/snippets/csharp/System.Net/WebClient/Credentials/webclientauth.cs#1)]
- [!code-vb[WebClientAuthentication#1](~/snippets/visualbasic/System.Net/WebClient/Credentials/webclientauth.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <altmember cref="T:System.Net.NetworkCredential" />
         <altmember cref="T:System.Net.CredentialCache" />
@@ -592,27 +501,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.DownloadData*> method downloads the resource with the URI specified by the `address` parameter. This method blocks while downloading the resource. To download a resource and continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.DownloadDataAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example requests data from a server and displays the data returned. It assumes that `remoteUri` contains a valid URI for the requested data.
-
- [!code-cpp[WebClient_DownloadData#1](~/snippets/cpp/VS_Snippets_Remoting/WebClient_DownloadData/CPP/webclient_downloaddata.cpp#1)]
- [!code-csharp[WebClient_DownloadData#1](~/snippets/csharp/System.Net/WebClient/DownloadData/webclient_downloaddata.cs#1)]
- [!code-vb[WebClient_DownloadData#1](~/snippets/visualbasic/System.Net/WebClient/DownloadData/webclient_downloaddata.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -668,20 +559,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.DownloadData*> method downloads the resource with the URI specified by the `address` parameter. This method blocks while downloading the resource. To download a resource and continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.DownloadDataAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
       </Docs>
@@ -740,24 +620,7 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This method retrieves the specified resource using the default method for the protocol associated with the URI scheme specified in `address`. The data is downloaded asynchronously using thread resources that are automatically allocated from the thread pool.
-
- This method does not block the calling thread while downloading the resource. To download a resource and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.DownloadData*> methods. When the download completes, the <xref:System.Net.WebClient.DownloadDataCompleted> event is raised. Your application must handle this event to receive notification. The downloaded data is available in the <xref:System.Net.DownloadDataCompletedEventArgs.Result> property.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.DownloadData(System.Uri)>.
 
 ]]></format>
         </remarks>
@@ -823,24 +686,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This method retrieves the specified resource using the default method for the protocol associated with the URI scheme specified in `address`. The data is downloaded asynchronously using thread resources that are automatically allocated from the thread pool.
-
- This method does not block the calling thread while downloading the resource. To download a resource and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.DownloadData*> methods. When the download completes, the <xref:System.Net.WebClient.DownloadDataCompleted> event is raised. Your application must handle this event to receive notification. The downloaded data is available in the <xref:System.Net.DownloadDataCompletedEventArgs.Result> property.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -897,32 +745,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This event is raised each time an asynchronous data download operation completes. Asynchronous data downloads are started by calling the <xref:System.Net.WebClient.DownloadDataAsync*> methods.
-
- The <xref:System.Net.DownloadDataCompletedEventHandler> is the delegate for this event. The <xref:System.Net.DownloadDataCompletedEventArgs> class provides the event handler with event data.
-
- For more information about how to handle events, see [Handling and Raising Events](/dotnet/standard/events/).
-
-
-
-## Examples
- The following code example demonstrates setting an event handler for this event.
-
- [!code-cpp[NCLWebClientAsync#21](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#21)]
- [!code-csharp[NCLWebClientAsync#21](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#21)]
- [!code-vb[NCLWebClientAsync#21](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#21)]
-
- The following code example shows an implementation of a handler for this event.
-
- [!code-cpp[NCLWebClientAsync#22](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#22)]
- [!code-csharp[NCLWebClientAsync#22](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#22)]
- [!code-vb[NCLWebClientAsync#22](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#22)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -980,24 +805,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the data resource has been downloaded.
-
- This method retrieves the specified resource using the default method for the protocol associated with the URI scheme specified in the `address` parameter. The data is downloaded asynchronously using thread resources that are automatically allocated from the thread pool.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- The following code example requests data from a server and displays the data returned. It assumes that `remoteUri` contains a valid URI for the requested data.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -1051,22 +861,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the data resource has been downloaded.
-
- This method retrieves the specified resource using the default method for the protocol associated with the URI scheme specified in the `address` parameter. The data is downloaded asynchronously using thread resources that are automatically allocated from the thread pool.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -1133,29 +930,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.DownloadFile*> method downloads to a local file data from the URI specified by in the `address` parameter. This method blocks while downloading the resource. To download a resource and continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.DownloadFileAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- When using this method in a middle tier application, such as an ASP.NET page, you will receive an error if the account under which the application executes does not have permission to access the file.
-
-## Examples
- The following code example downloads a file from http://www.contoso.com to the local hard drive.
-
- [!code-cpp[WebClient_DownloadFile#1](~/snippets/cpp/VS_Snippets_Remoting/WebClient_DownloadFile/CPP/webclient_downloadfile.cpp#1)]
- [!code-csharp[WebClient_DownloadFile#1](~/snippets/csharp/System.Net/WebClient/DownloadFile/webclient_downloadfile.cs#1)]
- [!code-vb[WebClient_DownloadFile#1](~/snippets/visualbasic/System.Net/WebClient/DownloadFile/webclient_downloadfile.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -1218,22 +995,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.DownloadFile*> method downloads to a local file data from the URI specified by in the `address` parameter. This method blocks while downloading the resource. To download a resource and continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.DownloadFileAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- When using this method in a middle tier application, such as an ASP.NET page, you will receive an error if the account under which the application executes does not have permission to access the file.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -1312,26 +1076,7 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This method downloads the resource at the URI specified by in the `address` parameter. When the download completes successfully, the downloaded file is named `fileName` on the local computer. The file is downloaded asynchronously using thread resources that are automatically allocated from the thread pool. To receive notification when the file is available, add an event handler to the <xref:System.Net.WebClient.DownloadFileCompleted> event.
-
- This method does not block the calling thread while the resource is being downloaded. To block while waiting for the download to complete, use one of the <xref:System.Net.WebClient.DownloadFile*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not specify an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- When using this method in an ASP.NET page, you will receive an error if the account that the page executes under does not have permission to access the local file.
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.DownloadFile(System.Uri,System.String)>.
 
 ]]></format>
         </remarks>
@@ -1404,26 +1149,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This method downloads the resource at the URI specified by in the `address` parameter. When the download completes successfully, the downloaded file is named `fileName` on the local computer. The file is downloaded asynchronously using thread resources that are automatically allocated from the thread pool. To receive notification when the file is available, add an event handler to the <xref:System.Net.WebClient.DownloadFileCompleted> event.
-
- This method does not block the calling thread while the resource is being downloaded. To block while waiting for the download to complete, use one of the <xref:System.Net.WebClient.DownloadFile*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not specify an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- When using this method in an ASP.NET page, you will receive an error if the account that the page executes under does not have permission to access the local file.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -1485,24 +1213,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This event is raised each time an asynchronous file download operation completes. Asynchronous file downloads are started by calling the <xref:System.Net.WebClient.DownloadFileAsync*> methods.
-
- The <xref:System.ComponentModel.AsyncCompletedEventHandler> is the delegate for this event. The <xref:System.ComponentModel.AsyncCompletedEventArgs> class provides the event handler with event data.
-
- For more information about how to handle events, see [Handling and Raising Events](/dotnet/standard/events/).
-
-## Examples
- The following code example demonstrates setting an event handler for the `DownloadFileCompleted` event.
-
- [!code-cpp[NCLWebClientAsync#19](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#19)]
- [!code-csharp[NCLWebClientAsync#19](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#19)]
- [!code-vb[NCLWebClientAsync#19](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#19)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1562,26 +1275,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task> object will complete after the data resource has been downloaded.
-
- This method downloads the resource at the URI specified by in the `address` parameter. When the download completes successfully, the downloaded file is named `fileName` on the local computer. The file is downloaded asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not specify an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- When using this method in an ASP.NET page, you will receive an error if the account that the page executes under does not have permission to access the local file.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -1642,26 +1338,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task> object will complete after the data resource has been downloaded.
-
- This method downloads the resource at the URI specified by in the `address` parameter. When the download completes successfully, the downloaded file is named `fileName` on the local computer. The file is downloaded asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not specify an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- When using this method in an ASP.NET page, you will receive an error if the account that the page executes under does not have permission to access the local file.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -1723,45 +1402,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This event is raised each time an asynchronous download makes progress. This event is raised when downloads are started using any of the following methods.
-
-|Method|Description|
-|------------|-----------------|
-|<xref:System.Net.WebClient.DownloadDataAsync*>|Downloads data from a resource and returns a <xref:System.Byte> array, without blocking the calling thread.|
-|<xref:System.Net.WebClient.DownloadFileAsync*>|Downloads data from a resource to a local file, without blocking the calling thread.|
-|<xref:System.Net.WebClient.OpenReadAsync*>|Returns the data from a resource, without blocking the calling thread.|
-
- The <xref:System.Net.DownloadProgressChangedEventHandler> is the delegate for this event. The <xref:System.Net.DownloadProgressChangedEventArgs> class provides the event handler with event data.
-
- For more information about how to handle events, see [Handling and Raising Events](/dotnet/standard/events/).
-
-> [!NOTE]
-> A passive FTP file transfer will always show a progress percentage of zero, since the server did not send the file size. To show progress, you can change the FTP connection to active by overriding the <xref:System.Web.Services.Protocols.WebClientProtocol.GetWebRequest(System.Uri)> virtual method:
-
-```csharp
-internal class MyWebClient : WebClientProtocol
-{
-    protected override WebRequest GetWebRequest(Uri address)
-    {
-        FtpWebRequest req = (FtpWebRequest)base.GetWebRequest(address);
-        req.UsePassive = false;
-        return req;
-    }
-}
-```
-
-## Examples
- The following code example demonstrates setting an event handler for the `DownloadProgressChanged` event.
-
-[!code-cpp[DownloadProgressChanged](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#SnippetDownloadProgressChanged)]
-[!code-csharp[DownloadProgressChanged](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#SnippetDownloadProgressChanged)]
-[!code-vb[DownloadProgressChanged](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#SnippetDownloadProgressChanged)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1820,27 +1463,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This method retrieves the specified resource. After it downloads the resource, the method uses the encoding specified in the <xref:System.Net.WebClient.Encoding> property to convert the resource to a <xref:System.String>. This method blocks while downloading the resource. To download a resource and continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.DownloadStringAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example demonstrates calling this method.
-
- [!code-cpp[NCLWebClientAsync#25](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#25)]
- [!code-csharp[NCLWebClientAsync#25](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#25)]
- [!code-vb[NCLWebClientAsync#25](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#25)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -1896,20 +1521,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This method retrieves the specified resource. After it downloads the resource, the method uses the encoding specified in the <xref:System.Net.WebClient.Encoding> property to convert the resource to a <xref:System.String>. This method blocks while downloading the resource. To download a resource and continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.DownloadStringAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -1974,24 +1588,7 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- The resource is downloaded asynchronously using thread resources that are automatically allocated from the thread pool.
-
- After downloading the resource, this method uses the encoding specified in the <xref:System.Net.WebClient.Encoding> property to convert the resource to a <xref:System.String>. This method does not block the calling thread while downloading the resource. To download a resource and block while waiting for the server's response, use the <xref:System.Net.WebClient.DownloadString*> method. When the download completes, the <xref:System.Net.WebClient.DownloadStringCompleted> event is raised. Your application must handle this event to receive notification. The downloaded string is available in the <xref:System.Net.DownloadStringCompletedEventArgs.Result> property.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.DownloadString(System.Uri)>.
 
 ]]></format>
         </remarks>
@@ -2057,24 +1654,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The resource is downloaded asynchronously using thread resources that are automatically allocated from the thread pool.
-
- After downloading the resource, this method uses the encoding specified in the <xref:System.Net.WebClient.Encoding> property to convert the resource to a <xref:System.String>. This method does not block the calling thread while downloading the resource. To download a resource and block while waiting for the server's response, use the <xref:System.Net.WebClient.DownloadString*> method. When the download completes, the <xref:System.Net.WebClient.DownloadStringCompleted> event is raised. Your application must handle this event to receive notification. The downloaded string is available in the <xref:System.Net.DownloadStringCompletedEventArgs.Result> property.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -2131,32 +1713,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This event is raised each time an asynchronous operation to download a resource as a string completes. These operations are started by calling the <xref:System.Net.WebClient.DownloadStringAsync*> methods.
-
- The <xref:System.Net.DownloadStringCompletedEventHandler> is the delegate for this event. The <xref:System.Net.DownloadStringCompletedEventArgs> class provides the event handler with event data.
-
- For more information about how to handle events, see [Handling and Raising Events](/dotnet/standard/events/).
-
-
-
-## Examples
- The following code example demonstrates setting an event handler for this event.
-
- [!code-cpp[NCLWebClientAsync#28](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#28)]
- [!code-csharp[NCLWebClientAsync#28](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#28)]
- [!code-vb[NCLWebClientAsync#28](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#28)]
-
- The following code example shows an implementation of a handler for this event.
-
- [!code-cpp[NCLWebClientAsync#29](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#29)]
- [!code-csharp[NCLWebClientAsync#29](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#29)]
- [!code-vb[NCLWebClientAsync#29](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#29)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -2214,23 +1773,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the data resource has been downloaded.  The resource is downloaded asynchronously using thread resources that are automatically allocated from the thread pool.
-
- After downloading the resource, this method uses the encoding specified in the <xref:System.Net.WebClient.Encoding> property to convert the resource to a <xref:System.String>. This method does not block the calling thread while downloading the resource.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
- This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -2284,23 +1829,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the data resource has been downloaded. The resource is downloaded asynchronously using thread resources that are automatically allocated from the thread pool.
-
- After downloading the resource, this method uses the encoding specified in the <xref:System.Net.WebClient.Encoding> property to convert the resource to a <xref:System.String>. This method does not block the calling thread while downloading the resource.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
- This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -2351,24 +1882,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.UploadString*> and <xref:System.Net.WebClient.UploadStringAsync*> methods use this property to convert the specified string to a <xref:System.Byte> array before uploading the string. For additional information, see the <xref:System.Text.Encoding.GetBytes*> method.
-
- When a string is downloaded using the <xref:System.Net.WebClient.DownloadString*> or <xref:System.Net.WebClient.DownloadStringAsync*> methods, <xref:System.Net.WebClient> uses the <xref:System.Text.Encoding> returned by this to convert the downloaded <xref:System.Byte> array into a string. For additional information, see the <xref:System.Text.Encoding.GetString*> method.
-
-
-
-## Examples
- The following code example demonstrates setting the value of this property.
-
- [!code-cpp[NCLWebClientAsync#1](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#1)]
- [!code-csharp[NCLWebClientAsync#1](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#1)]
- [!code-vb[NCLWebClientAsync#1](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -2417,23 +1933,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This method copies the existing <xref:System.Net.WebClient.Headers*>, <xref:System.Net.WebClient.Credentials*>, and method to the newly created <xref:System.Net.WebRequest> object.
-
- This method can be called only by classes that inherit from <xref:System.Net.WebClient>. It is provided to give inheritors access to the underlying <xref:System.Net.WebRequest> object. Derived classes should call the base class implementation of <xref:System.Net.WebClient.GetWebRequest*> to ensure the method works as expected.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#1](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#1)]
- [!code-csharp[NCLCustomWebClient#1](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#1)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -2492,23 +1994,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The object returned by this method is obtained by calling the <xref:System.Net.WebRequest.GetResponse*> method on the specified <xref:System.Net.WebRequest> object.
-
- This method can be called only by classes that inherit from <xref:System.Net.WebClient>. It is provided to give inheritors access to the underlying <xref:System.Net.WebResponse> object.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#2](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#2)]
- [!code-csharp[NCLCustomWebClient#2](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#2)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -2559,23 +2047,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The object returned by this method is obtained by calling the <xref:System.Net.WebRequest.EndGetResponse*> method on the specified <xref:System.Net.WebRequest> object.
-
- This method can be called only by classes that inherit from <xref:System.Net.WebClient>. It is provided to give inheritors access to the underlying <xref:System.Net.WebResponse> object.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#3](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#3)]
- [!code-csharp[NCLCustomWebClient#3](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#3)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -2621,50 +2095,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.Headers> property contains a <xref:System.Net.WebHeaderCollection> instance containing protocol headers that the <xref:System.Net.WebClient> sends with the request.
-
- Some common headers are considered restricted and are protected by the system and cannot be set or changed in a <xref:System.Net.WebHeaderCollection> object. Any attempt to set one of these restricted headers in the <xref:System.Net.WebHeaderCollection> object associated with a <xref:System.Net.WebClient> object will throw an exception later when attempting to send the <xref:System.Net.WebClient> request.
-
- Restricted headers protected by the system include, but are not limited to the following:
-
-- Date
-
-- Host
-
- In addition, some other headers are also restricted when using a <xref:System.Net.WebClient> object. These restricted headers include, but are not limited to the following:
-
-- Accept
-
-- Connection
-
-- Content-Length
-
-- Expect (when the value is set to "100-continue"
-
-- If-Modified-Since
-
-- Range
-
-- Transfer-Encoding
-
- The <xref:System.Net.HttpWebRequest> class has properties for setting some of the above headers. If it is important for an application to set these headers, then the <xref:System.Net.HttpWebRequest> class should be used instead of the <xref:System.Net.WebRequest> class.
-
- You should not assume that the header values will remain unchanged, because Web servers and caches may change or add headers to a Web request.
-
-
-
-## Examples
- The following code example uses the <xref:System.Net.WebClient.Headers*> collection to set the HTTP `Content-Type` header to `application/x-www-form-urlencoded,` to notify the server that form data is attached to the post.
-
- [!code-cpp[WebClient_UpLoadData_Headers#2](~/snippets/cpp/VS_Snippets_Remoting/WebClient_UpLoadData_Headers/CPP/webclient_uploaddata_headers.cpp#2)]
- [!code-csharp[WebClient_UpLoadData_Headers#2](~/snippets/csharp/System.Net/WebClient/Headers/webclient_uploaddata_headers.cs#2)]
- [!code-vb[WebClient_UpLoadData_Headers#2](~/snippets/visualbasic/System.Net/WebClient/Headers/webclient_uploaddata_headers.vb#2)]
-
- ]]></format>
+]]></format>
         </remarks>
         <altmember cref="P:System.Net.WebRequest.Headers" />
         <altmember cref="P:System.Net.HttpWebRequest.Headers" />
@@ -2756,25 +2189,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Classes that inherit from this class can override this method to perform additional tasks when the <xref:System.Net.WebClient.DownloadDataCompleted> event occurs.
-
- Raising an event invokes the event handler through a delegate. For more information, see [Handling and Raising Events](/dotnet/standard/events/).
-
- The <xref:System.Net.WebClient.OnDownloadDataCompleted*> method also allows derived classes to handle the event without attaching a delegate. This is the preferred technique for handling the event in a derived class.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#4](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#4)]
- [!code-csharp[NCLCustomWebClient#4](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#4)]
-
- ]]></format>
+]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>When overriding <see cref="M:System.Net.WebClient.OnDownloadDataCompleted(System.Net.DownloadDataCompletedEventArgs)" /> in a derived class, be sure to call the base class' <see cref="M:System.Net.WebClient.OnDownloadDataCompleted(System.Net.DownloadDataCompletedEventArgs)" /> method so that registered delegates receive the event.</para>
@@ -2825,25 +2242,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Classes that inherit from this class can override this method to perform additional tasks when the <xref:System.Net.WebClient.DownloadFileCompleted> event occurs.
-
- Raising an event invokes the event handler through a delegate. For more information, see [Handling and Raising Events](/dotnet/standard/events/).
-
- The <xref:System.Net.WebClient.OnDownloadFileCompleted*> method also allows derived classes to handle the event without attaching a delegate. This is the preferred technique for handling the event in a derived class.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#5](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#5)]
- [!code-csharp[NCLCustomWebClient#5](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#5)]
-
- ]]></format>
+]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>When overriding <see cref="M:System.Net.WebClient.OnDownloadFileCompleted(System.ComponentModel.AsyncCompletedEventArgs)" /> in a derived class, be sure to call the base class' <see cref="M:System.Net.WebClient.OnDownloadFileCompleted(System.ComponentModel.AsyncCompletedEventArgs)" /> method so that registered delegates receive the event.</para>
@@ -2894,25 +2295,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Classes that inherit from this class can override this method to perform additional tasks when the <xref:System.Net.WebClient.DownloadProgressChanged> event occurs.
-
- Raising an event invokes the event handler through a delegate. For more information, see [Handling and Raising Events](/dotnet/standard/events/).
-
- The <xref:System.Net.WebClient.OnDownloadProgressChanged*> method also allows derived classes to handle the event without attaching a delegate. This is the preferred technique for handling the event in a derived class.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#12](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#12)]
- [!code-csharp[NCLCustomWebClient#12](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#12)]
-
- ]]></format>
+]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>When overriding <see cref="M:System.Net.WebClient.OnDownloadProgressChanged(System.Net.DownloadProgressChangedEventArgs)" /> in a derived class, be sure to call the base class' <see cref="M:System.Net.WebClient.OnDownloadProgressChanged(System.Net.DownloadProgressChangedEventArgs)" /> method so that registered delegates receive the event.</para>
@@ -2963,25 +2348,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Classes that inherit from this class can override this method to perform additional tasks when the <xref:System.Net.WebClient.DownloadStringCompleted> event occurs.
-
- Raising an event invokes the event handler through a delegate. For more information, see [Handling and Raising Events](/dotnet/standard/events/).
-
- The <xref:System.Net.WebClient.OnDownloadStringCompleted*> method also allows derived classes to handle the event without attaching a delegate. This is the preferred technique for handling the event in a derived class.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#6](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#6)]
- [!code-csharp[NCLCustomWebClient#6](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#6)]
-
- ]]></format>
+]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>When overriding <see cref="M:System.Net.WebClient.OnDownloadStringCompleted(System.Net.DownloadStringCompletedEventArgs)" /> in a derived class, be sure to call the base class' <see cref="M:System.Net.WebClient.OnDownloadStringCompleted(System.Net.DownloadStringCompletedEventArgs)" /> method so that registered delegates receive the event.</para>
@@ -3032,25 +2401,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Classes that inherit from this class can override this method to perform additional tasks when the <xref:System.Net.WebClient.OpenReadCompleted> event occurs.
-
- Raising an event invokes the event handler through a delegate. For more information, see [Handling and Raising Events](/dotnet/standard/events/).
-
- The <xref:System.Net.WebClient.OnOpenReadCompleted*> method also allows derived classes to handle the event without attaching a delegate. This is the preferred technique for handling the event in a derived class.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#7](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#7)]
- [!code-csharp[NCLCustomWebClient#7](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#7)]
-
- ]]></format>
+]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>When overriding <see cref="M:System.Net.WebClient.OnOpenReadCompleted(System.Net.OpenReadCompletedEventArgs)" /> in a derived class, be sure to call the base class' <see cref="M:System.Net.WebClient.OnOpenReadCompleted(System.Net.OpenReadCompletedEventArgs)" /> method so that registered delegates receive the event.</para>
@@ -3101,25 +2454,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Classes that inherit from this class can override this method to perform additional tasks when the <xref:System.Net.WebClient.OpenWriteCompleted> event occurs.
-
- Raising an event invokes the event handler through a delegate. For more information, see [Handling and Raising Events](/dotnet/standard/events/).
-
- The <xref:System.Net.WebClient.OnOpenWriteCompleted*> method also allows derived classes to handle the event without attaching a delegate. This is the preferred technique for handling the event in a derived class.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#8](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#8)]
- [!code-csharp[NCLCustomWebClient#8](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#8)]
-
- ]]></format>
+]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>When overriding <see cref="M:System.Net.WebClient.OnOpenWriteCompleted(System.Net.OpenWriteCompletedEventArgs)" /> in a derived class, be sure to call the base class' <see cref="M:System.Net.WebClient.OnOpenWriteCompleted(System.Net.OpenWriteCompletedEventArgs)" /> method so that registered delegates receive the event.</para>
@@ -3170,25 +2507,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Classes that inherit from this class can override this method to perform additional tasks when the <xref:System.Net.WebClient.UploadDataCompleted> event occurs.
-
- Raising an event invokes the event handler through a delegate. For more information, see [Handling and Raising Events](/dotnet/standard/events/).
-
- The <xref:System.Net.WebClient.OnUploadDataCompleted*> method also allows derived classes to handle the event without attaching a delegate. This is the preferred technique for handling the event in a derived class.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#9](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#9)]
- [!code-csharp[NCLCustomWebClient#9](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#9)]
-
- ]]></format>
+]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>When overriding <see cref="M:System.Net.WebClient.OnUploadDataCompleted(System.Net.UploadDataCompletedEventArgs)" /> in a derived class, be sure to call the base class' <see cref="M:System.Net.WebClient.OnUploadDataCompleted(System.Net.UploadDataCompletedEventArgs)" /> method so that registered delegates receive the event.</para>
@@ -3239,25 +2560,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Classes that inherit from this class can override this method to perform additional tasks when the <xref:System.Net.WebClient.UploadFileCompleted> event occurs.
-
- Raising an event invokes the event handler through a delegate. For more information, see [Handling and Raising Events](/dotnet/standard/events/).
-
- The <xref:System.Net.WebClient.OnUploadFileCompleted*> method also allows derived classes to handle the event without attaching a delegate. This is the preferred technique for handling the event in a derived class.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#10](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#10)]
- [!code-csharp[NCLCustomWebClient#10](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#10)]
-
- ]]></format>
+]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>When overriding <see cref="M:System.Net.WebClient.OnUploadFileCompleted(System.Net.UploadFileCompletedEventArgs)" /> in a derived class, be sure to call the base class' <see cref="M:System.Net.WebClient.OnUploadFileCompleted(System.Net.UploadFileCompletedEventArgs)" /> method so that registered delegates receive the event.</para>
@@ -3308,25 +2613,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Classes that inherit from this class can override this method to perform additional tasks when the <xref:System.Net.WebClient.UploadProgressChanged> event occurs.
-
- Raising an event invokes the event handler through a delegate. For more information, see [Handling and Raising Events](/dotnet/standard/events/).
-
- The <xref:System.Net.WebClient.OnUploadProgressChanged*> method also allows derived classes to handle the event without attaching a delegate. This is the preferred technique for handling the event in a derived class.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#13](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#13)]
- [!code-csharp[NCLCustomWebClient#13](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#13)]
-
- ]]></format>
+]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>When overriding <see cref="M:System.Net.WebClient.OnUploadProgressChanged(System.Net.UploadProgressChangedEventArgs)" /> in a derived class, be sure to call the base class' <see cref="M:System.Net.WebClient.OnUploadProgressChanged(System.Net.UploadProgressChangedEventArgs)" /> method so that registered delegates receive the event.</para>
@@ -3443,25 +2732,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Classes that inherit from this class can override this method to perform additional tasks when the <xref:System.Net.WebClient.UploadValuesCompleted> event occurs.
-
- Raising an event invokes the event handler through a delegate. For more information, see [Handling and Raising Events](/dotnet/standard/events/).
-
- The <xref:System.Net.WebClient.OnUploadValuesCompleted*> method also allows derived classes to handle the event without attaching a delegate. This is the preferred technique for handling the event in a derived class.
-
-
-
-## Examples
- The following code example shows an implementation of this method that can be customized by a class derived from <xref:System.Net.WebClient>.
-
- [!code-cpp[NCLCustomWebClient#14](~/snippets/cpp/VS_Snippets_Remoting/NCLCustomWebClient/CPP/mywebclient.cpp#14)]
- [!code-csharp[NCLCustomWebClient#14](~/snippets/csharp/System.Net/WebClient/GetWebRequest/mywebclient.cs#14)]
-
- ]]></format>
+]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>When overriding <see cref="M:System.Net.WebClient.OnUploadValuesCompleted(System.Net.UploadValuesCompletedEventArgs)" /> in a derived class, be sure to call the base class' <see cref="M:System.Net.WebClient.OnUploadValuesCompleted(System.Net.UploadValuesCompletedEventArgs)" /> method so that registered delegates receive the event.</para>
@@ -3575,30 +2848,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.OpenRead*> method creates a <xref:System.IO.Stream> instance used to read the contents of the resource specified by the `address` parameter. This method blocks while opening the stream. To continue executing while waiting for the stream, use one of the <xref:System.Net.WebClient.OpenReadAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not `null`, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> You must call <xref:System.IO.Stream.Close*?displayProperty=nameWithType> when finished with the <xref:System.IO.Stream> to avoid running out of system resources.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example opens the resource identified by `uriString` and displays the results on the system console. The <xref:System.IO.Stream> returned by <xref:System.Net.WebClient.OpenRead*> is closed when the data has been read.
-
- [!code-cpp[WebClient_OpenRead#1](~/snippets/cpp/VS_Snippets_Remoting/WebClient_OpenRead/CPP/webclient_openread.cpp#1)]
- [!code-csharp[WebClient_OpenRead#1](~/snippets/csharp/System.Net/WebClient/OpenRead/webclient_openread.cs#1)]
- [!code-vb[WebClient_OpenRead#1](~/snippets/visualbasic/System.Net/WebClient/OpenRead/webclient_openread.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" />, <paramref name="address" /> is invalid.
@@ -3653,23 +2905,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.OpenRead*> method creates a <xref:System.IO.Stream> instance used to read the contents of the resource specified by the `address` parameter. This method blocks while opening the stream. To continue executing while waiting for the stream, use one of the <xref:System.Net.WebClient.OpenReadAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not `null`, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> You must call <xref:System.IO.Stream.Close*?displayProperty=nameWithType> when finished with the <xref:System.IO.Stream> to avoid running out of system resources.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" />, <paramref name="address" /> is invalid.
@@ -3733,27 +2971,7 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This method retrieves a <xref:System.IO.Stream> instance used to access the resource specified by the `address` parameter. The stream is obtained using thread resources that are automatically allocated from the thread pool. To receive notification when the stream is available, add an event handler to the <xref:System.Net.WebClient.OpenReadCompleted> event.
-
-> [!NOTE]
-> You must call <xref:System.IO.Stream.Close*?displayProperty=nameWithType> when you are finished with the <xref:System.IO.Stream> to avoid running out of system resources.
-
- This method does not block the calling thread while the stream is opening. To block while waiting for the stream, use the <xref:System.Net.WebClient.OpenReadAsync*> method.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not specify an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested resource. If the <xref:System.Net.WebClient.QueryString> property is not `null`, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.OpenRead(System.Uri)>.
 
 ]]></format>
         </remarks>
@@ -3823,27 +3041,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This method retrieves a <xref:System.IO.Stream> instance used to access the resource specified by the `address` parameter. The stream is obtained using thread resources that are automatically allocated from the thread pool. To receive notification when the stream is available, add an event handler to the <xref:System.Net.WebClient.OpenReadCompleted> event.
-
-> [!NOTE]
-> You must call <xref:System.IO.Stream.Close*?displayProperty=nameWithType> when you are finished with the <xref:System.IO.Stream> to avoid running out of system resources.
-
- This method does not block the calling thread while the stream is opening. To block while waiting for the stream, use the <xref:System.Net.WebClient.OpenRead*> method.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not specify an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested resource. If the <xref:System.Net.WebClient.QueryString> property is not `null`, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and address is invalid.
@@ -3904,32 +3104,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This event is raised each time an asynchronous operation to open a stream containing a resource completes. These operations are started by calling the <xref:System.Net.WebClient.OpenReadAsync*> methods.
-
- The <xref:System.Net.OpenReadCompletedEventHandler> is the delegate for this event. The <xref:System.Net.OpenReadCompletedEventArgs> class provides the event handler with event data.
-
- For more information about how to handle events, see [Handling and Raising Events](/dotnet/standard/events/).
-
-
-
-## Examples
- The following code example demonstrates setting an event handler for this event.
-
- [!code-cpp[NCLWebClientAsync#30](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#30)]
- [!code-csharp[NCLWebClientAsync#30](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#30)]
- [!code-vb[NCLWebClientAsync#30](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#30)]
-
- The following code example shows an implementation of a handler for this event.
-
- [!code-cpp[NCLWebClientAsync#31](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#31)]
- [!code-csharp[NCLWebClientAsync#31](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#31)]
- [!code-vb[NCLWebClientAsync#31](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#31)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -3987,27 +3164,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the a readable stream to the data resource has been opened. This method does not block the calling thread while the stream is opening.
-
- This method retrieves a <xref:System.IO.Stream> instance used to access the resource specified by the `address` parameter. The stream is obtained using thread resources that are automatically allocated from the thread pool.
-
-> [!NOTE]
-> You must call <xref:System.IO.Stream.Close*?displayProperty=nameWithType> when you are finished with the <xref:System.IO.Stream> to avoid running out of system resources.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not specify an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested resource. If the <xref:System.Net.WebClient.QueryString> property is not `null`, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and address is invalid.
@@ -4066,27 +3225,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the a readable stream to the data resource has been opened. This method does not block the calling thread while the stream is opening.
-
- This method retrieves a <xref:System.IO.Stream> instance used to access the resource specified by the `address` parameter. The stream is obtained using thread resources that are automatically allocated from the thread pool.
-
-> [!NOTE]
-> You must call <xref:System.IO.Stream.Close*?displayProperty=nameWithType> when you are finished with the <xref:System.IO.Stream> to avoid running out of system resources.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not specify an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested resource. If the <xref:System.Net.WebClient.QueryString> property is not `null`, it is appended to `address`.
-
- This method uses the RETR command to download an FTP resource. For an HTTP resource, the GET method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and address is invalid.
@@ -4157,27 +3298,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.OpenWrite*> method returns a writable stream that is used to send data to a resource. This method blocks while opening the stream. To continue executing while waiting for the stream, use one of the <xref:System.Net.WebClient.OpenWriteAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example reads data from the command line and uses <xref:System.Net.WebClient.OpenWrite*> to obtain a stream for writing the data. The <xref:System.IO.Stream> returned by <xref:System.Net.WebClient.OpenWrite*> is closed after the data is sent.
-
- [!code-cpp[WebClient_OpenWrite2#1](~/snippets/cpp/VS_Snippets_Remoting/WebClient_OpenWrite2/CPP/webclient_openwrite2.cpp#1)]
- [!code-csharp[WebClient_OpenWrite2#1](~/snippets/csharp/System.Net/WebClient/OpenWrite/webclient_openwrite2.cs#1)]
- [!code-vb[WebClient_OpenWrite2#1](~/snippets/visualbasic/System.Net/WebClient/OpenWrite/webclient_openwrite2.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" />, and <paramref name="address" /> is invalid.
@@ -4232,20 +3355,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.OpenWrite*> method returns a writable stream that is used to send data to a resource. This method blocks while opening the stream. To continue executing while waiting for the stream, use one of the <xref:System.Net.WebClient.OpenWriteAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" />, and <paramref name="address" /> is invalid.
@@ -4311,27 +3423,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.OpenWrite*> method returns a writable stream that is used to send data to a resource. The underlying request is made with the method specified in the `method` parameter. The data is sent to the server when you close the stream. This method blocks while opening the stream. To continue executing while waiting for the stream, use one of the <xref:System.Net.WebClient.OpenWriteAsync*> methods.
-
- If the `method` parameter specifies a method that is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not specify an absolute address, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example reads data from the command line and uses <xref:System.Net.WebClient.OpenWrite*> to obtain a stream used to write the data. The <xref:System.IO.Stream> returned by <xref:System.Net.WebClient.OpenWrite*> must be closed to send the data.
-
- [!code-cpp[WebClient_OpenWrite#1](~/snippets/cpp/VS_Snippets_Remoting/WebClient_OpenWrite/CPP/webclient_openwrite.cpp#1)]
- [!code-csharp[WebClient_OpenWrite#1](~/snippets/csharp/System.Net/WebClient/OpenWrite/webclient_openwrite.cs#1)]
- [!code-vb[WebClient_OpenWrite#1](~/snippets/visualbasic/System.Net/WebClient/OpenWrite/webclient_openwrite.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" />, and <paramref name="address" /> is invalid.
@@ -4396,18 +3490,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.OpenWrite*> method returns a writable stream that is used to send data to a resource. This method blocks while opening the stream. To continue executing while waiting for the stream, use one of the <xref:System.Net.WebClient.OpenWriteAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" />, and <paramref name="address" /> is invalid.
@@ -4471,22 +3556,7 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This method retrieves a writable stream that is used to send data to a resource. The stream is retrieved using thread resources that are automatically allocated from the thread pool. To receive notification when the stream is available, add an event handler to the <xref:System.Net.WebClient.OpenWriteCompleted> event. When you close the stream, the thread blocks until the request is sent to `address` and a response is received.
-
- This method does not block the calling thread while the stream is being opened. To block while waiting for the stream, use one of the <xref:System.Net.WebClient.OpenWrite*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.OpenWrite(System.Uri)>.
 
 ]]></format>
         </remarks>
@@ -4547,20 +3617,7 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This method retrieves a writable stream that is used to send data to a resource. The stream is retrieved using thread resources that are automatically allocated from the thread pool. To receive notification when the stream is available, add an event handler to the <xref:System.Net.WebClient.OpenWriteCompleted> event. When you close the stream, the thread blocks until the request is sent to `address` and a response is received.
-
- This method does not block the calling thread while the stream is being opened. To block while waiting for the stream, use one of the <xref:System.Net.WebClient.OpenWrite*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.OpenWrite(System.Uri,System.String)>.
 
 ]]></format>
         </remarks>
@@ -4623,24 +3680,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This method retrieves a writable stream that is used to send data to a resource. The stream is retrieved asynchronously using thread resources that are automatically allocated from the thread pool. To receive notification when the stream is available, add an event handler to the <xref:System.Net.WebClient.OpenWriteCompleted> event. The contents of the stream are sent to the server when you close the stream.
-
- If the `method` parameter specifies a method that is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- This method does not block the calling thread while the stream is being opened. To block while waiting for the stream, use one of the <xref:System.Net.WebClient.OpenWrite*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -4697,32 +3739,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This event is raised each time an asynchronous operation to open a stream that is used to send data to a resource completes. These operations are started by calling the <xref:System.Net.WebClient.OpenWriteAsync*> methods.
-
- The <xref:System.Net.OpenWriteCompletedEventHandler> is the delegate for this event. The <xref:System.Net.OpenWriteCompletedEventArgs> class provides the event handler with event data.
-
- For more information about how to handle events, see [Handling and Raising Events](/dotnet/standard/events/).
-
-
-
-## Examples
- The following code example demonstrates setting an event handler for this event.
-
- [!code-cpp[NCLWebClientAsync#14](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#14)]
- [!code-csharp[NCLWebClientAsync#14](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#14)]
- [!code-vb[NCLWebClientAsync#14](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#14)]
-
- The following code example shows an implementation of a handler for this event.
-
- [!code-cpp[NCLWebClientAsync#15](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#15)]
- [!code-csharp[NCLWebClientAsync#15](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#15)]
- [!code-vb[NCLWebClientAsync#15](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#15)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -4780,26 +3799,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the a writable stream to the data resource has been opened. This method does not block the calling thread while the stream is opening.
-
- This method retrieves a <xref:System.IO.Stream> instance used to write data to the resource specified by the `address` parameter. The stream is obtained using thread resources that are automatically allocated from the thread pool.
-
-> [!NOTE]
-> You must call <xref:System.IO.Stream.Close*?displayProperty=nameWithType> when you are finished with the <xref:System.IO.Stream> to avoid running out of system resources.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
- This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -4854,26 +3856,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the a writable stream to the data resource has been opened. This method does not block the calling thread while the stream is opening.
-
- This method retrieves a <xref:System.IO.Stream> instance used to write data to the resource specified by the `address` parameter. The stream is obtained using thread resources that are automatically allocated from the thread pool.
-
-> [!NOTE]
-> You must call <xref:System.IO.Stream.Close*?displayProperty=nameWithType> when you are finished with the <xref:System.IO.Stream> to avoid running out of system resources.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
- This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -4937,28 +3922,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the a writable stream to the data resource has been opened. This method does not block the calling thread while the stream is opening.
-
- This method retrieves a <xref:System.IO.Stream> instance used to write data to the resource specified by the `address` parameter. The stream is obtained using thread resources that are automatically allocated from the thread pool.
-
-> [!NOTE]
-> You must call <xref:System.IO.Stream.Close*?displayProperty=nameWithType> when you are finished with the <xref:System.IO.Stream> to avoid running out of system resources.
-
- If the `method` parameter specifies a method that is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
- This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -5023,28 +3989,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the a writable stream to the data resource has been opened. This method does not block the calling thread while the stream is opening.
-
- This method retrieves a <xref:System.IO.Stream> instance used to write data to the resource specified by the `address` parameter. The stream is obtained using thread resources that are automatically allocated from the thread pool.
-
-> [!NOTE]
-> You must call <xref:System.IO.Stream.Close*?displayProperty=nameWithType> when you are finished with the <xref:System.IO.Stream> to avoid running out of system resources.
-
- If the `method` parameter specifies a method that is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
- This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -5103,15 +4050,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.Proxy> property identifies the <xref:System.Net.IWebProxy> instance that communicates with remote servers on behalf of this <xref:System.Net.WebClient> object. The proxy is set by the system using configuration files and the Local Area Network settings. To specify that no proxy should be used, set the <xref:System.Net.WebClient.Proxy> property to `null`.
-
- For information on automatic proxy detection, see [Automatic Proxy Detection](/dotnet/framework/network-programming/automatic-proxy-detection).
-
- ]]></format>
+]]></format>
         </remarks>
         <altmember cref="T:System.Net.WebRequest" />
         <altmember cref="T:System.Net.WebResponse" />
@@ -5165,22 +4106,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.QueryString> property contains a <xref:System.Collections.Specialized.NameValueCollection> instance containing name/value pairs that are appended to the URI as a query string. The contents of the <xref:System.Net.WebClient.QueryString> property are preceded by a question mark (?), and name/value pairs are separated from one another by an ampersand (&).
-
-
-
-## Examples
- The following code example takes user input from the command line and builds a <xref:System.Collections.Specialized.NameValueCollection> that is assigned to the <xref:System.Net.WebClient.QueryString> property. It then downloads the response from the server to a local file.
-
- [!code-cpp[WebClient_QueryString#1](~/snippets/cpp/VS_Snippets_Remoting/WebClient_QueryString/CPP/webclient_querystring.cpp#1)]
- [!code-csharp[WebClient_QueryString#1](~/snippets/csharp/System.Net/WebClient/QueryString/webclient_querystring.cs#1)]
- [!code-vb[WebClient_QueryString#1](~/snippets/visualbasic/System.Net/WebClient/QueryString/webclient_querystring.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -5233,22 +4161,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.ResponseHeaders> property contains a <xref:System.Net.WebHeaderCollection> instance containing header information the <xref:System.Net.WebClient> receives with the response.
-
-
-
-## Examples
- The following code example downloads and displays the <xref:System.Net.WebClient.ResponseHeaders*> returned by a server.
-
- [!code-cpp[WebClient_BaseAddress_ResponseHeaders#2](~/snippets/cpp/VS_Snippets_Remoting/WebClient_BaseAddress_ResponseHeaders/CPP/webclient_baseaddress_responseheaders.cpp#2)]
- [!code-csharp[WebClient_BaseAddress_ResponseHeaders#2](~/snippets/csharp/System.Net/WebClient/BaseAddress/webclient_baseaddress_responseheaders.cs#2)]
- [!code-vb[WebClient_BaseAddress_ResponseHeaders#2](~/snippets/visualbasic/System.Net/WebClient/BaseAddress/webclient_baseaddress_responseheaders.vb#2)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -5310,29 +4225,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.UploadData*> method sends a data buffer to a resource.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used. If the underlying request is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- The <xref:System.Net.WebClient.UploadData*> method sends the content of `data` to the server without encoding it. This method blocks while uploading the data. To continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadDataAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example converts a string entered from the console to a <xref:System.Byte> array and posts the array to the specified server using <xref:System.Net.WebClient.UploadData*>. Any response from the server is displayed to the console.
-
- [!code-cpp[WebClient_UpLoadData2#1](~/snippets/cpp/VS_Snippets_Remoting/WebClient_UpLoadData2/CPP/webclient_uploaddata2.cpp#1)]
- [!code-csharp[WebClient_UpLoadData2#1](~/snippets/csharp/System.Net/WebClient/UploadData/webclient_uploaddata2.cs#1)]
- [!code-vb[WebClient_UpLoadData2#1](~/snippets/visualbasic/System.Net/WebClient/UploadData/webclient_uploaddata2.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" />, and <paramref name="address" /> is invalid.
@@ -5397,22 +4292,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.UploadData*> method sends a data buffer to a resource.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used. If the underlying request is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- The <xref:System.Net.WebClient.UploadData*> method sends the content of `data` to the server without encoding it. This method blocks while uploading the data. To continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadDataAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" />, and <paramref name="address" /> is invalid.
@@ -5488,29 +4370,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.UploadData*> method sends a data buffer to a resource using the HTTP method specified in the `method` parameter, and returns any response from the server. This method blocks while uploading the data. To continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadDataAsync*> methods.
-
- The <xref:System.Net.WebClient.UploadData*> method sends the content of `data` to the server without encoding it.
-
- If the `method` parameter specifies a verb that is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example converts a string entered from the console into a byte array and posts the array to the specified server using <xref:System.Net.WebClient.UploadData*>. Any response from the server is displayed to the console.
-
- [!code-cpp[WebClient_UpLoadData_Headers#2](~/snippets/cpp/VS_Snippets_Remoting/WebClient_UpLoadData_Headers/CPP/webclient_uploaddata_headers.cpp#2)]
- [!code-csharp[WebClient_UpLoadData_Headers#2](~/snippets/csharp/System.Net/WebClient/Headers/webclient_uploaddata_headers.cs#2)]
- [!code-vb[WebClient_UpLoadData_Headers#2](~/snippets/visualbasic/System.Net/WebClient/Headers/webclient_uploaddata_headers.vb#2)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" />, and <paramref name="address" /> is invalid.
@@ -5585,22 +4447,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.UploadData*> method sends a data buffer to a resource using the HTTP method specified in the `method` parameter, and returns any response from the server. This method blocks while uploading the data. To continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadDataAsync*> methods.
-
- The <xref:System.Net.WebClient.UploadData*> method sends the content of `data` to the server without encoding it.
-
- If the `method` parameter specifies a verb that is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" />, and <paramref name="address" /> is invalid.
@@ -5674,24 +4523,7 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This method sends a data buffer to a resource. The data buffer is sent asynchronously using thread resources that are automatically allocated from the thread pool. The data is not encoded. To receive notification when the data upload completes, add an event handler to the <xref:System.Net.WebClient.UploadDataCompleted> event.
-
- This method does not block the calling thread while the data is being sent. To send data and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadData*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.UploadData(System.Uri,System.Byte[])>.
 
 ]]></format>
         </remarks>
@@ -5763,22 +4595,7 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This method sends a data buffer to a resource. The data buffer is sent asynchronously using thread resources that are automatically allocated from the thread pool. The data is not encoded. To receive notification when the data upload completes, add an event handler to the <xref:System.Net.WebClient.UploadDataCompleted> event.
-
- This method does not block the calling thread while the data is being sent. To send data and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadData*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.UploadData(System.Uri,System.String,System.Byte[])>.
 
 ]]></format>
         </remarks>
@@ -5859,22 +4676,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This method sends a data buffer to a resource. The data buffer is sent asynchronously using thread resources that are automatically allocated from the thread pool. The data is not encoded. To receive notification when the data upload completes, add an event handler to the <xref:System.Net.WebClient.UploadDataCompleted> event.
-
- This method does not block the calling thread while the data is being sent. To send data and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadData*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -5935,32 +4739,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This event is raised each time an asynchronous data upload operation completes. Asynchronous data uploads are started by calling the <xref:System.Net.WebClient.UploadDataAsync*> methods.
-
- The <xref:System.Net.UploadDataCompletedEventHandler> is the delegate for this event. The <xref:System.Net.UploadDataCompletedEventArgs> class provides the event handler with event data.
-
- For more information about how to handle events, see [Handling and Raising Events](/dotnet/standard/events/).
-
-
-
-## Examples
- The following code example demonstrates setting an event handler for this event.
-
- [!code-cpp[NCLWebClientAsync#36](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#36)]
- [!code-csharp[NCLWebClientAsync#36](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#36)]
- [!code-vb[NCLWebClientAsync#36](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#36)]
-
- The following code example shows an implementation of a handler for this event.
-
- [!code-cpp[NCLWebClientAsync#37](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#37)]
- [!code-csharp[NCLWebClientAsync#37](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#37)]
- [!code-vb[NCLWebClientAsync#37](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#37)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -6020,24 +4801,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the a data buffer has been uploaded to the resource.
-
- This method sends a data buffer to a resource. The data buffer is sent asynchronously using thread resources that are automatically allocated from the thread pool. The data is not encoded.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -6097,24 +4863,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the a data buffer has been uploaded to the resource.
-
- This method sends a data buffer to a resource. The data buffer is sent asynchronously using thread resources that are automatically allocated from the thread pool. The data is not encoded.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -6184,22 +4935,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the a data buffer has been uploaded to the resource.
-
- This method sends a data buffer to a resource. The data buffer is sent asynchronously using thread resources that are automatically allocated from the thread pool. The data is not encoded.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -6269,22 +5007,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the a data buffer has been uploaded to the resource.
-
- This method sends a data buffer to a resource. The data buffer is sent asynchronously using thread resources that are automatically allocated from the thread pool. The data is not encoded.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.WebException">The URI formed by combining <see cref="P:System.Net.WebClient.BaseAddress" /> and <paramref name="address" /> is invalid.
@@ -6356,34 +5081,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.UploadFile*> method sends a local file to a resource. This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
- This method blocks while uploading the file. To continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadFileAsync*> methods.
-
- The `POST` method is defined by HTTP. If the underlying request does not use HTTP and `POST` is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example uploads the specified file to the specified URI using <xref:System.Net.WebClient.UploadFile*>. Any response returned by the server is displayed on the console.
-
- [!code-cpp[WebClient_UpLoadFile#1](~/snippets/cpp/VS_Snippets_Remoting/WebClient_UpLoadFile/CPP/webclient_uploadfile.cpp#1)]
- [!code-csharp[WebClient_UpLoadFile#1](~/snippets/csharp/System.Net/WebClient/UploadFile/webclient_uploadfile.cs#1)]
- [!code-vb[WebClient_UpLoadFile#1](~/snippets/visualbasic/System.Net/WebClient/UploadFile/webclient_uploadfile.vb#1)]
-
- The following code example shows an ASP.NET page that can accept posted files and is suitable for use with the <xref:System.Net.WebClient.UploadFile*> method. The page must reside on a Web server. Its address provides the value for the `address` parameter of the <xref:System.Net.WebClient.UploadFile*> method.
-
- [!code-aspx-csharp[NCLWebClientAsp#1](~/snippets/csharp/System.Net/WebClient/UploadFile/fileuploadercs.aspx#1)]
- [!code-aspx-vb[NCLWebClientAsp#1](~/snippets/visualbasic/VS_Snippets_Remoting/NCLWebClientAsp/VB/fileuploadervb.aspx#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -6456,22 +5156,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.UploadFile*> method sends a local file to a resource. This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
- This method blocks while uploading the file. To continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadFileAsync*> methods.
-
- The `POST` method is defined by HTTP. If the underlying request does not use HTTP and `POST` is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -6555,32 +5242,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- When address specifies an HTTP resource, the <xref:System.Net.WebClient.UploadFile*> method sends a local file to a resource using the HTTP method specified in the `method` parameter and returns any response from the server. This method blocks while uploading the file. To continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadFileAsync*> methods.
-
- If the `method` parameter specifies a verb that is not understood by the server or the `address` resource, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example uploads the specified file to the specified URI using <xref:System.Net.WebClient.UploadFile*>. Any response returned by the server is displayed on the console.
-
- [!code-cpp[WebClient_UpLoadFile2#1](~/snippets/cpp/VS_Snippets_Remoting/WebClient_UpLoadFile2/CPP/webclient_uploadfile2.cpp#1)]
- [!code-csharp[WebClient_UpLoadFile2#1](~/snippets/csharp/System.Net/WebClient/UploadFile/webclient_uploadfile2.cs#1)]
- [!code-vb[WebClient_UpLoadFile2#1](~/snippets/visualbasic/System.Net/WebClient/UploadFile/webclient_uploadfile2.vb#1)]
-
- The following code example shows an ASP.NET page that can accept posted files and is suitable for use with the <xref:System.Net.WebClient.UploadFile*> method. The page must reside on a Web server. Its address provides the value for the `address` parameter of the <xref:System.Net.WebClient.UploadFile*> method.
-
- [!code-aspx-csharp[NCLWebClientAsp#1](~/snippets/csharp/System.Net/WebClient/UploadFile/fileuploadercs.aspx#1)]
- [!code-aspx-vb[NCLWebClientAsp#1](~/snippets/visualbasic/VS_Snippets_Remoting/NCLWebClientAsp/VB/fileuploadervb.aspx#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -6663,20 +5327,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- When address specifies an HTTP resource, the <xref:System.Net.WebClient.UploadFile*> method sends a local file to a resource using the HTTP method specified in the `method` parameter and returns any response from the server. This method blocks while uploading the file. To continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadFileAsync*> methods.
-
- If the `method` parameter specifies a verb that is not understood by the server or the `address` resource, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -6758,24 +5411,7 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- The file is sent asynchronously using thread resources that are automatically allocated from the thread pool. To receive notification when the file upload completes, add an event handler to the <xref:System.Net.WebClient.UploadFileCompleted> event.
-
- This method does not block the calling thread while the file is being sent. To send a file and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadFile*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.UploadFile(System.Uri,System.String)>.
 
 ]]></format>
         </remarks>
@@ -6859,24 +5495,7 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- The file is sent asynchronously using thread resources that are automatically allocated from the thread pool. To receive notification when the file upload completes, add an event handler to the <xref:System.Net.WebClient.UploadFileCompleted> event.
-
- This method does not block the calling thread while the file is being sent. To send a file and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadFile*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.UploadFile(System.Uri,System.String,System.String)>.
 
 ]]></format>
         </remarks>
@@ -6969,24 +5588,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The file is sent asynchronously using thread resources that are automatically allocated from the thread pool. To receive notification when the file upload completes, add an event handler to the <xref:System.Net.WebClient.UploadFileCompleted> event.
-
- This method does not block the calling thread while the file is being sent. To send a file and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadFile*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -7059,32 +5663,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This event is raised each time an asynchronous file upload operation completes. Asynchronous file uploads are started by calling the <xref:System.Net.WebClient.UploadFileAsync*> methods.
-
- The <xref:System.Net.UploadFileCompletedEventHandler> is the delegate for this event. The <xref:System.Net.UploadFileCompletedEventArgs> class provides the event handler with event data.
-
- For more information about how to handle events, see [Handling and Raising Events](/dotnet/standard/events/).
-
-
-
-## Examples
- The following code example demonstrates setting an event handler for this event.
-
- [!code-cpp[NCLWebClientAsync#4](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#4)]
- [!code-csharp[NCLWebClientAsync#4](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#4)]
- [!code-vb[NCLWebClientAsync#4](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#4)]
-
- The following code example shows an implementation of a handler for this event.
-
- [!code-cpp[NCLWebClientAsync#5](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#5)]
- [!code-csharp[NCLWebClientAsync#5](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#5)]
- [!code-vb[NCLWebClientAsync#5](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#5)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -7144,22 +5725,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the file has been uploaded to the resource. The file is sent asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -7231,22 +5799,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the file has been uploaded to the resource. The file is sent asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -7328,22 +5883,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the file has been uploaded to the resource. The file is sent asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- BY default, this method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -7425,22 +5967,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the file has been uploaded to the resource. The file is sent asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- BY default, this method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -7513,38 +6042,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This event is raised each time an asynchronous upload makes progress. This event is raised when uploads are started using any of the following methods.
-
-|Method|Description|
-|------------|-----------------|
-|<xref:System.Net.WebClient.UploadDataAsync*>|Sends a <xref:System.Byte> array to the resource, without blocking the calling thread.|
-|<xref:System.Net.WebClient.UploadFileAsync*>|Sends a local file to the resource, without blocking the calling thread.|
-|<xref:System.Net.WebClient.UploadValuesAsync*>|Sends a <xref:System.Collections.Specialized.NameValueCollection> to the resource and returns a <xref:System.Byte> array containing any response, without blocking the calling thread.|
-
- The <xref:System.Net.UploadProgressChangedEventHandler> is the delegate for this event. The <xref:System.Net.UploadProgressChangedEventArgs> class provides the event handler with event data.
-
- For more information about how to handle events, see [Handling and Raising Events](/dotnet/standard/events/).
-
-
-
-## Examples
- The following code example demonstrates setting an event handler for this event.
-
- [!code-cpp[NCLWebClientAsync#4](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#4)]
- [!code-csharp[NCLWebClientAsync#4](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#4)]
- [!code-vb[NCLWebClientAsync#4](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#4)]
-
- The following code example shows an implementation of a handler for this event.
-
- [!code-cpp[NCLWebClientAsync#42](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#42)]
- [!code-csharp[NCLWebClientAsync#42](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#42)]
- [!code-vb[NCLWebClientAsync#42](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#42)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -7605,27 +6105,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Before uploading the string, this method converts it to a <xref:System.Byte> array using the encoding specified in the <xref:System.Net.WebClient.Encoding> property. This method blocks while the string is transmitted. To send a string and continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadStringAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example demonstrates calling this method.
-
- [!code-cpp[NCLWebClientAsync#1](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#1)]
- [!code-csharp[NCLWebClientAsync#1](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#1)]
- [!code-vb[NCLWebClientAsync#1](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -7686,20 +6168,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Before uploading the string, this method converts it to a <xref:System.Byte> array using the encoding specified in the <xref:System.Net.WebClient.Encoding> property. This method blocks while the string is transmitted. To send a string and continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadStringAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string (""), and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -7770,25 +6241,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Before uploading the string, this method converts it to a <xref:System.Byte> array using the encoding specified in the <xref:System.Net.WebClient.Encoding> property. This method blocks while the string is transmitted. To send a string and continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadStringAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example demonstrates calling this method.
-
- [!code-cpp[NCLWebClientAsync#2](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#2)]
- [!code-csharp[NCLWebClientAsync#2](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#2)]
- [!code-vb[NCLWebClientAsync#2](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#2)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -7863,18 +6318,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Before uploading the string, this method converts it to a <xref:System.Byte> array using the encoding specified in the <xref:System.Net.WebClient.Encoding> property. This method blocks while the string is transmitted. To send a string and continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadStringAsync*> methods.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -7948,24 +6394,7 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This method sends a string to a resource. The string is sent asynchronously using thread resources that are automatically allocated from the thread pool. Before uploading the string, this method converts it to a <xref:System.Byte> array using the encoding specified in the <xref:System.Net.WebClient.Encoding> property. To receive notification when the string upload completes, you can add an event handler to the <xref:System.Net.WebClient.UploadStringCompleted> event.
-
- This method does not block the calling thread while the string is being sent. To send a string and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadString*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.UploadString(System.Uri,System.String)>.
 
 ]]></format>
         </remarks>
@@ -8037,22 +6466,7 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This method sends a string to a resource. The string is sent asynchronously using thread resources that are automatically allocated from the thread pool. Before uploading the string, this method converts it to a <xref:System.Byte> array using the encoding specified in the <xref:System.Net.WebClient.Encoding> property. To receive notification when the string upload completes, you can add an event handler to the <xref:System.Net.WebClient.UploadStringCompleted> event.
-
- This method does not block the calling thread while the string is being sent. To send a string and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadString*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.UploadString(System.Uri,System.String,System.String)>.
 
 ]]></format>
         </remarks>
@@ -8137,22 +6551,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This method sends a string to a resource. The string is sent asynchronously using thread resources that are automatically allocated from the thread pool. Before uploading the string, this method converts it to a <xref:System.Byte> array using the encoding specified in the <xref:System.Net.WebClient.Encoding> property. To receive notification when the string upload completes, you can add an event handler to the <xref:System.Net.WebClient.UploadStringCompleted> event.
-
- This method does not block the calling thread while the string is being sent. To send a string and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadString*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -8217,32 +6618,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This event is raised each time an asynchronous string upload operation completes. Asynchronous string uploads are started by calling the <xref:System.Net.WebClient.UploadStringAsync*> methods.
-
- The <xref:System.Net.UploadStringCompletedEventHandler> is the delegate for this event. The <xref:System.Net.UploadStringCompletedEventArgs> class provides the event handler with event data.
-
- For more information about how to handle events, see [Handling and Raising Events](/dotnet/standard/events/).
-
-
-
-## Examples
- The following code example demonstrates setting an event handler for this event.
-
- [!code-cpp[NCLWebClientAsync#38](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#38)]
- [!code-csharp[NCLWebClientAsync#38](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#38)]
- [!code-vb[NCLWebClientAsync#38](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#38)]
-
- The following code example shows an implementation of a handler for this event.
-
- [!code-cpp[NCLWebClientAsync#39](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#39)]
- [!code-csharp[NCLWebClientAsync#39](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#39)]
- [!code-vb[NCLWebClientAsync#39](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#39)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -8302,22 +6680,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the string has been uploaded to the resource. The string is sent asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- Before uploading the string, this method converts it to a <xref:System.Byte> array using the encoding specified in the <xref:System.Net.WebClient.Encoding> property. This method blocks while the string is transmitted.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -8377,22 +6742,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the string has been uploaded to the resource. The string is sent asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- Before uploading the string, this method converts it to a <xref:System.Byte> array using the encoding specified in the <xref:System.Net.WebClient.Encoding> property. This method blocks while the string is transmitted.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -8462,22 +6814,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the string has been uploaded to the resource. The string is sent asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- Before uploading the string, this method converts it to a <xref:System.Byte> array using the encoding specified in the <xref:System.Net.WebClient.Encoding> property. This method blocks while the string is transmitted.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -8551,22 +6890,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the string has been uploaded to the resource. The string is sent asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- Before uploading the string, this method converts it to a <xref:System.Byte> array using the encoding specified in the <xref:System.Net.WebClient.Encoding> property. This method blocks while the string is transmitted.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -8642,31 +6968,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.UploadValues*> method sends a <xref:System.Collections.Specialized.NameValueCollection> to a server. This method blocks while uploading the data. To continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadValuesAsync*> methods.
-
- If the underlying request is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the Content-type header is `null`, the <xref:System.Net.WebClient.UploadValues*> method sets it to "application/x-www-form-urlencoded".
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example gathers information from the user (name, age, and address) and posts the values to the server using <xref:System.Net.WebClient.UploadValues*>. Any response from the server is displayed on the console.
-
- [!code-cpp[WebClient_UploadValues#1](~/snippets/cpp/VS_Snippets_Remoting/WebClient_UploadValues/CPP/webclient_uploadvalues.cpp#1)]
- [!code-csharp[WebClient_UploadValues#1](~/snippets/csharp/System.Net/WebClient/UploadValues/webclient_uploadvalues.cs#1)]
- [!code-vb[WebClient_UploadValues#1](~/snippets/visualbasic/System.Net/WebClient/UploadValues/webclient_uploadvalues.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -8739,24 +7043,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.UploadValues*> method sends a <xref:System.Collections.Specialized.NameValueCollection> to a server. This method blocks while uploading the data. To continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadValuesAsync*> methods.
-
- If the underlying request is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the Content-type header is `null`, the <xref:System.Net.WebClient.UploadValues*> method sets it to "application/x-www-form-urlencoded".
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -8840,29 +7129,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.UploadValues*> method sends a <xref:System.Collections.Specialized.NameValueCollection> to a resource using the method specified in the `method` parameter and returns any response from the server. This method blocks while uploading the data. To continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadValuesAsync*> methods.
-
- If the `Content-type` header is `null`, the <xref:System.Net.WebClient.UploadValues*> method sets it to `application/x-www-form-urlencoded`.
-
- If the `method` parameter specifies a verb that is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-## Examples
- The following code example gathers information from the user (name, age, and address) and posts the values to the server using <xref:System.Net.WebClient.UploadValues*>. Any response from the server is displayed on the console.
-
- [!code-cpp[WebClient_UploadValues2#1](~/snippets/cpp/VS_Snippets_Remoting/WebClient_UploadValues2/CPP/webclient_uploadvalues2.cpp#1)]
- [!code-csharp[WebClient_UploadValues2#1](~/snippets/csharp/System.Net/WebClient/UploadValues/webclient_uploadvalues2.cs#1)]
- [!code-vb[WebClient_UploadValues2#1](~/snippets/visualbasic/System.Net/WebClient/UploadValues/webclient_uploadvalues2.vb#1)]
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -8945,22 +7214,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebClient.UploadValues*> method sends a <xref:System.Collections.Specialized.NameValueCollection> to a resource using the method specified in the `method` parameter and returns any response from the server. This method blocks while uploading the data. To continue executing while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadValuesAsync*> methods.
-
- If the `Content-type` header is `null`, the <xref:System.Net.WebClient.UploadValues*> method sets it to `application/x-www-form-urlencoded`.
-
- If the `method` parameter specifies a verb that is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -9042,24 +7298,7 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This method sends a string to a resource. The string is sent asynchronously using thread resources that are automatically allocated from the thread pool. Before uploading the string, this method converts it to a <xref:System.Byte> array using the encoding specified in the <xref:System.Net.WebClient.Encoding> property. To receive notification when the string upload completes, you can add an event handler to the <xref:System.Net.WebClient.UploadStringCompleted> event.
-
- This method does not block the calling thread while the string is being sent. To send a string and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadString*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.UploadValues(System.Uri,System.Collections.Specialized.NameValueCollection)>.
 
 ]]></format>
         </remarks>
@@ -9131,26 +7370,7 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This method sends the data contained in a <xref:System.Collections.Specialized.NameValueCollection> to the `address` resource. Use this method to send form data to a URI for processing. The data is sent using the form-urlencoded media type; the Content-Type header value must be set to "application/x-www-form-urlencoded". The header is set correctly by default. The <xref:System.Net.WebClient.UploadValuesAsync*> methods throw a <xref:System.Net.WebException> if you call this method with a different Content-Type header value set in the <xref:System.Net.WebClient.Headers*> collection.
-
- If the `method` method is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- The <xref:System.Collections.Specialized.NameValueCollection> is sent asynchronously using thread resources that are automatically allocated from the thread pool. To receive notification when the upload operation completes, add an event handler to the <xref:System.Net.WebClient.UploadValuesCompleted> event.
-
- This method does not block the calling thread while the string is being sent. To send a string and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadValues*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not empty, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebClient.UploadValues(System.Uri,System.String,System.Collections.Specialized.NameValueCollection)>.
 
 ]]></format>
         </remarks>
@@ -9235,26 +7455,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This method sends the data contained in a <xref:System.Collections.Specialized.NameValueCollection> to the `address` resource. Use this method to send form data to a URI for processing. The data is sent using the form-urlencoded media type; the Content-Type header value must be set to "application/x-www-form-urlencoded". The header is set correctly by default. The <xref:System.Net.WebClient.UploadValuesAsync*> methods throw a <xref:System.Net.WebException> if you call this method with a different Content-Type header value set in the <xref:System.Net.WebClient.Headers*> collection.
-
- If the `method` method is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- The <xref:System.Collections.Specialized.NameValueCollection> is sent asynchronously using thread resources that are automatically allocated from the thread pool. To receive notification when the upload operation completes, add an event handler to the <xref:System.Net.WebClient.UploadValuesCompleted> event.
-
- This method does not block the calling thread while the string is being sent. To send a string and block while waiting for the server's response, use one of the <xref:System.Net.WebClient.UploadValues*> methods.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not empty, it is appended to `address`.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -9319,17 +7522,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This event is raised each time an asynchronous upload of a <xref:System.Collections.Specialized.NameValueCollection> object's data completes. These uploads are started by calling the <xref:System.Net.WebClient.UploadValuesAsync*> methods.
-
- The <xref:System.Net.UploadValuesCompletedEventHandler> is the delegate for this event. The <xref:System.Net.UploadValuesCompletedEventArgs> class provides the event handler with event data.
-
- For more information about how to handle events, see [Handling and Raising Events](/dotnet/standard/events/).
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -9389,26 +7584,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the name/value collection has been uploaded to the resource. The name/value collection is sent asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the underlying request is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the Content-type header is `null`, this method sets it to "application/x-www-form-urlencoded".
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -9476,26 +7654,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the name/value collection has been uploaded to the resource. The name/value collection is sent asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the underlying request is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the Content-type header is `null`, this method sets it to "application/x-www-form-urlencoded".
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -9573,26 +7734,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the name/value collection has been uploaded to the resource. The name/value collection is sent asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the underlying request is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the Content-type header is `null`, this method sets it to "application/x-www-form-urlencoded".
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -9674,26 +7818,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the name/value collection has been uploaded to the resource. The name/value collection is sent asynchronously using thread resources that are automatically allocated from the thread pool.
-
- In .NET Framework, you can cancel asynchronous operations that have not completed by calling the <xref:System.Net.WebClient.CancelAsync*> method.
-
- If the underlying request is not understood by the server, the underlying protocol classes determine what occurs. Typically, a <xref:System.Net.WebException> is thrown with the <xref:System.Net.WebException.Status> property set to indicate the error.
-
- If the Content-type header is `null`, this method sets it to "application/x-www-form-urlencoded".
-
- If the <xref:System.Net.WebClient.BaseAddress> property is not an empty string ("") and `address` does not contain an absolute URI, `address` must be a relative URI that is combined with <xref:System.Net.WebClient.BaseAddress*> to form the absolute URI of the requested data. If the <xref:System.Net.WebClient.QueryString> property is not an empty string, it is appended to `address`.
-
- This method uses the STOR command to upload an FTP resource. For an HTTP resource, the POST method is used.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter is <see langword="null" />.
 
@@ -9761,22 +7888,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Set this property to `true` when requests made by this <xref:System.Net.WebClient> object should, if requested by the server, be authenticated using the default credentials of the currently logged on user. For client applications, this is the desired behavior in most scenarios. For middle tier applications, such as ASP.NET applications, instead of using this property, you would typically set the <xref:System.Net.WebClient.Credentials> property to the credentials of the client on whose behalf the request is made.
-
-
-
-## Examples
- The following code example demonstrates setting this property.
-
- [!code-cpp[NCLWebClientAsync#3](~/snippets/cpp/VS_Snippets_Remoting/NCLWebClientAsync/CPP/asyncmethods.cpp#3)]
- [!code-csharp[NCLWebClientAsync#3](~/snippets/csharp/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.cs#3)]
- [!code-vb[NCLWebClientAsync#3](~/snippets/visualbasic/System.Net/DownloadDataCompletedEventArgs/Overview/asyncmethods.vb#3)]
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -9832,17 +7946,9 @@ internal class MyWebClient : WebClientProtocol
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This event is raised each time an asynchronous operation used to write data to a resource using a write stream is closed. These operations result from calls to the <xref:System.Net.WebClient.OpenWriteTaskAsync*> methods.
-
- The <xref:System.Net.WriteStreamClosedEventHandler> is the delegate for this event. The <xref:System.Net.WriteStreamClosedEventArgs> class provides the event handler with event data.
-
- For more information about how to handle events, see [Handling and Raising Events](/dotnet/standard/events/).
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>

--- a/xml/System.Net/WebException.xml
+++ b/xml/System.Net/WebException.xml
@@ -618,11 +618,6 @@
 
  The value of <xref:System.Net.WebException.Status*> is one of the <xref:System.Net.WebExceptionStatus> values.
 
-> [!WARNING]
-> The <xref:System.Net.WebExceptionStatus.ProxyNameResolutionFailure> error is not returned to Windows 8.x Store apps.
-
-
-
 ## Examples
  The following example checks the <xref:System.Net.WebException.Status> property and prints to the console the <xref:System.Net.HttpWebResponse.StatusCode*> and <xref:System.Net.HttpWebResponse.StatusDescription*> of the underlying <xref:System.Net.HttpWebResponse> instance.
 

--- a/xml/System.Net/WebHeaderCollection.xml
+++ b/xml/System.Net/WebHeaderCollection.xml
@@ -83,37 +83,8 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The <xref:System.Net.WebHeaderCollection> class is generally accessed through <xref:System.Net.WebRequest.Headers*?displayProperty=nameWithType> or <xref:System.Net.WebResponse.Headers*?displayProperty=nameWithType>.
 
- On .NET Framework, some common headers are considered restricted and are either exposed directly by the API (such as `Content-Type`) or protected by the system and cannot be changed. This does *not* apply to .NET Core and .NET 5+, where none of the headers are restricted.
-
- The restricted headers are:
-
-- Accept
-
-- Connection
-
-- Content-Length
-
-- Content-Type
-
-- Date
-
-- Expect
-
-- Host
-
-- If-Modified-Since
-
-- Range
-
-- Referer
-
-- Transfer-Encoding
-
-- User-Agent
-
-- Proxy-Connection
+The <xref:System.Net.WebHeaderCollection> class is generally accessed through <xref:System.Net.WebRequest.Headers*?displayProperty=nameWithType> or <xref:System.Net.WebResponse.Headers*?displayProperty=nameWithType>.
 
  ]]></format>
     </remarks>
@@ -310,10 +281,7 @@
  :::code language="vb" source="~/snippets/visualbasic/System.Net/WebHeaderCollection/Add/webheadercollection_add.vb" id="Snippet1":::
 
 > [!NOTE]
-> The length of the *value* portion of `header`, that is, the string after the colon (:), is validated only in .NET Framework and .NET Core versions 2.0 - 3.1.
-> - On all applicable .NET Framework versions: A <xref:System.Net.WebHeaderCollection> instance that's returned by the <xref:System.Net.HttpListenerResponse.Headers> property will throw an <xref:System.ArgumentOutOfRangeException> if the length of the *value* portion of `header` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a *value* of any length.
-> - On .NET Core versions through version 3.1: A <xref:System.Net.WebHeaderCollection> instance used with any header of type <xref:System.Net.HttpResponseHeader> will throw an <xref:System.ArgumentOutOfRangeException> if the length of the *value* portion of `header` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a *value* of any length.
-> - On .NET 5 and later versions: <xref:System.Net.WebHeaderCollection> accepts a *value* of any length.
+> <xref:System.Net.WebHeaderCollection> accepts a *value* of any length.
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -336,7 +304,6 @@
  -or-
 
  The value part of <paramref name="header" /> contains invalid characters.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">.NET Framework and .NET Core versions 2.0 - 3.1 only: The length of the string after the colon (:) is greater than 65535.</exception>
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -395,13 +362,9 @@
  If the specified header is already present, `value` is added to the comma-separated list of values associated with the header.
 
 > [!NOTE]
-> The length of `value` is validated only in .NET Framework and .NET Core versions 2.0 - 3.1.
-> - On all applicable .NET Framework versions: A <xref:System.Net.WebHeaderCollection> instance that's returned by the <xref:System.Net.HttpListenerResponse.Headers> property will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET Core versions through version 3.1: A <xref:System.Net.WebHeaderCollection> instance used with any header of type <xref:System.Net.HttpResponseHeader> will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET 5 and later versions: <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
+> <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentOutOfRangeException">.NET Framework and .NET Core versions 2.0 - 3.1 only: The length of <paramref name="value" /> is greater than 65535.</exception>
         <exception cref="T:System.InvalidOperationException">This <see cref="T:System.Net.WebHeaderCollection" /> instance does not allow instances of <see cref="T:System.Net.HttpRequestHeader" />.</exception>
       </Docs>
     </Member>
@@ -461,13 +424,9 @@
  If the specified header is already present, `value` is added to the comma-separated list of values associated with the header.
 
 > [!NOTE]
-> The length of `value` is validated only in .NET Framework and .NET Core versions 2.0 - 3.1.
-> - On all applicable .NET Framework versions: A <xref:System.Net.WebHeaderCollection> instance that's returned by the <xref:System.Net.HttpListenerResponse.Headers> property will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET Core versions through version 3.1: A <xref:System.Net.WebHeaderCollection> instance used with any header of type <xref:System.Net.HttpResponseHeader> will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET 5 and later versions: <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
+> <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentOutOfRangeException">.NET Framework and .NET Core versions 2.0 - 3.1 only: The length of <paramref name="value" /> is greater than 65535.</exception>
         <exception cref="T:System.InvalidOperationException">This <see cref="T:System.Net.WebHeaderCollection" /> instance does not allow instances of <see cref="T:System.Net.HttpResponseHeader" />.</exception>
       </Docs>
     </Member>
@@ -543,10 +502,7 @@
  :::code language="vb" source="~/snippets/visualbasic/System.Net/WebHeaderCollection/Add/webheadercollection_add.vb" id="Snippet1":::
 
 > [!NOTE]
-> The length of `value` is validated only in .NET Framework and .NET Core versions 2.0 - 3.1.
-> - On all applicable .NET Framework versions: A <xref:System.Net.WebHeaderCollection> instance that's returned by the <xref:System.Net.HttpListenerResponse.Headers> property will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET Core versions through version 3.1: A <xref:System.Net.WebHeaderCollection> instance used with any header of type <xref:System.Net.HttpResponseHeader> will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET 5 and later versions: <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
+> <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentException">
@@ -559,7 +515,6 @@
  -or-
 
  <paramref name="value" /> contains invalid characters.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">.NET Framework and .NET Core versions 2.0 - 3.1 only: The length of <paramref name="value" /> is greater than 65535.</exception>
       </Docs>
     </Member>
     <Member MemberName="AddWithoutValidate">
@@ -624,10 +579,7 @@
  The <xref:System.Net.WebHeaderCollection.AddWithoutValidate*> method adds a header to the collection without checking whether the header is on the restricted header list.
 
 > [!NOTE]
-> The length of `headerValue` is validated only in .NET Framework and .NET Core versions 2.0 - 3.1.
-> - On all applicable .NET Framework versions: A <xref:System.Net.WebHeaderCollection> instance that's returned by the <xref:System.Net.HttpListenerResponse.Headers> property will throw an <xref:System.ArgumentOutOfRangeException> if the length of `headerValue` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `headerValue` of any length.
-> - On .NET Core versions through version 3.1: A <xref:System.Net.WebHeaderCollection> instance used with any header of type <xref:System.Net.HttpResponseHeader> will throw an <xref:System.ArgumentOutOfRangeException> if the length of `headerValue` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `headerValue` of any length.
-> - On .NET 5 and later versions: <xref:System.Net.WebHeaderCollection> accepts a `headerValue` of any length.
+> <xref:System.Net.WebHeaderCollection> accepts a `headerValue` of any length.
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentException">
@@ -636,8 +588,6 @@
  -or-
 
  <paramref name="headerValue" /> contains invalid characters.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">
-          .NET Framework and .NET Core only: <paramref name="headerName" /> is not <see langword="null" /> and the length of <paramref name="headerValue" /> is too long (greater than 65,535 characters).</exception>
         <block subset="none" type="overrides">
           <para>Use the <see cref="M:System.Net.WebHeaderCollection.AddWithoutValidate(System.String,System.String)" /> method to add headers that are normally exposed through properties.</para>
         </block>
@@ -1600,13 +1550,9 @@
 ## Remarks
 
 > [!NOTE]
-> The length of `value` is validated only in .NET Framework and .NET Core versions 2.0 - 3.1.
-> - On all applicable .NET Framework versions: A <xref:System.Net.WebHeaderCollection> instance that's returned by the <xref:System.Net.HttpListenerResponse.Headers> property will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET Core versions through version 3.1: A <xref:System.Net.WebHeaderCollection> instance used with any header of type <xref:System.Net.HttpResponseHeader> will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET 5 and later versions: <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
+> <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentOutOfRangeException">.NET Framework and .NET Core versions 2.0 - 3.1 only: The length of <paramref name="value" /> is greater than 65535.</exception>
         <exception cref="T:System.InvalidOperationException">This <see cref="T:System.Net.WebHeaderCollection" /> instance does not allow instances of <see cref="T:System.Net.HttpResponseHeader" />.</exception>
       </Docs>
     </Member>
@@ -2008,13 +1954,9 @@
  If the header specified in `header` is already present, `value` replaces the existing value.
 
 > [!NOTE]
-> The length of `value` is validated only in .NET Framework and .NET Core versions 2.0 - 3.1.
-> - On all applicable .NET Framework versions: A <xref:System.Net.WebHeaderCollection> instance that's returned by the <xref:System.Net.HttpListenerResponse.Headers> property will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET Core versions through version 3.1: A <xref:System.Net.WebHeaderCollection> instance used with any header of type <xref:System.Net.HttpResponseHeader> will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET 5 and later versions: <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
+> <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentOutOfRangeException">.NET Framework and .NET Core versions 2.0 - 3.1 only: The length of <paramref name="value" /> is greater than 65535.</exception>
         <exception cref="T:System.InvalidOperationException">This <see cref="T:System.Net.WebHeaderCollection" /> instance does not allow instances of <see cref="T:System.Net.HttpRequestHeader" />.</exception>
       </Docs>
     </Member>
@@ -2074,13 +2016,9 @@
  If the header specified in `header` is already present, `value` replaces the existing value.
 
 > [!NOTE]
-> The length of `value` is validated only in .NET Framework and .NET Core versions 2.0 - 3.1.
-> - On all applicable .NET Framework versions: A <xref:System.Net.WebHeaderCollection> instance that's returned by the <xref:System.Net.HttpListenerResponse.Headers> property will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET Core versions through version 3.1: A <xref:System.Net.WebHeaderCollection> instance used with any header of type <xref:System.Net.HttpResponseHeader> will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET 5 and later versions: <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
+> <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentOutOfRangeException">.NET Framework and .NET Core versions 2.0 - 3.1 only: The length of <paramref name="value" /> is greater than 65535.</exception>
         <exception cref="T:System.InvalidOperationException">This <see cref="T:System.Net.WebHeaderCollection" /> instance does not allow instances of <see cref="T:System.Net.HttpResponseHeader" />.</exception>
       </Docs>
     </Member>
@@ -2156,15 +2094,11 @@
  :::code language="vb" source="~/snippets/visualbasic/System.Net/WebHeaderCollection/Set/webheadercollection_set.vb" id="Snippet1":::
 
 > [!NOTE]
-> The length of `value` is validated only in .NET Framework and .NET Core versions 2.0 - 3.1.
-> - On all applicable .NET Framework versions: A <xref:System.Net.WebHeaderCollection> instance that's returned by the <xref:System.Net.HttpListenerResponse.Headers> property will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET Core versions through version 3.1: A <xref:System.Net.WebHeaderCollection> instance used with any header of type <xref:System.Net.HttpResponseHeader> will throw an <xref:System.ArgumentOutOfRangeException> if the length of `value` is greater than 65535. All other <xref:System.Net.WebHeaderCollection> instances accept a `value` of any length.
-> - On .NET 5 and later versions: <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
+> <xref:System.Net.WebHeaderCollection> accepts a `value` of any length.
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="name" /> is <see langword="null" /> or <see cref="F:System.String.Empty" />.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">.NET Framework and .NET Core versions 2.0 - 3.1 only: The length of <paramref name="value" /> is greater than 65535.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="name" /> is a restricted header.
 

--- a/xml/System.Net/WebPermission.xml
+++ b/xml/System.Net/WebPermission.xml
@@ -51,29 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- <xref:System.Net.WebPermission> provides a set of methods and properties to control access to Internet resources. You can use a <xref:System.Net.WebPermission> to provide either restricted or unrestricted access to your resource, based on the <xref:System.Security.Permissions.PermissionState> that is set when the <xref:System.Net.WebPermission> is created.
-
- Create a <xref:System.Net.WebPermission> instance by calling its constructor using one of the following sets of parameters:
-
-- No parameters. The default <xref:System.Security.Permissions.PermissionState> is <xref:System.Security.Permissions.PermissionState.None>.
-
-- A <xref:System.Security.Permissions.PermissionState>. Specify either <xref:System.Security.Permissions.PermissionState.Unrestricted> to allow any URI to be used in the target class, or <xref:System.Security.Permissions.PermissionState.None> to allow access only to URIs that you specify through the use of the <xref:System.Net.WebPermission.AddPermission*> method.
-
-- A <xref:System.Net.NetworkAccess> value and a URI string. The specified URI has permissions granted by the <xref:System.Net.NetworkAccess> value.
-
-- A <xref:System.Net.NetworkAccess> specifier and URI regular expression.
-
- The <xref:System.Net.WebPermission.ConnectList*> and <xref:System.Net.WebPermission.AcceptList*> hold the URIs to which you have granted access permission. To add a URI to either of these lists, use <xref:System.Net.WebPermission.AddPermission*>. If you pass <xref:System.Net.NetworkAccess.Accept> as the <xref:System.Net.NetworkAccess> parameter, the URI will be added to the <xref:System.Net.WebPermission.AcceptList*>. <xref:System.Net.WebPermission> will allow connections to your target class with URIs matching the <xref:System.Net.WebPermission.AcceptList*>.
-
-> [!CAUTION]
-> To deny access to an Internet resource, you must deny access to all the possible paths to that resource. This requires calling <xref:System.Net.WebPermission.%23ctor*?displayProperty=nameWithType> with state parameter set to <xref:System.Security.CodeAccessPermission.Deny*>. A better approach is to allow access to the specific resource only.
-
-> [!NOTE]
-> You need to deny access using only the resource canonical path. There is no need to use all the path's syntactical variations.
-
-> [!NOTE]
-> User name and default port information is stripped from the <xref:System.Uri> before the comparison with the regular expression argument that is supplied to the <xref:System.Net.WebPermission.%23ctor(System.Net.NetworkAccess,System.Text.RegularExpressions.Regex)> constructor. If the regular expression contains user information or the default port number, then all incoming <xref:System.Uri>s will fail to match the regular expression.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.CodeAccessPermission" />
@@ -120,14 +97,7 @@
       <Parameters />
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.Net.WebPermission" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates a new instance of the <xref:System.Net.WebPermission> class. This constructor creates an empty permission that does not grant any rights.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Net.WebPermission.IsUnrestricted" />
       </Docs>
     </Member>
@@ -164,14 +134,7 @@
       <Docs>
         <param name="state">A <see cref="T:System.Security.Permissions.PermissionState" /> value.</param>
         <summary>Creates a new instance of the <see cref="T:System.Net.WebPermission" /> class that passes all demands or fails all demands.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The value of the `state` parameter is either <xref:System.Security.Permissions.PermissionState.None?displayProperty=nameWithType> or <xref:System.Security.Permissions.PermissionState.Unrestricted?displayProperty=nameWithType>, respectively yielding fully restricted or fully unrestricted access to all security variables. If you specify <xref:System.Security.Permissions.PermissionState.None?displayProperty=nameWithType>, then you can give access to individual URIs using <xref:System.Net.WebPermission.AddPermission*>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="F:System.Security.Permissions.PermissionState.Unrestricted" />
       </Docs>
     </Member>
@@ -210,14 +173,7 @@
         <param name="access">A NetworkAccess value that indicates what kind of access to grant to the specified URI. <see cref="F:System.Net.NetworkAccess.Accept" /> indicates that the application is allowed to accept connections from the Internet on a local resource. <see cref="F:System.Net.NetworkAccess.Connect" /> indicates that the application is allowed to connect to specific Internet resources.</param>
         <param name="uriString">A URI string to which access rights are granted.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.WebPermission" /> class with the specified access rights for the specified URI.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor initializes a <xref:System.Net.WebPermission> and grants its target permission to either make a remote host connection or accept a remote host connection using the URI described by the `uriString` parameter.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="uriString" /> is <see langword="null" />.</exception>
         <altmember cref="T:System.Text.RegularExpressions.Regex" />
@@ -258,20 +214,7 @@
         <param name="access">A <see cref="T:System.Net.NetworkAccess" /> value that indicates what kind of access to grant to the specified URI. <see cref="F:System.Net.NetworkAccess.Accept" /> indicates that the application is allowed to accept connections from the Internet on a local resource. <see cref="F:System.Net.NetworkAccess.Connect" /> indicates that the application is allowed to connect to specific Internet resources.</param>
         <param name="uriRegex">A regular expression that describes the URI to which access is to be granted.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.WebPermission" /> class with the specified access rights for the specified URI regular expression.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor initializes a <xref:System.Net.WebPermission> and grants its target permission to either make a remote host connection or accept a remote host connection using the URI described by the `uriRegex` parameter.
-
-> [!NOTE]
-> It is recommended that you create `uriRegex` using the <xref:System.Text.RegularExpressions.RegexOptions.IgnoreCase?displayProperty=nameWithType>, <xref:System.Text.RegularExpressions.RegexOptions.Compiled?displayProperty=nameWithType>, and <xref:System.Text.RegularExpressions.RegexOptions.Singleline?displayProperty=nameWithType> flags.
-
-> [!NOTE]
-> A candidate URI string is checked against the list of relevant regular expressions (<xref:System.Net.WebPermission.AcceptList*> or <xref:System.Net.WebPermission.ConnectList*>) in two ways. First, the candidate URI string is checked against the appropriate list; then, if there is no match, the candidate URI string is converted into a <xref:System.Uri> and checked against the appropriate list.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="T:System.Text.RegularExpressions.Regex" />
       </Docs>
     </Member>
@@ -308,20 +251,7 @@
       <Docs>
         <summary>This property returns an enumeration of a single accept permissions held by this <see cref="T:System.Net.WebPermission" />. The possible objects types contained in the returned enumeration are <see cref="T:System.String" /> and <see cref="T:System.Text.RegularExpressions.Regex" />.</summary>
         <value>The <see cref="T:System.Collections.IEnumerator" /> interface that contains accept permissions.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property gets a list of local resources permitted by this <xref:System.Net.WebPermission>. The class to which you have applied <xref:System.Net.WebPermission> only has permission to receive an incoming connection to local resources found in this list.
-
-> [!NOTE]
-> You can add URIs to this list using <xref:System.Net.WebPermission.AddPermission*>.
-
-> [!NOTE]
-> A candidate URI string is checked against the list of relevant regular expressions (<xref:System.Net.WebPermission.AcceptList*> or <xref:System.Net.WebPermission.ConnectList*>) in two ways. First, the candidate URI string is checked against the appropriate list; then, if there is no match, the candidate URI string is converted into a <xref:System.Uri> and checked against the appropriate list.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Net.WebPermission.AddPermission(System.Net.NetworkAccess,System.String)" />
       </Docs>
     </Member>
@@ -373,20 +303,7 @@
         <param name="access">A <see cref="T:System.Net.NetworkAccess" /> that specifies the access rights that are granted to the URI.</param>
         <param name="uriString">A string that describes the URI to which access rights are granted.</param>
         <summary>Adds the specified URI string with the specified access rights to the current <see cref="T:System.Net.WebPermission" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If you have specified <xref:System.Security.Permissions.PermissionState.None> as the <xref:System.Security.Permissions.PermissionState>, use <xref:System.Net.WebPermission.AddPermission*> to permit the use of `uriString` in the target class. The way that `uriString` can be used by the target class is specified by `access`. Specify <xref:System.Net.NetworkAccess.Accept> as the access parameter to add the URI specified by the `uriString` parameter to the list of URI accept strings, or specify <xref:System.Net.NetworkAccess.Connect> as the access parameter to add the URI to the list of URI connect strings.
-
-> [!NOTE]
-> Calling <xref:System.Net.WebPermission.AddPermission*> on <xref:System.Security.Permissions.PermissionState.Unrestricted><xref:System.Net.WebPermission> will have no effect, because permission is granted to all URIs.
-
-> [!NOTE]
-> A candidate URI string is checked against the list of relevant regular expressions (<xref:System.Net.WebPermission.AcceptList*> or <xref:System.Net.WebPermission.ConnectList*>) in two ways. First, the candidate URI string is checked against the appropriate list; then, if there is no match, the candidate URI string is converted into a <xref:System.Uri> and checked against the appropriate list.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="uriString" /> is <see langword="null" />.</exception>
         <altmember cref="T:System.Net.NetworkAccess" />
@@ -430,23 +347,7 @@
         <param name="access">A NetworkAccess that specifies the access rights that are granted to the URI.</param>
         <param name="uriRegex">A regular expression that describes the set of URIs to which access rights are granted.</param>
         <summary>Adds the specified URI with the specified access rights to the current <see cref="T:System.Net.WebPermission" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If you have specified <xref:System.Security.Permissions.PermissionState.None> as the <xref:System.Security.Permissions.PermissionState>, use <xref:System.Net.WebPermission.AddPermission*> to allow the use of `uriRegex` in the target class. Specify <xref:System.Net.NetworkAccess.Accept> as the `access` parameter to add the URI specified by the `uriRegex` parameter to the list of URI accept strings, or specify <xref:System.Net.NetworkAccess.Connect> as the access parameter to add the URI to the list of URI connect strings.
-
-> [!NOTE]
-> Calling <xref:System.Net.WebPermission.AddPermission*> on an <xref:System.Security.Permissions.PermissionState.Unrestricted><xref:System.Net.WebPermission> instance will have no effect as permission is granted to all URIs.
-
-> [!NOTE]
-> It is recommended that you create `uriRegex` using the <xref:System.Text.RegularExpressions.RegexOptions.IgnoreCase?displayProperty=nameWithType>, <xref:System.Text.RegularExpressions.RegexOptions.Compiled?displayProperty=nameWithType>, and <xref:System.Text.RegularExpressions.RegexOptions.Singleline?displayProperty=nameWithType> flags.
-
-> [!NOTE]
-> A candidate URI string is checked against the list of relevant regular expressions (<xref:System.Net.WebPermission.AcceptList*> or <xref:System.Net.WebPermission.ConnectList*>) in two ways. First, the candidate URI string is checked against the appropriate list; then, if there is no match, the candidate URI string is converted into a <xref:System.Uri> and checked against the appropriate list.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="uriRegex" /> parameter is <see langword="null" />.</exception>
         <altmember cref="T:System.Net.NetworkAccess" />
       </Docs>
@@ -484,20 +385,7 @@
       <Docs>
         <summary>This property returns an enumeration of a single connect permissions held by this <see cref="T:System.Net.WebPermission" />. The possible objects types contained in the returned enumeration are <see cref="T:System.String" /> and <see cref="T:System.Text.RegularExpressions.Regex" />.</summary>
         <value>The <see cref="T:System.Collections.IEnumerator" /> interface that contains connect permissions.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property gets a list of remote resources that are permitted by this <xref:System.Net.WebPermission>. The class to which you have applied <xref:System.Net.WebPermission> only has permission to connect with resources found in this list.
-
-> [!NOTE]
-> You can add URIs to this list using <xref:System.Net.WebPermission.AddPermission*>.
-
-> [!NOTE]
-> A candidate URI string is checked against the list of relevant regular expressions (<xref:System.Net.WebPermission.AcceptList*> or <xref:System.Net.WebPermission.ConnectList*>) in two ways. First, the candidate URI string is checked against the appropriate list; then, if there is no match, the candidate URI string is converted into a <xref:System.Uri> and checked against the appropriate list.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Net.WebPermission.AddPermission(System.Net.NetworkAccess,System.String)" />
       </Docs>
     </Member>
@@ -535,14 +423,7 @@
       <Docs>
         <summary>Creates a copy of a <see cref="T:System.Net.WebPermission" />.</summary>
         <returns>A new instance of the <see cref="T:System.Net.WebPermission" /> class that has the same values as the original.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.IPermission> returned by this method represents the same access to resources as the original <xref:System.Net.WebPermission>. This method overrides <xref:System.Security.CodeAccessPermission.Copy*> and is implemented to support the <xref:System.Security.IPermission> interface.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -581,16 +462,7 @@
       <Docs>
         <param name="securityElement">The XML encoding from which to reconstruct the <see cref="T:System.Net.WebPermission" />.</param>
         <summary>Reconstructs a <see cref="T:System.Net.WebPermission" /> from an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.WebPermission.FromXml*> method reconstructs a <xref:System.Net.WebPermission> from an XML encoding that is defined by the <xref:System.Security.SecurityElement> class.
-
- Use the <xref:System.Net.WebPermission.ToXml*> method to XML-encode the <xref:System.Net.WebPermission>, including state information.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="securityElement" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="securityElement" /> is not a permission element for this type.</exception>
@@ -634,16 +506,7 @@
         <param name="target">The <see cref="T:System.Net.WebPermission" /> to compare with the current instance.</param>
         <summary>Returns the logical intersection of two <see cref="T:System.Net.WebPermission" /> instances.</summary>
         <returns>A new <see cref="T:System.Net.WebPermission" /> that represents the intersection of the current instance and the <paramref name="target" /> parameter. If the intersection is empty, the method returns <see langword="null" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Net.WebPermission.Intersect*> returns a <xref:System.Net.WebPermission> that contains those permissions that are common in both `target` and the current instance.
-
- This method overrides <xref:System.Security.CodeAccessPermission.Intersect*> and is implemented to support the <xref:System.Security.IPermission> interface.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not <see langword="null" /> or of type <see cref="T:System.Net.WebPermission" /></exception>
       </Docs>
@@ -686,14 +549,7 @@
         <summary>Determines whether the current <see cref="T:System.Net.WebPermission" /> is a subset of the specified object.</summary>
         <returns>
           <see langword="true" /> if the current instance is a subset of the <paramref name="target" /> parameter; otherwise, <see langword="false" />. If the target is <see langword="null" />, the method returns <see langword="true" /> for an empty current permission that is not unrestricted and <see langword="false" /> otherwise.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If the current <xref:System.Net.WebPermission> specifies a set of associated resources that is wholly contained by the `target` parameter, then the current <xref:System.Net.WebPermission> is a subset of `target`. This method overrides <xref:System.Net.WebPermission.IsSubsetOf*> and is implemented to support the <xref:System.Security.IPermission> interface.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The target parameter is not an instance of <see cref="T:System.Net.WebPermission" />.</exception>
         <exception cref="T:System.NotSupportedException">The current instance contains a Regex-encoded right and there is not exactly the same right found in the target instance.</exception>
       </Docs>
@@ -736,17 +592,7 @@
         <summary>Checks the overall permission state of the <see cref="T:System.Net.WebPermission" />.</summary>
         <returns>
           <see langword="true" /> if the <see cref="T:System.Net.WebPermission" /> was created with the <see cref="F:System.Security.Permissions.PermissionState.Unrestricted" /><see cref="T:System.Security.Permissions.PermissionState" />; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If <xref:System.Net.WebPermission> is <xref:System.Security.Permissions.PermissionState.Unrestricted>, then the target class can use all URIs. Otherwise, specific permission must be given for any URI you want to use with the target class.
-
-> [!NOTE]
-> Use <xref:System.Net.WebPermission.AddPermission*> to add a URI and specify its permissions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Net.WebPermission.AddPermission(System.Net.NetworkAccess,System.String)" />
       </Docs>
     </Member>
@@ -784,14 +630,7 @@
       <Docs>
         <summary>Creates an XML encoding of a <see cref="T:System.Net.WebPermission" /> and its current state.</summary>
         <returns>A <see cref="T:System.Security.SecurityElement" /> that contains an XML-encoded representation of the <see cref="T:System.Net.WebPermission" />, including state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use the <xref:System.Net.WebPermission.FromXml*> method to restore the state information from a <xref:System.Security.SecurityElement>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Net.WebPermission.FromXml(System.Security.SecurityElement)" />
       </Docs>
     </Member>
@@ -832,14 +671,7 @@
         <param name="target">The <see cref="T:System.Net.WebPermission" /> to combine with the current <see cref="T:System.Net.WebPermission" />.</param>
         <summary>Returns the logical union between two instances of the <see cref="T:System.Net.WebPermission" /> class.</summary>
         <returns>A <see cref="T:System.Net.WebPermission" /> that represents the union of the current instance and the <paramref name="target" /> parameter. If either <see langword="WebPermission" /> is <see cref="F:System.Security.Permissions.PermissionState.Unrestricted" />, the method returns a <see cref="T:System.Net.WebPermission" /> that is <see cref="F:System.Security.Permissions.PermissionState.Unrestricted" />. If the target is <see langword="null" />, the method returns a copy of the current <see cref="T:System.Net.WebPermission" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Net.WebPermission.Union*> returns a <xref:System.Net.WebPermission> that contains all the permissions in both `target` and the current instance.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">target is not <see langword="null" /> or of type <see cref="T:System.Net.WebPermission" />.</exception>
         <altmember cref="T:System.Security.Permissions.PermissionState" />
       </Docs>

--- a/xml/System.Net/WebPermissionAttribute.xml
+++ b/xml/System.Net/WebPermissionAttribute.xml
@@ -51,13 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- <xref:System.Net.WebPermissionAttribute> allows you to declaratively specify which URI strings and regular expression strings your class can use.
-
- The security information specified in the <xref:System.Net.WebPermissionAttribute> is stored in the metadata of the attribute target, which is the class to which <xref:System.Net.WebPermissionAttribute> is applied. The system accesses this information at run time. The <xref:System.Security.Permissions.SecurityAction?displayProperty=nameWithType> passed to the constructor determines the allowable <xref:System.Net.WebPermissionAttribute> targets. The system uses the <xref:System.Net.WebPermission> returned by the <xref:System.Net.WebPermissionAttribute.CreatePermission*> method to convert the security information of the attribute target to a serializable form stored in metadata.
-
-> [!NOTE]
-> <xref:System.Net.WebPermissionAttribute> is used only for Declarative Security. For Imperative Security, use the corresponding <xref:System.Net.WebPermission>.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -95,14 +88,7 @@
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.WebPermissionAttribute" /> class with a value that specifies the security actions that can be performed on this class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.SecurityAction> value passed to this constructor specifies the allowable security actions that can be performed on this class.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="action" /> is not a valid <see cref="T:System.Security.Permissions.SecurityAction" /> value.</exception>
       </Docs>
@@ -140,14 +126,7 @@
       <Docs>
         <summary>Gets or sets the URI string accepted by the current <see cref="T:System.Net.WebPermissionAttribute" />.</summary>
         <value>A string containing the URI accepted by the current <see cref="T:System.Net.WebPermissionAttribute" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- When applying <xref:System.Net.WebPermissionAttribute> to your class, this property specifies what URI string will be accepted for use within your class. This permission is applied when the security system calls <xref:System.Net.WebPermissionAttribute.CreatePermission*>. This property is write-once.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <see cref="P:System.Net.WebPermissionAttribute.Accept" /> is not <see langword="null" /> when you attempt to set the value. If you wish to specify more than one Accept URI, use an additional attribute declaration statement.</exception>
         <related type="Article" href="/dotnet/framework/network-programming/introducing-pluggable-protocols">Introducing Pluggable Protocols</related>
@@ -186,14 +165,7 @@
       <Docs>
         <summary>Gets or sets a regular expression pattern that describes the URI accepted by the current <see cref="T:System.Net.WebPermissionAttribute" />.</summary>
         <value>A string containing a regular expression pattern that describes the URI accepted by the current <see cref="T:System.Net.WebPermissionAttribute" />. This string must be escaped according to the rules for encoding a <see cref="T:System.Text.RegularExpressions.Regex" /> constructor string.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- When applying <xref:System.Net.WebPermissionAttribute> to your class, this property specifies what regular expression string will be accepted for use within your class. This property is write-once.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <see cref="P:System.Net.WebPermissionAttribute.AcceptPattern" /> is not <see langword="null" /> when you attempt to set the value. If you wish to specify more than one Accept URI, use an additional attribute declaration statement.</exception>
         <related type="Article" href="/dotnet/standard/base-types/regular-expression-language-quick-reference">Regular Expression Language - Quick Reference</related>
@@ -232,14 +204,7 @@
       <Docs>
         <summary>Gets or sets the URI connection string controlled by the current <see cref="T:System.Net.WebPermissionAttribute" />.</summary>
         <value>A string containing the URI connection controlled by the current <see cref="T:System.Net.WebPermissionAttribute" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- When applying <xref:System.Net.WebPermissionAttribute> to your class, this property specifies what URI connection is accepted for use within your class. This property is write-once.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <see cref="P:System.Net.WebPermissionAttribute.Connect" /> is not <see langword="null" /> when you attempt to set the value. If you wish to specify more than one Connect URI, use an additional attribute declaration statement.</exception>
         <related type="Article" href="/dotnet/framework/network-programming/introducing-pluggable-protocols">Introducing Pluggable Protocols</related>
@@ -278,14 +243,7 @@
       <Docs>
         <summary>Gets or sets a regular expression pattern that describes the URI connection controlled by the current <see cref="T:System.Net.WebPermissionAttribute" />.</summary>
         <value>A string containing a regular expression pattern that describes the URI connection controlled by this <see cref="T:System.Net.WebPermissionAttribute" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- When applying <xref:System.Net.WebPermissionAttribute> to your class, this property specifies what regular expression connect string is accepted for use within your class. This property is write-once.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <see cref="P:System.Net.WebPermissionAttribute.ConnectPattern" /> is not <see langword="null" /> when you attempt to set the value. If you wish to specify more than one connect URI, use an additional attribute declaration statement.</exception>
         <related type="Article" href="/dotnet/standard/base-types/regular-expression-language-quick-reference">Regular Expression Language - Quick Reference</related>
@@ -325,16 +283,7 @@
       <Docs>
         <summary>Creates and returns a new instance of the <see cref="T:System.Net.WebPermission" /> class.</summary>
         <returns>A <see cref="T:System.Net.WebPermission" /> corresponding to the security declaration.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.SocketPermissionAttribute.CreatePermission*> method is called by the security system, not by application code.
-
- The security information described by <xref:System.Net.WebPermissionAttribute> is stored in the metadata of the attribute target, which is the class to which <xref:System.Net.WebPermissionAttribute> is applied. The system accesses the information at run time. The system uses the <xref:System.Net.WebPermission> returned by <xref:System.Net.SocketPermissionAttribute.CreatePermission*> to convert the security information of the attribute target to a serializable form stored in metadata.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Net/WebProxy.xml
+++ b/xml/System.Net/WebProxy.xml
@@ -1170,18 +1170,12 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
- The <xref:System.Net.WebProxy.GetDefaultProxy*> method reads the nondynamic proxy settings from the computer's Internet options and creates a <xref:System.Net.WebProxy> instance with those settings.
-
- The <xref:System.Net.WebProxy.GetDefaultProxy*> method does not pick up any dynamic settings that are generated from scripts run by Internet Explorer, from automatic configuration entries, or from DHCP or DNS lookups.
-
- Applications should use the <xref:System.Net.Http.HttpClient.DefaultProxy?displayProperty=nameWithType> property instead of the <xref:System.Net.WebProxy.GetDefaultProxy*> method.
-
 > [!NOTE]
-> This property is not supported on .NET Core.
+> This property is not supported.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.PlatformNotSupportedException">On .NET Core.</exception>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetObjectData">

--- a/xml/System.Net/WebProxy.xml
+++ b/xml/System.Net/WebProxy.xml
@@ -1171,7 +1171,7 @@
           <format type="text/markdown"><![CDATA[
 
 > [!NOTE]
-> This property is not supported.
+> This method is not supported.
 
  ]]></format>
         </remarks>

--- a/xml/System.Net/WebRequest.xml
+++ b/xml/System.Net/WebRequest.xml
@@ -69,26 +69,6 @@
 
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- <xref:System.Net.WebRequest> is the `abstract` base class for .NET's request/response model for accessing data from the Internet. An application that uses the request/response model can request data from the Internet in a protocol-agnostic manner, in which the application works with instances of the <xref:System.Net.WebRequest> class while protocol-specific descendant classes carry out the details of the request.
-
- Requests are sent from an application to a particular URI, such as a Web page on a server. The URI determines the proper descendant class to create from a list of <xref:System.Net.WebRequest> descendants registered for the application. <xref:System.Net.WebRequest> descendants are typically registered to handle a specific protocol, such as HTTP or FTP, but can be registered to handle a request to a specific server or path on a server.
-
- The <xref:System.Net.WebRequest> class throws a <xref:System.Net.WebException> when errors occur while accessing an Internet resource. The <xref:System.Net.WebException.Status> property is one of the <xref:System.Net.WebExceptionStatus> values that indicates the source of the error. When <xref:System.Net.WebException.Status*> is <xref:System.Net.WebExceptionStatus.ProtocolError?displayProperty=nameWithType>, the <xref:System.Net.WebException.Response> property contains the <xref:System.Net.WebResponse> received from the Internet resource.
-
- Because the <xref:System.Net.WebRequest> class is an `abstract` class, the actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by <xref:System.Net.WebRequest.Create*> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-> [!NOTE]
-> Use the <xref:System.Net.WebRequest.Create*> method to initialize new <xref:System.Net.WebRequest> instances. Do not use the <xref:System.Net.WebRequest> constructor.
-
-> [!NOTE]
-> If the application that creates the WebRequest object runs with the credentials of a Normal user, the application will not be able to access certificates installed in the local machine store unless permission has been explicitly given to the user to do so.
-
-## Examples
- The following example shows how to create a <xref:System.Net.WebRequest> instance and return the response.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/Overview/webrequestget.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/Overview/webrequestget.vb" id="Snippet1":::
-
  ]]></format>
     </remarks>
     <block subset="none" type="overrides">
@@ -219,20 +199,8 @@
         <param name="serializationInfo">The information required to serialize the new <see cref="T:System.Net.WebRequest" /> instance.</param>
         <param name="streamingContext">A <see cref="T:System.Runtime.Serialization.StreamingContext" /> that indicates the source of the serialized stream associated with the new <see cref="T:System.Net.WebRequest" /> instance.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.WebRequest" /> class from the specified instances of the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> and <see cref="T:System.Runtime.Serialization.StreamingContext" /> classes.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
- When implemented by a descendant class, this constructor implements the <xref:System.Runtime.Serialization.ISerializable> interface for the <xref:System.Net.WebRequest> descendant.
-
-> [!NOTE]
-> An application must run in full trust mode when using serialization.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to access the constructor, when the constructor is not overridden in a descendant class.</exception>
-        <related type="Article" href="/dotnet/standard/serialization/xml-and-soap-serialization">XML and SOAP Serialization</related>
       </Docs>
     </Member>
     <Member MemberName="Abort">
@@ -282,16 +250,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.Abort*> method cancels asynchronous requests to Internet resources started with the <xref:System.Net.WebRequest.BeginGetResponse*> method.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to access the method, when the method is not overridden in a descendant class.</exception>
       </Docs>
@@ -412,24 +373,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.BeginGetRequestStream*> method starts an asynchronous request for a stream used to send data to an Internet resource. The callback method that implements the <xref:System.AsyncCallback> delegate uses the <xref:System.Net.WebRequest.EndGetRequestStream*> method to return the request stream.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-
-
-## Examples
- The following example uses the <xref:System.Net.WebRequest.BeginGetRequestStream*> to asynchronously obtain the request stream.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/BeginGetRequestStream/webrequest_begingetrequest.cs" id="Snippet3":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/BeginGetRequestStream/webrequest_begingetrequest.vb" id="Snippet3":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to access the method, when the method is not overridden in a descendant class.</exception>
         <altmember cref="M:System.Net.WebRequest.EndGetRequestStream(System.IAsyncResult)" />
@@ -496,26 +442,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.BeginGetResponse*> method starts an asynchronous request for a response. The callback method that implements the <xref:System.AsyncCallback> delegate uses the <xref:System.Net.WebRequest.EndGetResponse*> method to return the <xref:System.Net.WebResponse> from the Internet resource.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-> [!NOTE]
-> If a WebException is thrown, use the <xref:System.Net.WebException.Response*> and <xref:System.Net.WebException.Status*> properties of the exception to determine the response from the server.
-
-
-
-## Examples
- The following example uses <xref:System.Net.WebRequest.BeginGetResponse*> to asynchronously request the target resource. When the resource has been obtained, the specified callback method will be executed.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Abort/begingetresponse.cs" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to access the method, when the method is not overridden in a descendant class.</exception>
         <altmember cref="M:System.Net.WebRequest.EndGetResponse(System.IAsyncResult)" />
@@ -571,24 +500,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The current cache policy and the presence of the requested resource in the cache determine whether a response can be retrieved from the cache. Using cached responses usually improves application performance, but there is a risk that the response in the cache does not match the response on the server.
-
- Default cache policy can be specified in the Machine.config configuration file or by setting the <xref:System.Net.HttpWebRequest.DefaultCachePolicy> property for requests that use the Hypertext Transfer Protocol (HTTP) or Secure Hypertext Transfer Protocol (HTTPS) URI scheme.
-
- A copy of a resource is only added to the cache if the response stream for the resource is retrieved and read to the end of the stream. So another request for the same resource could use a cached copy, depending on the cache policy level for this request.
-
-
-
-## Examples
- The following code example demonstrates setting the cache policy for a Web request.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/CachePolicy/example.cs" id="Snippet2":::
-
- ]]></format>
+]]></format>
         </remarks>
         <altmember cref="T:System.Net.Cache.RequestCachePolicy" />
         <altmember cref="T:System.Net.Cache.HttpRequestCacheLevel" />
@@ -646,16 +560,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.ConnectionGroupName> property associates specific requests within an application to one or more connection pools.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to get or set the property, when the property is not overridden in a descendant class.</exception>
         <block subset="none" type="overrides">
@@ -707,24 +614,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.ContentLength> property contains the number of bytes of data sent to the Internet resource by the <xref:System.Net.WebRequest> instance.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-
-
-## Examples
- The following example sets the <xref:System.Net.WebRequest.ContentLength> property to the amount of bytes in the outgoing byte buffer.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/ContentLength/webrequest_contenttype.cs" id="Snippet4":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/ContentLength/webrequest_contenttype.vb" id="Snippet4":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to get or set the property, when the property is not overridden in a descendant class.</exception>
         <altmember cref="P:System.Net.HttpWebRequest.ContentLength" />
@@ -783,24 +675,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.ContentType> property contains the media type of the request. This is typically the MIME encoding of the content.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-
-
-## Examples
- The following example sets the <xref:System.Net.WebRequest.ContentType> property to the appropriate media type.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/ContentLength/webrequest_contenttype.cs" id="Snippet4":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/ContentLength/webrequest_contenttype.vb" id="Snippet4":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to get or set the property, when the property is not overridden in a descendant class.</exception>
         <altmember cref="P:System.Net.HttpWebRequest.ContentType" />
@@ -1273,24 +1150,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.Credentials> property contains the authentication credentials required to access the Internet resource.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-
-
-## Examples
- The following example sets the <xref:System.Net.WebRequest.Credentials> property using the default credentials of the current user. When the request is made, credentials stored in this property are used to validate the client. This is identical to setting the <xref:System.Net.WebRequest.UseDefaultCredentials> property to `true`.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/Overview/webrequestget.cs" id="Snippet2":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/Overview/webrequestget.vb" id="Snippet2":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to get or set the property, when the property is not overridden in a descendant class.</exception>
         <altmember cref="T:System.Net.NetworkCredential" />
@@ -1346,28 +1208,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- This policy is used for this request if the following conditions exist:
-
-- There is no <xref:System.Net.HttpWebRequest.DefaultCachePolicy> property specified for this request.
-
-- The machine and application configuration files do not specify a cache policy that is applicable to the Uniform Resource Identifier (URI) used to create this request.
-
- The cache policy determines whether the requested resource can be taken from a cache instead of sending the request to the resource host computer.
-
- A copy of a resource is only added to the cache if the response stream for the resource is retrieved and read to the end of the stream. So another request for the same resource could use a cached copy, depending on the cache policy level for this request.
-
-
-
-## Examples
- The following code example demonstrates setting the default cache policy for Web requests.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/CachePolicy/example.cs" id="Snippet15":::
-
- ]]></format>
+]]></format>
         </remarks>
         <altmember cref="T:System.Net.Cache.RequestCachePolicy" />
         <altmember cref="T:System.Net.Cache.HttpRequestCacheLevel" />
@@ -1425,17 +1268,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.DefaultWebProxy> property gets or sets the global proxy. The <xref:System.Net.WebRequest.DefaultWebProxy> property determines the default proxy that all <xref:System.Net.WebRequest> instances use if the request supports proxies and no proxy is set explicitly using the <xref:System.Net.HttpWebRequest.Proxy> property. Proxies are currently supported by <xref:System.Net.FtpWebRequest> and <xref:System.Net.HttpWebRequest>.
-
- The <xref:System.Net.WebRequest.DefaultWebProxy> property reads proxy settings from the app.config file. If there is no config file, the current user's Internet options proxy settings are used.
-
- If the <xref:System.Net.WebRequest.DefaultWebProxy> property is set to null, all subsequent instances of the <xref:System.Net.WebRequest> class created by the <xref:System.Net.WebRequest.Create*> or <xref:System.Net.WebRequest.CreateDefault*> methods do not have a proxy.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1490,27 +1325,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.EndGetRequestStream*> method completes an asynchronous stream request that was started by the <xref:System.Net.WebRequest.BeginGetRequestStream*> method.
-
-> [!NOTE]
-> To avoid timing issues with garbage collection, be sure to close the response stream by calling the <xref:System.IO.Stream.Close*> method on the stream returned by <xref:System.Net.WebResponse.GetResponseStream*> after calling <xref:System.Net.WebRequest.EndGetResponse*>.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-
-
-## Examples
- The following example obtains and uses the request stream by calling the <xref:System.Net.WebRequest.EndGetRequestStream*>. The <xref:System.Net.WebRequest.EndGetRequestStream*> method completes the asynchronous call to <xref:System.Net.WebRequest.BeginGetRequestStream*>.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/BeginGetRequestStream/webrequest_begingetrequest.cs" id="Snippet3":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/BeginGetRequestStream/webrequest_begingetrequest.vb" id="Snippet3":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to access the method, when the method is not overridden in a descendant class.</exception>
         <altmember cref="M:System.Net.WebRequest.BeginGetRequestStream(System.AsyncCallback,System.Object)" />
@@ -1568,23 +1385,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.EndGetResponse*> method completes an asynchronous request for an Internet resource that was started with the <xref:System.Net.WebRequest.BeginGetResponse*> method.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-
-
-## Examples
- The following example calls the <xref:System.Net.WebRequest.EndGetResponse*> to retrieve the target resource.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/HttpWebRequest/Abort/begingetresponse.cs" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to access the method, when the method is not overridden in a descendant class.</exception>
         <altmember cref="M:System.Net.WebRequest.BeginGetResponse(System.AsyncCallback,System.Object)" />
@@ -1694,26 +1497,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.GetRequestStream*> method initiates a request to send data to the Internet resource and returns a <xref:System.IO.Stream> instance for sending data to the Internet resource.
-
- The <xref:System.Net.WebRequest.GetRequestStream*> method provides synchronous access to the <xref:System.IO.Stream>. For asynchronous access, use the <xref:System.Net.WebRequest.BeginGetRequestStream*> and <xref:System.Net.WebRequest.EndGetRequestStream*> methods.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-
-
-## Examples
- The following example uses the <xref:System.Net.WebRequest.GetRequestStream*> method to obtain a stream and then writes data that stream.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/ContentLength/webrequest_contenttype.cs" id="Snippet4":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/ContentLength/webrequest_contenttype.vb" id="Snippet4":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to access the method, when the method is not overridden in a descendant class.</exception>
         <altmember cref="M:System.Net.WebRequest.BeginGetRequestStream(System.AsyncCallback,System.Object)" />
@@ -1762,15 +1548,7 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete when the <xref:System.IO.Stream> for writing data to the Internet resource is available.
-
- After you call <xref:System.Net.WebRequest.GetRequestStreamAsync*>, make sure you close the request stream before you call <xref:System.Net.WebRequest.GetResponseAsync*>.
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebRequest.GetRequestStream>.
 
 ]]></format>
         </remarks>
@@ -1819,29 +1597,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.GetResponse*> method sends a request to an Internet resource and returns a <xref:System.Net.WebResponse> instance. If the request has already been initiated by a call to <xref:System.Net.WebRequest.GetRequestStream*>, the <xref:System.Net.WebRequest.GetResponse*> method completes the request and returns any response.
-
- The <xref:System.Net.WebRequest.GetResponse*> method provides synchronous access to the <xref:System.Net.WebResponse>. For asynchronous access, use the <xref:System.Net.WebRequest.BeginGetResponse*> and <xref:System.Net.WebRequest.EndGetResponse*> methods.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-> [!NOTE]
-> If a WebException is thrown, use the <xref:System.Net.WebException.Response*> and <xref:System.Net.WebException.Status*> properties of the exception to determine the response from the server.
-
-
-
-## Examples
- The following example sets the <xref:System.Net.WebRequest.Timeout> property to 10000 milliseconds. If the timeout period expires before the resource can be returned, a <xref:System.Net.WebException> is thrown.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/GetResponse/webrequest_timeout.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/GetResponse/webrequest_timeout.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to access the method, when the method is not overridden in a descendant class.</exception>
         <altmember cref="M:System.Net.WebRequest.BeginGetResponse(System.AsyncCallback,System.Object)" />
@@ -1890,13 +1648,7 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
-
- This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after a response to an Internet request is available.
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.WebRequest.GetResponse>.
 
 ]]></format>
         </remarks>
@@ -1944,15 +1696,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- <xref:System.Net.WebRequest.GetSystemWebProxy*> method reads the current user's Internet options proxy settings. This process includes the options to automatically detect proxy settings, use an automatic configuration script, manual proxy server settings, and advanced manual proxy server settings.
-
- If your application impersonates several users, you can use the <xref:System.Net.WebRequest.GetSystemWebProxy*> method to retrieve a proxy for each impersonated user.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -2002,24 +1748,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.Headers> property contains a <xref:System.Net.WebHeaderCollection> instance containing the header information to send to the Internet resource.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-
-
-## Examples
- The following example displays the header name/value pairs associated with this request.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/Headers/webrequest_headers.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/Headers/webrequest_headers.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to get or set the property, when the property is not overridden in a descendant class.</exception>
         <altmember cref="T:System.Net.WebHeaderCollection" />
@@ -2067,13 +1798,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The impersonation level determines how the server can use the client's credentials.
-
- ]]></format>
+]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -2123,24 +1850,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- When overridden in a descendant class, the <xref:System.Net.WebRequest.Method> property contains the request method to use in this request.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-
-
-## Examples
- The following example sets the <xref:System.Net.WebRequest.Method> property to POST to indicate that the request will post data to the target host.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/BeginGetRequestStream/webrequest_begingetrequest.cs" id="Snippet3":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/BeginGetRequestStream/webrequest_begingetrequest.vb" id="Snippet3":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">If the property is not overridden in a descendant class, any attempt is made to get or set the property.</exception>
         <block subset="none" type="overrides">
@@ -2192,16 +1904,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- With the exception of the first request, the <xref:System.Net.WebRequest.PreAuthenticate> property indicates whether to send authentication information with subsequent requests without waiting to be challenged by the server. When <xref:System.Net.WebRequest.PreAuthenticate*> is `false`, the <xref:System.Net.WebRequest> waits for an authentication challenge before sending authentication information.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to get or set the property, when the property is not overridden in a descendant class.</exception>
         <altmember cref="P:System.Net.HttpWebRequest.PreAuthenticate" />
@@ -2257,24 +1962,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.Proxy> property identifies the network proxy that the request uses to access the Internet resource. The request is made through the proxy server rather than directly to the Internet resource.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-
-
-## Examples
- The following example displays the current network proxy address and allows the user to assign a new network proxy address and port number.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/Proxy/webrequest_proxy.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/Proxy/webrequest_proxy.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to get or set the property, when the property is not overridden in a descendant class.</exception>
         <altmember cref="T:System.Net.IWebProxy" />
@@ -2332,30 +2022,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.RegisterPrefix*> method registers <xref:System.Net.WebRequest> descendants to service requests. <xref:System.Net.WebRequest> descendants are typically registered to handle a specific protocol, such HTTP or FTP, but can be registered to handle a request to a specific server or path on a server.
-
- The pre-registered reserve types already registered include the following:
-
--   `http://`
-
--   `https://`
-
--   `ftp://`
-
--   `file://`
-
- For more information, see the <xref:System.Net.WebRequest.Create(System.String)> and <xref:System.Net.WebRequest.Create(System.Uri)> methods.
-
- Duplicate prefixes are not allowed. <xref:System.Net.WebRequest.RegisterPrefix*> returns `false` if an attempt is made to register a duplicate prefix.
-
-> [!NOTE]
-> The <xref:System.Net.HttpWebRequest> class is registered to service requests for HTTP and HTTPS schemes by default. Attempts to register a different <xref:System.Net.WebRequest> descendant for these schemes will fail.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="prefix" /> is <see langword="null" />
@@ -2411,24 +2080,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- When overridden in a descendant class, the <xref:System.Net.WebRequest.RequestUri> property contains the <xref:System.Uri> instance that <xref:System.Net.WebRequest.Create*> method uses to create the request.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-
-
-## Examples
- The following example checks the <xref:System.Net.WebRequest.RequestUri> property to determine the site originally requested.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/RequestUri/webrequest_requesturi.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/RequestUri/webrequest_requesturi.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to get or set the property, when the property is not overridden in a descendant class.</exception>
         <block subset="none" type="overrides">
@@ -2538,24 +2192,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- The <xref:System.Net.WebRequest.Timeout> property indicates the length of time, in milliseconds, until the request times out and throws a <xref:System.Net.WebException>. The <xref:System.Net.WebRequest.Timeout> property affects only synchronous requests made with the <xref:System.Net.WebRequest.GetResponse*> method. To time out asynchronous requests, use the <xref:System.Net.WebRequest.Abort*> method.
-
-> [!NOTE]
-> The <xref:System.Net.WebRequest> class is an `abstract` class. The actual behavior of <xref:System.Net.WebRequest> instances at run time is determined by the descendant class returned by the <xref:System.Net.WebRequest.Create*?displayProperty=nameWithType> method. For more information about default values and exceptions, see the documentation for the descendant classes, such as <xref:System.Net.HttpWebRequest> and <xref:System.Net.FileWebRequest>.
-
-
-
-## Examples
- The following example sets the <xref:System.Net.WebRequest.Timeout> property to 10000 milliseconds. If the timeout period expires before the resource can be returned, a <xref:System.Net.WebException> is thrown.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/GetResponse/webrequest_timeout.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Net/WebRequest/GetResponse/webrequest_timeout.vb" id="Snippet1":::
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.NotImplementedException">Any attempt is made to get or set the property, when the property is not overridden in a descendant class.</exception>
         <block subset="none" type="overrides">
@@ -2607,13 +2246,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE [obsolete-notice](~/includes/web-request-obsolete.md)]
 
- Set this property to `true` when requests made by this <xref:System.Net.WebRequest> object should, if requested by the server, be authenticated using the credentials of the currently logged on user. For client applications, this is the desired behavior in most scenarios. For middle tier applications, such as ASP.NET applications, instead of using this property, you would typically set the <xref:System.Net.WebRequest.Credentials> property to the credentials of the client on whose behalf the request is made.
-
- ]]></format>
+]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">You attempted to set this property after the request was sent.</exception>
         <exception cref="T:System.NotImplementedException">Any attempt is made to access the property, when the property is not overridden in a descendant class.</exception>

--- a/xml/System.Net/WebResponse.xml
+++ b/xml/System.Net/WebResponse.xml
@@ -513,9 +513,6 @@
 
  When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.WebResponse> references. This method invokes the `Dispose()` method of each referenced object.
 
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -922,17 +919,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates if headers are supported.</summary>
-        <value>Returns <see cref="T:System.Boolean" />.
-
- <see langword="true" /> if headers are supported; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property is always true for .NET Framework 4.5.
-
- ]]></format>
-        </remarks>
+        <value><see langword="true" /> if headers are supported; otherwise, <see langword="false" />.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Runtime.Serialization.ISerializable.GetObjectData">

--- a/xml/System.Net/WriteStreamClosedEventArgs.xml
+++ b/xml/System.Net/WriteStreamClosedEventArgs.xml
@@ -73,8 +73,8 @@
           <AttributeName Language="F#">[&lt;System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)&gt;]</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName Language="C#">[System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]</AttributeName>
-          <AttributeName Language="F#">[&lt;System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)&gt;]</AttributeName>
+          <AttributeName Language="C#">[System.Obsolete("This API supports the .NET infrastructure and is not intended to be used directly from your code.", true)]</AttributeName>
+          <AttributeName Language="F#">[&lt;System.Obsolete("This API supports the .NET infrastructure and is not intended to be used directly from your code.", true)&gt;]</AttributeName>
         </Attribute>
       </Attributes>
       <Parameters />
@@ -116,8 +116,8 @@
           <AttributeName Language="F#">[&lt;System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)&gt;]</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName Language="C#">[System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)]</AttributeName>
-          <AttributeName Language="F#">[&lt;System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.", true)&gt;]</AttributeName>
+          <AttributeName Language="C#">[System.Obsolete("This API supports the .NET infrastructure and is not intended to be used directly from your code.", true)]</AttributeName>
+          <AttributeName Language="F#">[&lt;System.Obsolete("This API supports the .NET infrastructure and is not intended to be used directly from your code.", true)&gt;]</AttributeName>
         </Attribute>
       </Attributes>
       <ReturnValue>


### PR DESCRIPTION
.NET Framework API ref has moved to its own repo (https://github.com/dotnet/dotnetfw-api-docs), so we can clean up .NET Framework remarks, exceptions, and code examples out of this repo. Contributes to #12513.

Removes remarks and examples related to:

- .NET Framework versions
- Code-access security
- Configuring apps via app.config file
- App domains

Also remarks *all* remarks from obsolete APIs.

*Hide whitespace changes*