### PR TITLE
Remove .NET Framework remarks (System.Net.*)

### DIFF
--- a/xml/System.Net.Cache/HttpCacheAgeControl.xml
+++ b/xml/System.Net.Cache/HttpCacheAgeControl.xml
@@ -300,7 +300,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>For internal use only.An <see cref="T:System.ArgumentException" /> is thrown if you try to use this member.</summary>
+        <summary>For internal use only. An <see cref="T:System.ArgumentException" /> is thrown if you try to use this member.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Net.Cache/HttpCacheAgeControl.xml
+++ b/xml/System.Net.Cache/HttpCacheAgeControl.xml
@@ -53,7 +53,7 @@
 
 ## Examples
  The following code example creates a policy based on MaxAgeAndMinFresh.
-  
+
  :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/CachePolicy/example.cs" id="Snippet9":::
 
  ]]></format>
@@ -300,7 +300,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>For internal use only. The Framework will throw an <see cref="T:System.ArgumentException" /> if you try to use this member.</summary>
+        <summary>For internal use only.An <see cref="T:System.ArgumentException" /> is thrown if you try to use this member.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Net.Cache/HttpRequestCacheLevel.xml
+++ b/xml/System.Net.Cache/HttpRequestCacheLevel.xml
@@ -49,25 +49,15 @@
 ## Remarks
  This enumeration is used to set the cache level specified by <xref:System.Net.Cache.HttpRequestCachePolicy> objects.
 
- This `BypassCache` value is the default cache behavior specified in the machine configuration file that ships with the .NET Framework. No entries are taken from caches, added to caches, or removed from caches between the client and server.
-
  The <xref:System.Net.HttpWebRequest.DefaultCachePolicy?displayProperty=nameWithType> property is used to get or set the default cache policy for <xref:System.Net.HttpWebRequest> instances. The <xref:System.Net.WebRequest.DefaultCachePolicy?displayProperty=nameWithType> property is used to get or set the default cache policy for a <xref:System.Net.WebRequest> instance. The <xref:System.Net.WebRequest.CachePolicy> property is used to get or set the cache policy for a specific request.
 
  A copy of a resource is only added to the cache if the response stream for the resource is retrieved and read to the end of the stream. So another request for the same resource could use a cached copy, depending on the default cache policy level for this request.
-
-
-
-## Examples
- The following code example sets the application domain's caching policy to Default.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/CachePolicy/example.cs" id="Snippet2":::
 
  ]]></format>
     </remarks>
     <altmember cref="P:System.Net.HttpWebRequest.DefaultCachePolicy" />
     <altmember cref="P:System.Net.WebRequest.CachePolicy" />
     <related type="Article" href="/dotnet/framework/network-programming/cache-management-for-network-applications">Cache Management for Network Applications</related>
-    <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/requestcaching-element-network-settings">RequestCaching Element (Network Settings)</related>
   </Docs>
   <Members>
     <Member MemberName="BypassCache">
@@ -107,7 +97,7 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>Satisfies a request by using the server. No entries are taken from caches, added to caches, or removed from caches between the client and server. No entries are taken from caches, added to caches, or removed from caches between the client and server. This is the default cache behavior specified in the machine configuration file that ships with the .NET Framework.</summary>
+        <summary>Satisfies a request by using the server. No entries are taken from caches, added to caches, or removed from caches between the client and server. No entries are taken from caches, added to caches, or removed from caches between the client and server.</summary>
       </Docs>
     </Member>
     <Member MemberName="CacheIfAvailable">

--- a/xml/System.Net.Cache/HttpRequestCacheLevel.xml
+++ b/xml/System.Net.Cache/HttpRequestCacheLevel.xml
@@ -97,7 +97,7 @@
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>Satisfies a request by using the server. No entries are taken from caches, added to caches, or removed from caches between the client and server. No entries are taken from caches, added to caches, or removed from caches between the client and server.</summary>
+        <summary>Satisfies a request by using the server. No entries are taken from caches, added to caches, or removed from caches between the client and server.</summary>
       </Docs>
     </Member>
     <Member MemberName="CacheIfAvailable">

--- a/xml/System.Net.Cache/HttpRequestCachePolicy.xml
+++ b/xml/System.Net.Cache/HttpRequestCachePolicy.xml
@@ -48,18 +48,11 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- You can specify a default cache policy for your application by using the <xref:System.Net.HttpWebRequest.DefaultCachePolicy> property or the application or machine configuration files. For more information, see [&lt;requestCaching&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/requestcaching-element-network-settings).
+ You can specify a default cache policy for your application by using the <xref:System.Net.HttpWebRequest.DefaultCachePolicy> property.
 
  You can specify the cache policy for an individual request by using the <xref:System.Net.WebRequest.CachePolicy> property.
 
  Caching for Web services is not supported.
-
-
-
-## Examples
- The following code example creates a default cache policy for the application domain, and overrides it for a request.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/CachePolicy/example.cs" id="Snippet2":::
 
  ]]></format>
     </remarks>
@@ -527,14 +520,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Applications typically use <xref:System.Net.Cache.HttpRequestCacheLevel.Default> as their cache policy level. The <xref:System.Net.WebRequest.CachePolicy> property, if not `null`, determines the cache policy in effect for a request. The default policy for the application domain can be set using the <xref:System.Net.HttpWebRequest.DefaultCachePolicy> property or by settings in the machine or application configuration files. For more information, see [&lt;requestCaching&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/requestcaching-element-network-settings).
-
-
-
-## Examples
- The following code example demonstrates displaying the value of this property.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/CachePolicy/example.cs" id="Snippet11":::
+ Applications typically use <xref:System.Net.Cache.HttpRequestCacheLevel.Default> as their cache policy level. The <xref:System.Net.WebRequest.CachePolicy> property, if not `null`, determines the cache policy in effect for a request. The default policy can be set using the <xref:System.Net.HttpWebRequest.DefaultCachePolicy> property.
 
  ]]></format>
         </remarks>

--- a/xml/System.Net.Cache/RequestCacheLevel.xml
+++ b/xml/System.Net.Cache/RequestCacheLevel.xml
@@ -49,8 +49,6 @@
 ## Remarks
  Members of this enumeration are used to initialize <xref:System.Net.Cache.RequestCachePolicy> objects. The current setting for a <xref:System.Net.Cache.RequestCachePolicy> object is available in the <xref:System.Net.Cache.HttpRequestCachePolicy.Level?displayProperty=nameWithType> property.
 
- This <xref:System.Net.Cache.HttpRequestCacheLevel.BypassCache> value is the default cache behavior specified in the machine configuration file that ships with the .NET Framework. No entries are taken from caches, added to caches, or removed from caches between the client and server.
-
  The <xref:System.Net.HttpWebRequest.DefaultCachePolicy?displayProperty=nameWithType> property is used to get or set the default cache policy for <xref:System.Net.HttpWebRequest> instances. The <xref:System.Net.WebRequest.CachePolicy?displayProperty=nameWithType> property is used to get or set the default cache policy for a <xref:System.Net.WebRequest> instances. The <xref:System.Net.WebRequest.CachePolicy?displayProperty=nameWithType> property is used to get or set the cache policy for a specific request.
 
 If the cache behavior is `CacheIfAvailable` or `Revalidate`, a copy of a requested resource is only added to the cache if the response stream for the resource is retrieved and read to the end of the stream. With `CacheIfAvailable`, subsequent requests for the same resource would use a cached copy. With `Revalidate`, subsequent requests for the same resource would use a cached copy if the timestamp for the cached resource is the same as the timestamp of the resource on the server.
@@ -67,7 +65,6 @@ A copy of a resource is only added to the cache if the response stream for the r
     <altmember cref="P:System.Net.HttpWebRequest.DefaultCachePolicy" />
     <altmember cref="P:System.Net.WebRequest.CachePolicy" />
     <related type="Article" href="/dotnet/framework/network-programming/cache-management-for-network-applications">Cache Management for Network Applications</related>
-    <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/requestcaching-element-network-settings">RequestCaching Element (Network Settings)</related>
   </Docs>
   <Members>
     <Member MemberName="BypassCache">
@@ -107,7 +104,7 @@ A copy of a resource is only added to the cache if the response stream for the r
       </ReturnValue>
       <MemberValue>1</MemberValue>
       <Docs>
-        <summary>Satisfies a request by using the server. No entries are taken from caches, added to caches, or removed from caches between the client and server. This is the default cache behavior specified in the machine configuration file that ships with the .NET Framework.</summary>
+        <summary>Satisfies a request by using the server. No entries are taken from caches, added to caches, or removed from caches between the client and server.</summary>
       </Docs>
     </Member>
     <Member MemberName="CacheIfAvailable">

--- a/xml/System.Net.Cache/RequestCachePolicy.xml
+++ b/xml/System.Net.Cache/RequestCachePolicy.xml
@@ -48,13 +48,11 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- You can specify a default cache policy for your application by using the <xref:System.Net.HttpWebRequest.DefaultCachePolicy> property or the application or machine configuration files. For more information, see [&lt;requestCaching&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/requestcaching-element-network-settings).
+ You can specify a default cache policy for your application by using the <xref:System.Net.HttpWebRequest.DefaultCachePolicy> property.
 
  You can specify the cache policy for an individual request by using the <xref:System.Net.WebRequest.CachePolicy> property.
 
  Caching for Web services is not supported.
-
-
 
 ## Examples
  The following code example creates a policy with <xref:System.Net.Cache.RequestCachePolicy.Level*> set to <xref:System.Net.Cache.RequestCacheLevel.CacheOnly>, and uses it to set the cache policy of a <xref:System.Net.WebRequest>.
@@ -231,14 +229,7 @@
 ## Remarks
  Applications typically use <xref:System.Net.Cache.RequestCacheLevel.Default> as their cache policy level. Using the <xref:System.Net.Cache.RequestCacheLevel.Default> level, the effective cache policy is determined by the current cache policy and the age of the content in the cache. The <xref:System.Net.WebRequest.CachePolicy?displayProperty=nameWithType> property, if not `null`, determines the cache policy in effect for a request.
 
- The default policy for the application domain can be set using the <xref:System.Net.HttpWebRequest.DefaultCachePolicy*> or the application or machine configuration file. For more information, see [&lt;requestCaching&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/requestcaching-element-network-settings).
-
-
-
-## Examples
- The following code example creates a <xref:System.Net.Cache.RequestCacheLevel.CacheOnly> policy and sends a request.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net/WebRequest/CachePolicy/example.cs" id="Snippet13":::
+You can set the default policy using the <xref:System.Net.HttpWebRequest.DefaultCachePolicy> property.
 
  ]]></format>
         </remarks>

--- a/xml/System.Net.Http/HttpClient.xml
+++ b/xml/System.Net.Http/HttpClient.xml
@@ -589,7 +589,8 @@ This property has no effect on any of the <xref:System.Net.Http.HttpClient.Send*
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The request message was already sent by the <see cref="T:System.Net.Http.HttpClient" /> instance.
@@ -658,7 +659,8 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The request message was already sent by the <see cref="T:System.Net.Http.HttpClient" /> instance.
@@ -733,7 +735,8 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The request message was already sent by the <see cref="T:System.Net.Http.HttpClient" /> instance.
@@ -808,7 +811,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The request message was already sent by the <see cref="T:System.Net.Http.HttpClient" /> instance.
@@ -956,7 +960,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read. The behavior is the same as if <xref:System.Net.Http.HttpCompletionOption.ResponseContentRead> has been explicitly specified.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1018,7 +1023,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read. The behavior is the same as if <xref:System.Net.Http.HttpCompletionOption.ResponseContentRead> has been explicitly specified.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1085,7 +1091,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete based on the `completionOption` parameter after the part or all of the response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1153,7 +1160,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read. The behavior is the same as if <xref:System.Net.Http.HttpCompletionOption.ResponseContentRead> has been explicitly specified.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1221,7 +1229,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete based on the `completionOption` parameter after the part or all of the response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1284,7 +1293,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read. The behavior is the same as if <xref:System.Net.Http.HttpCompletionOption.ResponseContentRead> has been explicitly specified.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1357,7 +1367,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete based on the `completionOption` parameter after the part or all of the response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1427,7 +1438,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete based on the `completionOption` parameter after the part or all of the response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1517,7 +1529,8 @@ The request failed due to timeout.</exception>
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1812,7 +1825,8 @@ The request failed due to timeout.</exception>
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of a timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1880,7 +1894,8 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of a timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1945,7 +1960,8 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout: an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of a timeout: an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
@@ -2011,7 +2027,8 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="requestUri" /> is <see langword="null" />.</exception>
@@ -2105,7 +2122,8 @@ The request failed due to timeout.</exception>
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -2173,7 +2191,8 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -2238,7 +2257,8 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="requestUri" /> is <see langword="null" />.</exception>
@@ -2304,7 +2324,8 @@ The request failed due to timeout.</exception>
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="requestUri" /> is <see langword="null" />.</exception>
@@ -2699,7 +2720,8 @@ The size specified is greater than the maximum allowed buffer size.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -2763,7 +2785,8 @@ The size specified is greater than the maximum allowed buffer size.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -2835,7 +2858,8 @@ The size specified is greater than the maximum allowed buffer size.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -2905,7 +2929,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -2998,7 +3023,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -3062,7 +3088,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -3134,7 +3161,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -3204,7 +3232,8 @@ The request failed due to timeout.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown. (On .NET Core versions, <xref:System.OperationCanceledException> without any inner exception is thrown.)
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>

--- a/xml/System.Net.Http/HttpClient.xml
+++ b/xml/System.Net.Http/HttpClient.xml
@@ -589,11 +589,7 @@ This property has no effect on any of the <xref:System.Net.Http.HttpClient.Send*
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations:
->
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The request message was already sent by the <see cref="T:System.Net.Http.HttpClient" /> instance.
@@ -605,12 +601,8 @@ The <paramref name="requestUri" /> is not an absolute URI.
 -or-
 
 <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> is not set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />.
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />.</exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="DeleteAsync">
@@ -666,11 +658,7 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations:
->
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The request message was already sent by the <see cref="T:System.Net.Http.HttpClient" /> instance.
@@ -682,12 +670,8 @@ The <paramref name="requestUri" /> is not an absolute URI.
 -or-
 
 <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> is not set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: the request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="DeleteAsync">
@@ -749,11 +733,7 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
->
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The request message was already sent by the <see cref="T:System.Net.Http.HttpClient" /> instance.
@@ -765,16 +745,12 @@ The <paramref name="requestUri" /> is not an absolute URI.
 -or-
 
 <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> is not set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: the request timed out.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="DeleteAsync">
@@ -832,11 +808,7 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The request message was already sent by the <see cref="T:System.Net.Http.HttpClient" /> instance.
@@ -848,16 +820,12 @@ The <paramref name="requestUri" /> is not an absolute URI.
 -or-
 
 <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> is not set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: the request timed out.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="Dispose">
@@ -988,19 +956,12 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read. The behavior is the same as if <xref:System.Net.Http.HttpCompletionOption.ResponseContentRead> has been explicitly specified.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: the request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
         <exception cref="T:System.UriFormatException">The provided request URI is not valid relative or absolute URI.</exception>
       </Docs>
     </Member>
@@ -1057,19 +1018,12 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read. The behavior is the same as if <xref:System.Net.Http.HttpCompletionOption.ResponseContentRead> has been explicitly specified.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: the request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetAsync">
@@ -1131,15 +1085,12 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete based on the `completionOption` parameter after the part or all of the response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
         <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or timeout.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
         <exception cref="T:System.UriFormatException">The provided request URI is not valid relative or absolute URI.</exception>
       </Docs>
     </Member>
@@ -1202,24 +1153,17 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read. The behavior is the same as if <xref:System.Net.Http.HttpCompletionOption.ResponseContentRead> has been explicitly specified.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: the request timed out.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
         <exception cref="T:System.UriFormatException">The provided request URI is not valid relative or absolute URI.</exception>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetAsync">
@@ -1277,19 +1221,12 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete based on the `completionOption` parameter after the part or all of the response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: the request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetAsync">
@@ -1347,23 +1284,16 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read. The behavior is the same as if <xref:System.Net.Http.HttpCompletionOption.ResponseContentRead> has been explicitly specified.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">TThe request failed due to an issue getting an HTTP response such as network connectivity, DNS failure or server certificate validation. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: the request timed out.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">TThe request failed due to an issue getting an HTTP response such as network connectivity, DNS failure or server certificate validation. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetAsync">
@@ -1427,24 +1357,17 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete based on the `completionOption` parameter after the part or all of the response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: the request timed out.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
         <exception cref="T:System.UriFormatException">The provided request URI is not valid relative or absolute URI.</exception>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetAsync">
@@ -1504,23 +1427,16 @@ The <paramref name="requestUri" /> is not an absolute URI.
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete based on the `completionOption` parameter after the part or all of the response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: the request timed out.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="GetByteArrayAsync">
@@ -1601,10 +1517,7 @@ The <paramref name="requestUri" /> is not an absolute URI.
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1612,12 +1525,8 @@ In some scenarios, you might need more control over which status codes are consi
 
 -or-
 
-The response status code was outside of the range of 200-299 (which indicate success according to the standard).
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The response status code was outside of the range of 200-299 (which indicate success according to the standard).</exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
         <exception cref="T:System.UriFormatException">The provided request URI is not valid relative or absolute URI.</exception>
       </Docs>
     </Member>
@@ -1676,10 +1585,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout:
-> - .NET Framework throws a <xref:System.Net.Http.HttpRequestException>.
-> - .NET Core throws a <xref:System.OperationCanceledException> without any inner exception.
-> - .NET 5 and later versions throw a <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException>.
+> In case of a timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
 
           ]]></format>
         </remarks>
@@ -1688,12 +1594,8 @@ In some scenarios, you might need more control over which status codes are consi
 
 -or-
 
-The response status code was outside of the range of 200-299 (which indicate success according to the standard).
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The response status code was outside of the range of 200-299 (which indicate success according to the standard).</exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetByteArrayAsync">
@@ -1749,10 +1651,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout:
-> - .NET Framework throws a <xref:System.Net.Http.HttpRequestException>.
-> - .NET Core throws a <xref:System.OperationCanceledException> without any inner exception.
-> - .NET 5 and later versions throw a <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException>.
+> In case of a timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
 
           ]]></format>
         </remarks>
@@ -1766,7 +1665,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetByteArrayAsync">
@@ -1818,10 +1717,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout:
-> - .NET Framework throws a <xref:System.Net.Http.HttpRequestException>.
-> - .NET Core throws a <xref:System.OperationCanceledException> without any inner exception.
-> - .NET 5 and later versions throw a <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException>.
+> In case of a timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
 
           ]]></format>
         </remarks>
@@ -1835,7 +1731,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="GetStreamAsync">
@@ -1916,10 +1812,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout:
-> - .NET Framework throws a <xref:System.Net.Http.HttpRequestException>.
-> - .NET Core throws a <xref:System.OperationCanceledException> without any inner exception.
-> - .NET 5 and later versions throw a <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException>.
+> In case of a timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -1927,12 +1820,8 @@ In some scenarios, you might need more control over which status codes are consi
 
 -or-
 
-The response status code was outside of the range of 200-299 (which indicate success according to the standard).
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The response status code was outside of the range of 200-299 (which indicate success according to the standard).</exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
         <exception cref="T:System.UriFormatException">The provided request URI is not valid relative or absolute URI.</exception>
       </Docs>
     </Member>
@@ -1991,10 +1880,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout:
-> - .NET Framework throws a <xref:System.Net.Http.HttpRequestException>.
-> - .NET Core throws a <xref:System.OperationCanceledException> without any inner exception.
-> - .NET 5 and later versions throw a <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException>.
+> In case of a timeout, <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -2002,12 +1888,8 @@ In some scenarios, you might need more control over which status codes are consi
 
 -or-
 
-The response status code was outside of the range of 200-299 (which indicate success according to the standard).
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The response status code was outside of the range of 200-299 (which indicate success according to the standard).</exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetStreamAsync">
@@ -2063,17 +1945,14 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout:
-> - .NET Framework throws a <xref:System.Net.Http.HttpRequestException>.
-> - .NET Core throws an <xref:System.OperationCanceledException> without any inner exception.
-> - .NET 5 and later versions throw an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException>.
+> In case of a timeout: an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
         <exception cref="T:System.ArgumentNullException">The <paramref name="requestUri" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
 
@@ -2132,10 +2011,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout:
-> - .NET Framework throws a <xref:System.Net.Http.HttpRequestException>.
-> - .NET Core throws a <xref:System.OperationCanceledException> without any inner exception.
-> - .NET 5 and later versions throw a <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException>.
+> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="requestUri" /> is <see langword="null" />.</exception>
@@ -2148,7 +2024,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="GetStringAsync">
@@ -2229,10 +2105,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout:
-> - .NET Framework throws a <xref:System.Net.Http.HttpRequestException>.
-> - .NET Core throws a <xref:System.OperationCanceledException> without any inner exception.
-> - .NET 5 and later versions throw a <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException>.
+> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -2240,12 +2113,8 @@ In some scenarios, you might need more control over which status codes are consi
 
 -or-
 
-The response status code was outside of the range of 200-299 (which indicate success according to the standard).
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The response status code was outside of the range of 200-299 (which indicate success according to the standard).</exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
         <exception cref="T:System.UriFormatException">The provided request URI is not valid relative or absolute URI.</exception>
       </Docs>
     </Member>
@@ -2304,10 +2173,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout:
-> - .NET Framework throws a <xref:System.Net.Http.HttpRequestException>.
-> - .NET Core throws a <xref:System.OperationCanceledException> without any inner exception.
-> - .NET 5 and later versions throw a <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException>.
+> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
@@ -2315,12 +2181,8 @@ In some scenarios, you might need more control over which status codes are consi
 
 -or-
 
-The response status code was outside of the range of 200-299 (which indicate success according to the standard).
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The response status code was outside of the range of 200-299 (which indicate success according to the standard).</exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetStringAsync">
@@ -2376,10 +2238,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout:
-> - .NET Framework throws a <xref:System.Net.Http.HttpRequestException>.
-> - .NET Core throws a <xref:System.OperationCanceledException> without any inner exception.
-> - .NET 5 and later versions throw a <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException>.
+> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="requestUri" /> is <see langword="null" />.</exception>
@@ -2393,7 +2252,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetStringAsync">
@@ -2445,10 +2304,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
 > [!NOTE]
-> In case of a timeout:
-> - .NET Framework throws a <xref:System.Net.Http.HttpRequestException>.
-> - .NET Core throws a <xref:System.OperationCanceledException> without any inner exception.
-> - .NET 5 and later versions throw a <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException>.
+> In case of a timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="requestUri" /> is <see langword="null" />.</exception>
@@ -2461,7 +2317,7 @@ The response status code was outside of the range of 200-299 (which indicate suc
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="MaxResponseContentBufferSize">
@@ -2843,19 +2699,12 @@ The size specified is greater than the maximum allowed buffer size.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
         <exception cref="T:System.UriFormatException">The provided request URI is not valid relative or absolute URI.</exception>
       </Docs>
     </Member>
@@ -2914,19 +2763,12 @@ The size specified is greater than the maximum allowed buffer size.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="PostAsync">
@@ -2993,24 +2835,17 @@ The size specified is greater than the maximum allowed buffer size.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: The request timed out.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
         <exception cref="T:System.UriFormatException">The provided request URI is not valid relative or absolute URI.</exception>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="PostAsync">
@@ -3070,23 +2905,16 @@ The size specified is greater than the maximum allowed buffer size.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: The request timed out.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="PutAsync">
@@ -3170,19 +2998,12 @@ The size specified is greater than the maximum allowed buffer size.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
         <exception cref="T:System.UriFormatException">The provided request URI is not valid relative or absolute URI.</exception>
       </Docs>
     </Member>
@@ -3241,19 +3062,12 @@ The size specified is greater than the maximum allowed buffer size.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="PutAsync">
@@ -3320,24 +3134,17 @@ The size specified is greater than the maximum allowed buffer size.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: The request timed out.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
         <exception cref="T:System.UriFormatException">The provided request URI is not valid relative or absolute URI.</exception>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="PutAsync">
@@ -3397,23 +3204,16 @@ The size specified is greater than the maximum allowed buffer size.</exception>
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the whole response (including content) is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The <paramref name="requestUri" /> is not an absolute URI and <see cref="P:System.Net.Http.HttpClient.BaseAddress" /> isn't set.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: The request timed out.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="Send">
@@ -3618,7 +3418,7 @@ The custom <see cref="T:System.Net.Http.HttpMessageHandler" /> does not override
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="Send">
@@ -3691,7 +3491,7 @@ The custom <see cref="T:System.Net.Http.HttpMessageHandler" /> does not override
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="SendAsync">
@@ -3758,10 +3558,7 @@ The custom <see cref="T:System.Net.Http.HttpMessageHandler" /> does not override
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete once the entire response including content is read. The behavior is the same as if <xref:System.Net.Http.HttpCompletionOption.ResponseContentRead> has been explicitly specified.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
 
 This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Http.HttpClient.Send(System.Net.Http.HttpRequestMessage)>.
 
@@ -3769,12 +3566,8 @@ This method stores in the task it returns all non-usage exceptions that the meth
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="request" /> is <see langword="null" />.</exception>
         <exception cref="T:System.InvalidOperationException">The request message was already sent by the <see cref="T:System.Net.Http.HttpClient" /> instance.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendAsync">
@@ -3824,10 +3617,7 @@ This method stores in the task it returns all non-usage exceptions that the meth
  This operation doesn't block. Depending on the value of the `completionOption` parameter, the returned <xref:System.Threading.Tasks.Task`1> object will complete as soon as a response is available or the entire response including content is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
 
 This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Http.HttpClient.Send(System.Net.Http.HttpRequestMessage,System.Net.Http.HttpCompletionOption)>.
 
@@ -3835,12 +3625,8 @@ This method stores in the task it returns all non-usage exceptions that the meth
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="request" /> is <see langword="null" />.</exception>
         <exception cref="T:System.InvalidOperationException">The request message was already sent by the <see cref="T:System.Net.Http.HttpClient" /> instance.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: The request timed out.</exception>
-        <exception cref="T:System.OperationCanceledException">.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
+        <exception cref="T:System.OperationCanceledException">The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendAsync">
@@ -3890,10 +3676,7 @@ This method stores in the task it returns all non-usage exceptions that the meth
  This operation doesn't block. The returned <xref:System.Threading.Tasks.Task`1> object will complete once the entire response including content is read. The behavior is the same as if <xref:System.Net.Http.HttpCompletionOption.ResponseContentRead> has been explicitly specified.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
 
 This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Http.HttpClient.Send(System.Net.Http.HttpRequestMessage)>.
 
@@ -3901,16 +3684,12 @@ This method stores in the task it returns all non-usage exceptions that the meth
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="request" /> is <see langword="null" />.</exception>
         <exception cref="T:System.InvalidOperationException">The request message was already sent by the <see cref="T:System.Net.Http.HttpClient" /> instance.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: The request timed out.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendAsync">
@@ -3962,10 +3741,7 @@ This method stores in the task it returns all non-usage exceptions that the meth
  This operation doesn't block. Depending on the value of the `completionOption` parameter, the returned <xref:System.Threading.Tasks.Task`1> object will complete as soon as a response is available or the entire response including content is read.
 
 > [!NOTE]
-> In case of timeout, different exceptions are thrown on different .NET implementations.
-> - <xref:System.Net.Http.HttpRequestException> is thrown on all applicable .NET Framework versions.
-> - <xref:System.OperationCanceledException> without any inner exception is thrown on all applicable .NET Core versions.
-> - <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown on .NET 5 and later versions.
+> In case of timeout, an <xref:System.OperationCanceledException> that nests a <xref:System.TimeoutException> is thrown.
 
 This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Http.HttpClient.Send(System.Net.Http.HttpRequestMessage,System.Net.Http.HttpCompletionOption)>.
 
@@ -3973,16 +3749,12 @@ This method stores in the task it returns all non-usage exceptions that the meth
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="request" /> is <see langword="null" />.</exception>
         <exception cref="T:System.InvalidOperationException">The request message was already sent by the <see cref="T:System.Net.Http.HttpClient" /> instance.</exception>
-        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" />
-
--or-
-
-.NET Framework only: the request timed out.</exception>
+        <exception cref="T:System.Net.Http.HttpRequestException">The request failed due to an issue getting a valid HTTP response, such as network connectivity failure, DNS failure, server certificate validation error, or invalid server response. On .NET 8 and later versions, the reason is indicated by <see cref="P:System.Net.Http.HttpRequestException.HttpRequestError" /></exception>
         <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.
 
 -or-
 
-.NET Core and .NET 5 and later only: The request failed due to timeout.</exception>
+The request failed due to timeout.</exception>
       </Docs>
     </Member>
     <Member MemberName="Timeout">

--- a/xml/System.Net.Http/HttpClientHandler.xml
+++ b/xml/System.Net.Http/HttpClientHandler.xml
@@ -129,15 +129,14 @@
 ## Remarks
  Set <xref:System.Net.Http.HttpClientHandler.AllowAutoRedirect*> to `true` if you want the handler to automatically follow HTTP redirection headers to the new location of the resource. The maximum number of redirections to follow is set by the <xref:System.Net.Http.HttpClientHandler.MaxAutomaticRedirections> property.
 
- If <xref:System.Net.Http.HttpClientHandler.AllowAutoRedirect*> is set to `false`, all HTTP responses with an HTTP status code from 300 to 399 are  returned to the application.
+ If <xref:System.Net.Http.HttpClientHandler.AllowAutoRedirect*> is set to `false`, all HTTP responses with an HTTP status code from 300 to 399 are returned to the application.
 
  The Authorization header is cleared on auto-redirects and the handler automatically tries to re-authenticate to the redirected location. No other headers are cleared. In practice, this means that an application can't put custom authentication information into the Authorization header if it is possible to encounter redirection. Instead, the application must implement and register a custom authentication module.
 
  If you are using cookies by specifically adding them to the <xref:System.Net.Http.HttpRequestMessage.Headers> collection, these are not cleared when a redirect is followed, as the handler has no way of knowing what domain a cookie is allowed for. If you want to mimic browser behavior, use the <xref:System.Net.CookieContainer> class which allows you to specify the target domain for a cookie.
 
 > [!NOTE]
-> On .NET Core and .NET 5 and later versions, setting <xref:System.Net.Http.HttpClientHandler.AllowAutoRedirect> to `true` **does not enable** automatic redirection to an HTTP URI from an HTTPS URI.
-> Such (secure to insecure) redirections are only followed on .NET Framework.
+> Setting <xref:System.Net.Http.HttpClientHandler.AllowAutoRedirect> to `true` **does not enable** automatic redirection to an HTTP URI from an HTTPS URI.
 
  ]]></format>
         </remarks>
@@ -192,9 +191,6 @@
 
  Setting automatic decompression to anything other than <xref:System.Net.DecompressionMethods.None> will result in adding `Accept-Encoding` header with the set values into every outgoing <xref:System.Net.Http.HttpRequestMessage>.
 
-
-For the .NET Framework 4.x `System.Net.Http` binary in the Global Assembly Cache (GAC), the default value is <xref:System.Net.DecompressionMethods.None>.
-
  ]]></format>
         </remarks>
       </Docs>
@@ -241,7 +237,6 @@ For the .NET Framework 4.x `System.Net.Http` binary in the Global Assembly Cache
         <value>
           <see langword="true" /> if the certificate revocation list is checked; otherwise, <see langword="false" />.</value>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.PlatformNotSupportedException">.NET Framework 4.7.1 only: This property is not implemented.</exception>
       </Docs>
     </Member>
     <Member MemberName="ClientCertificateOptions">
@@ -330,7 +325,7 @@ For the .NET Framework 4.x `System.Net.Http` binary in the Global Assembly Cache
 
 ## Remarks
 
-On .NET Core, the key usage attribute on the X509 certificate, if present, is required to have the value "Digital Signature" in order to be used when sending the request.
+The key usage attribute on the X509 certificate, if present, is required to have the value "Digital Signature" in order to be used when sending the request.
 
  ]]></format>
         </remarks>
@@ -1210,7 +1205,6 @@ handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousA
         <summary>Gets or sets the TLS/SSL protocols used by the <see cref="T:System.Net.Http.HttpClient" /> objects managed by the HttpClientHandler object.</summary>
         <value>A bitwise combination of the enumeration values that specify the TLS/SSL protocols.</value>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.PlatformNotSupportedException">.NET Framework 4.7.1 only: This property is not implemented.</exception>
       </Docs>
     </Member>
     <Member MemberName="SupportsAutomaticDecompression">

--- a/xml/System.Net.Http/HttpResponseMessage.xml
+++ b/xml/System.Net.Http/HttpResponseMessage.xml
@@ -354,10 +354,8 @@ When the `disposing` parameter is `true`, this method releases all resources hel
 
 ## Remarks
  The <xref:System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode*> method throws an <xref:System.Net.Http.HttpRequestException> if <xref:System.Net.Http.HttpResponseMessage.StatusCode> is outside of the range 200-299 (the range of status codes indicating success according to the standard).
- 
- In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
- In .NET Framework, if the <xref:System.Net.Http.HttpResponseMessage.Content*> is not `null`, this method also calls <xref:System.Net.Http.HttpResponseMessage.Dispose*> to free managed and unmanaged resources. Starting with .NET Core 3.0, the content is not disposed.
+ In some scenarios, you might need more control over which status codes are considered to be successful; for example, an API might be expected to always return `200 OK`. In such cases, we recommend to manually check if <xref:System.Net.Http.HttpResponseMessage.StatusCode> matches the expected value.
 
  ]]></format>
         </remarks>

--- a/xml/System.Net.Http/SocketsHttpHandler.xml
+++ b/xml/System.Net.Http/SocketsHttpHandler.xml
@@ -949,7 +949,7 @@ For example, if the value is 64, then 65,536 bytes are allowed for the maximum r
       </ReturnValue>
       <Docs>
         <summary>Gets or sets how long a connection can be idle in the pool to be considered reusable.</summary>
-        <value>The maximum idle time for a connection in the pool. The default value is 1 minute.</value>
+        <value>The maximum idle time for a connection in the pool. The default value for this property is 1 minute in .NET 6 and later versions; the default value is 2 minutes in .NET Core and .NET 5.</value>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The value specified is less than <see cref="F:System.TimeSpan.Zero" /> and is not <see cref="F:System.Threading.Timeout.InfiniteTimeSpan" />.</exception>
         <exception cref="T:System.InvalidOperationException">An operation has already been started on the current instance.</exception>

--- a/xml/System.Net.Http/SocketsHttpHandler.xml
+++ b/xml/System.Net.Http/SocketsHttpHandler.xml
@@ -949,7 +949,7 @@ For example, if the value is 64, then 65,536 bytes are allowed for the maximum r
       </ReturnValue>
       <Docs>
         <summary>Gets or sets how long a connection can be idle in the pool to be considered reusable.</summary>
-        <value>The maximum idle time for a connection in the pool. The default value for this property is 1 minute in .NET 6 and later versions; the default value is 2 minutes in .NET Core and .NET 5</value>
+        <value>The maximum idle time for a connection in the pool. The default value is 1 minute.</value>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The value specified is less than <see cref="F:System.TimeSpan.Zero" /> and is not <see cref="F:System.Threading.Timeout.InfiniteTimeSpan" />.</exception>
         <exception cref="T:System.InvalidOperationException">An operation has already been started on the current instance.</exception>

--- a/xml/System.Net.Http/WinHttpHandler.xml
+++ b/xml/System.Net.Http/WinHttpHandler.xml
@@ -60,8 +60,7 @@ Starting in .NET 5, <xref:System.Net.Http.WinHttpHandler> is no longer included 
 
 Starting with version 6.0.0, <xref:System.Net.Http.WinHttpHandler> supports trailing headers, also known as trailers ([RFC 7230 - 4.1.2. Chunked Trailer Part](https://tools.ietf.org/html/rfc7230#section-4.1.2)).
 
-- On .NET Standard 2.1 and .NET 8 or later, trailers are added to <xref:System.Net.Http.HttpResponseMessage.TrailingHeaders>.
-- On .NET Framework, trailers are added to a well-known property in <xref:System.Net.Http.HttpRequestMessage.Properties?displayProperty=nameWithType> on the request object corresponding to the response (<xref:System.Net.Http.HttpResponseMessage.RequestMessage?displayProperty=nameWithType>). The name of the property is `__ResponseTrailers`, the type of the property value is <xref:System.Net.Http.Headers.HttpHeaders>.
+Trailers are added to <xref:System.Net.Http.HttpResponseMessage.TrailingHeaders>.
 
 Trailer support is implemented via the `WINHTTP_QUERY_FLAG_TRAILERS` [Query Info Flag](/windows/win32/winhttp/query-info-flags) which has been introduced in Windows 11, version 21H2 (10.0; Build 22000). On Windows systems where `WINHTTP_QUERY_FLAG_TRAILERS` is unsupported, trailers are ignored.
 

--- a/xml/System.Net.Mail/MailMessage.xml
+++ b/xml/System.Net.Mail/MailMessage.xml
@@ -162,14 +162,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes an empty instance of the <see cref="T:System.Net.Mail.MailMessage" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- From is set to the value in the network element for mailSettings[&lt;smtp&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings), if it exists.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -691,9 +684,7 @@
 ## Remarks
  The value specified for the <xref:System.Net.Mail.MailMessage.BodyEncoding> property sets the character set field in the Content-Type header. The default character set is `"us-ascii"`.
 
- If you set the <xref:System.Net.Mail.MailMessage.BodyEncoding> property to <xref:System.Text.Encoding.UTF8*>, <xref:System.Text.Encoding.Unicode*>, or <xref:System.Text.Encoding.UTF32*>, the Framework selects a <xref:System.Net.Mime.TransferEncoding> of <xref:System.Net.Mime.TransferEncoding.Base64> for this <xref:System.Net.Mail.MailMessage>.
-
-
+ If you set the <xref:System.Net.Mail.MailMessage.BodyEncoding> property to <xref:System.Text.Encoding.UTF8*>, <xref:System.Text.Encoding.Unicode*>, or <xref:System.Text.Encoding.UTF32*>, .NET selects a <xref:System.Net.Mime.TransferEncoding> of <xref:System.Net.Mime.TransferEncoding.Base64> for this <xref:System.Net.Mail.MailMessage>.
 
 ## Examples
  The following code example demonstrates creating a mail message that uses UTF8 encoding.

--- a/xml/System.Net.Mail/SmtpAccess.xml
+++ b/xml/System.Net.Mail/SmtpAccess.xml
@@ -36,21 +36,7 @@
   </Base>
   <Docs>
     <summary>Specifies the level of access allowed to a Simple Mail Transport Protocol (SMTP) server.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.Mail.SmtpAccess> enumeration is used by the <xref:System.Net.Mail.SmtpPermission> and <xref:System.Net.Mail.SmtpPermissionAttribute> classes to specify a level of access to an SMTP host computer. The <xref:System.Net.Mail.SmtpClient> class demands an <xref:System.Net.Mail.SmtpPermission> when sending electronic mail to the SMTP host for delivery.
-
-
-
-## Examples
- The following code example uses the <xref:System.Net.Mail.SmtpAccess> enumeration to create a permission object.
-  
- :::code language="csharp" source="~/snippets/csharp/System.Net.Mail/SmtpAccess/Overview/mailpermissions.cs" id="Snippet1":::
-
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="Connect">

--- a/xml/System.Net.Mail/SmtpClient.xml
+++ b/xml/System.Net.Mail/SmtpClient.xml
@@ -66,12 +66,6 @@ The `SmtpClient` class is used to send email to an SMTP server for delivery. The
 > [!IMPORTANT]
 > We don't recommend that you use the `SmtpClient` class for new development because `SmtpClient` doesn't support many modern protocols. Use [MailKit](https://github.com/jstedfast/MailKit) or other libraries instead. For more information, see [SmtpClient shouldn't be used](https://github.com/dotnet/platform-compat/blob/master/docs/DE0005.md).
 
-The `SmtpClient` class is:
-
-- Included in .NET Standard 2.0 and later versions and therefore must be part of any .NET implementation that supports those versions.
-- Present and can be used in .NET Framework 4 through .NET Framework 4.8.
-- Usable in .NET (Core), but its use isn't recommended.
-
 The classes shown in the following table are used to construct email messages that can be sent using <xref:System.Net.Mail.SmtpClient>.
 
 | Class                              | Description                                                |
@@ -90,7 +84,7 @@ The classes shown in the following table are used to construct email messages th
 
 To include an attachment with an email message, first create the attachment by using the <xref:System.Net.Mail.Attachment> class, and then add it to the message by using the <xref:System.Net.Mail.MailMessage.Attachments?displayProperty=nameWithType> property. Depending on the email reader used by the recipients and the file type of the attachment, some recipients might not be able to read the attachment. For clients that cannot display the attachment in its original form, you can specify alternate views by using the <xref:System.Net.Mail.MailMessage.AlternateViews?displayProperty=nameWithType> property.
 
- In .NET Framework, you can use the application or machine configuration files to specify default host, port, and credentials values for all <xref:System.Net.Mail.SmtpClient> objects. For more information, see [&lt;mailSettings&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings). .NET Core does not support setting defaults. As a workaround, you must set the relevant properties on <xref:System.Net.Mail.SmtpClient> directly.
+To specify host, port, and credentials values for all <xref:System.Net.Mail.SmtpClient> objects, set the relevant properties on <xref:System.Net.Mail.SmtpClient> directly.
 
  To send the email message and block while waiting for the email to be transmitted to the SMTP server, use one of the synchronous <xref:System.Net.Mail.SmtpClient.Send*> methods. To allow your program's main thread to continue executing while the email is transmitted, use one of the asynchronous <xref:System.Net.Mail.SmtpClient.SendAsync*> methods. The <xref:System.Net.Mail.SmtpClient.SendCompleted> event is raised when a <xref:System.Net.Mail.SmtpClient.SendAsync*> operation completes. To receive this event, you must add a <xref:System.Net.Mail.SendCompletedEventHandler> delegate to <xref:System.Net.Mail.SmtpClient.SendCompleted>. The <xref:System.Net.Mail.SendCompletedEventHandler> delegate must reference a callback method that handles notification of <xref:System.Net.Mail.SmtpClient.SendCompleted> events. To cancel an asynchronous email transmission, use the <xref:System.Net.Mail.SmtpClient.SendAsyncCancel*> method.
 
@@ -117,10 +111,6 @@ The following code example demonstrates sending an email message asynchronously.
  ]]></format>
     </remarks>
     <altmember cref="N:System.Net.Mime" />
-    <related type="Article" href="/dotnet/framework/network-programming/">Network Programming in the .NET Framework</related>
-    <related type="Article" href="/dotnet/framework/network-programming/network-programming-samples">Network Programming Samples</related>
-    <related type="Article" href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</related>
-    <related type="Article" href="/dotnet/framework/network-programming/security-in-network-programming">Security in Network Programming</related>
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
@@ -166,24 +156,8 @@ The following code example demonstrates sending an email message asynchronously.
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Initializes a new instance of the <see cref="T:System.Net.Mail.SmtpClient" /> class by using configuration file settings.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor initializes the <xref:System.Net.Mail.SmtpClient.Host*>, <xref:System.Net.Mail.SmtpClient.Credentials*>, and <xref:System.Net.Mail.SmtpClient.Port*> properties for the new <xref:System.Net.Mail.SmtpClient> by using the settings in the application or machine configuration files. For more information, see [&lt;mailSettings&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings).
-
-
-
-## Examples
- The following code example demonstrates sending an email message.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net.Mail/Attachment/Overview/mail.cs" id="Snippet4":::
-
- For an example of the \<mailSettings> node in the application or machine configuration file, see [&lt;mailSettings&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings).
-
- ]]></format>
-        </remarks>
+        <summary>Initializes a new instance of the <see cref="T:System.Net.Mail.SmtpClient" /> class using the default port.</summary>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -225,23 +199,7 @@ The following code example demonstrates sending an email message asynchronously.
       <Docs>
         <param name="host">A <see cref="T:System.String" /> that contains the name or IP address of the host computer used for SMTP transactions.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.Mail.SmtpClient" /> class that sends email by using the specified SMTP server.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The `host` parameter is used to initialize the value of the <xref:System.Net.Mail.SmtpClient.Host> property. The <xref:System.Net.Mail.SmtpClient.Credentials*> and <xref:System.Net.Mail.SmtpClient.Port*> properties are initialized by using the settings in the application or machine configuration files. If `host` is `null` or equal to <xref:System.String.Empty?displayProperty=nameWithType>, <xref:System.Net.Mail.SmtpClient.Host*> is initialized using the settings in the application or machine configuration files.
-
- For more information about using the application and machine configuration files, see [&lt;mailSettings&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings). If information is specified using <xref:System.Net.Mail.SmtpClient> constructors or properties, this information overrides the configuration file settings.
-
-
-
-## Examples
- The following code example demonstrates calling this constructor.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net.Mail/Attachment/Overview/mail.cs" id="Snippet3":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -285,23 +243,7 @@ The following code example demonstrates sending an email message asynchronously.
         <param name="host">A <see cref="T:System.String" /> that contains the name or IP address of the host used for SMTP transactions.</param>
         <param name="port">An <see cref="T:System.Int32" /> greater than zero that contains the port to be used on <paramref name="host" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.Mail.SmtpClient" /> class that sends email by using the specified SMTP server and port.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The `host` and `port` parameters set the value of the <xref:System.Net.Mail.SmtpClient.Host*> and <xref:System.Net.Mail.SmtpClient.Port*> properties, respectively. If `host` is `null` or equal to <xref:System.String.Empty?displayProperty=nameWithType>, <xref:System.Net.Mail.SmtpClient.Host*> is initialized using the settings in the application or machine configuration files. If `port` is zero, <xref:System.Net.Mail.SmtpClient.Port*> is initialized using the settings in the application or machine configuration files. The <xref:System.Net.Mail.SmtpClient.Credentials> property is initialized using the settings in the application or machine configuration files.
-
- For more information about using the application and machine configuration files, see [&lt;mailSettings&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings). If information is specified using <xref:System.Net.Mail.SmtpClient> constructors or properties, this information overrides the configuration file settings.
-
-
-
-## Examples
- The following code example demonstrates calling this constructor.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net.Mail/Attachment/Overview/mail.cs" id="Snippet1":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="port" /> cannot be less than zero.</exception>
       </Docs>
@@ -348,7 +290,7 @@ The following code example demonstrates sending an email message asynchronously.
         <ReturnType>System.Security.Cryptography.X509Certificates.X509CertificateCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Specify which certificates should be used to establish the Secure Sockets Layer (SSL) connection.</summary>
+        <summary>Gets the certificates that should be used to establish the Secure Sockets Layer (SSL) connection.</summary>
         <value>An <see cref="T:System.Security.Cryptography.X509Certificates.X509CertificateCollection" />, holding one or more client certificates. The default value is derived from the mail configuration attributes in a configuration file.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -357,9 +299,7 @@ The following code example demonstrates sending an email message asynchronously.
  Client certificates are, by default, optional; however, the server configuration might require that the client present a valid certificate as part of the initial connection negotiation.
 
 > [!NOTE]
->  The Framework caches SSL sessions as they are created and attempts to reuse a cached session for a new request, if possible. When attempting to reuse an SSL session, the Framework uses the first element of <xref:System.Net.Mail.SmtpClient.ClientCertificates*> (if there is one), or tries to reuse an anonymous sessions if <xref:System.Net.Mail.SmtpClient.ClientCertificates*> is empty.
-
-
+> .NET caches SSL sessions as they are created and attempts to reuse a cached session for a new request, if possible. When attempting to reuse an SSL session, .NET uses the first element of <xref:System.Net.Mail.SmtpClient.ClientCertificates*> (if there is one), or tries to reuse an anonymous sessions if <xref:System.Net.Mail.SmtpClient.ClientCertificates*> is empty.
 
 ## Examples
  The following code example establishes an SSL connection with the SMTP server and uses the connection to send an email.
@@ -368,7 +308,6 @@ The following code example demonstrates sending an email message asynchronously.
 
  ]]></format>
         </remarks>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">MailSettings Element (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="Credentials">
@@ -409,19 +348,15 @@ The following code example demonstrates sending an email message asynchronously.
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the credentials used to authenticate the sender.</summary>
-        <value>An <see cref="T:System.Net.ICredentialsByHost" /> that represents the credentials to use for authentication; or <see langword="null" /> if no credentials have been specified.</value>
+        <value>The credentials to use for authentication; or <see langword="null" /> if no credentials have been specified.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  Some SMTP servers require that the client be authenticated before the server will send email on its behalf. To use your default network credentials, you can set the <xref:System.Net.Mail.SmtpClient.UseDefaultCredentials*> to `true` instead of setting this property. If the <xref:System.Net.Mail.SmtpClient.UseDefaultCredentials> property is set to `false,` then the value set in the <xref:System.Net.Mail.SmtpClient.Credentials> property will be used for the credentials when connecting to the server. If the <xref:System.Net.Mail.SmtpClient.UseDefaultCredentials> property is set to `false` and the <xref:System.Net.Mail.SmtpClient.Credentials> property has not been set, then mail is sent to the server anonymously.
 
- Credentials information can also be specified using the application and machine configuration files. For more information, see [&lt;mailSettings&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings). If information is specified using the <xref:System.Net.Mail.SmtpClient.Credentials> property, this information overrides the configuration file settings.
-
 > [!CAUTION]
->  If you provide credentials for basic authentication, they are sent to the server in clear text. This can present a security issue because your credentials can be seen, and then used by others.
-
-
+>  If you provide credentials for basic authentication, they are sent to the server in clear text. This can present a security issue because your credentials can be seen and used by others.
 
 ## Examples
  The following code example demonstrates setting the credentials used to send an email.
@@ -527,8 +462,6 @@ The following code example demonstrates sending an email message asynchronously.
 
  ]]></format>
         </remarks>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">&lt;mailSettings&gt; Element (Network Settings)</related>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings">&lt;smtp&gt; Element (Network Settings)</related>
       </Docs>
     </Member>
     <MemberGroup MemberName="Dispose">
@@ -755,9 +688,6 @@ The following code example demonstrates sending an email message asynchronously.
 
  ]]></format>
         </remarks>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">&lt;mailSettings&gt; Element (Network Settings)</related>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings">&lt;smtp&gt; Element (Network Settings)</related>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/network-element-network-settings">&lt;network&gt; Element (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="Host">
@@ -799,30 +729,11 @@ The following code example demonstrates sending an email message asynchronously.
       <Docs>
         <summary>Gets or sets the name or IP address of the host used for SMTP transactions.</summary>
         <value>A <see cref="T:System.String" /> that contains the name or IP address of the computer to use for SMTP transactions.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The value of the <xref:System.Net.Mail.SmtpClient.Host> property can also be set using constructors or the application or machine configuration file. For more information, see [&lt;mailSettings&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings).
-
- If information is specified using this property, this information overrides the configuration file settings.
-
-
-
-## Examples
- The following code example demonstrates sending an email message by using the host and port specified in an application configuration file.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net.Mail/Attachment/Overview/mail.cs" id="Snippet7":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The value specified for a set operation is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The value specified for a set operation is equal to <see cref="F:System.String.Empty" /> ("").</exception>
         <exception cref="T:System.InvalidOperationException">You cannot change the value of this property when an email is being sent.</exception>
         <altmember cref="P:System.Net.Mail.SmtpClient.Port" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">mailSettings for system.net</related>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings">&lt;smtp&gt; Element (Network Settings)</related>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/network-element-network-settings">&lt;network&gt; Element (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="OnSendCompleted">
@@ -930,8 +841,6 @@ The following code example demonstrates sending an email message asynchronously.
 
  ]]></format>
         </remarks>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">&lt;mailSettings&gt; Element (Network Settings)</related>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings">&lt;smtp&gt; Element (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="Port">
@@ -972,27 +881,10 @@ The following code example demonstrates sending an email message asynchronously.
       <Docs>
         <summary>Gets or sets the port used for SMTP transactions.</summary>
         <value>An <see cref="T:System.Int32" /> that contains the port number on the SMTP host. The default value is 25.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The value of the <xref:System.Net.Mail.SmtpClient.Port> property can also be set using constructors or the application or machine configuration file. For more information about using configuration files, see [&lt;mailSettings&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings). If information is specified using this property, this information overrides the configuration file settings.
-
-
-
-## Examples
- The following code example demonstrates sending an email message by using the host and port specified in an application configuration file.
-
- :::code language="csharp" source="~/snippets/csharp/System.Net.Mail/Attachment/Overview/mail.cs" id="Snippet7":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The value specified for a set operation is less than or equal to zero.</exception>
         <exception cref="T:System.InvalidOperationException">You cannot change the value of this property when an email is being sent.</exception>
         <altmember cref="P:System.Net.Mail.SmtpClient.Host" />
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">mailSettings for system.net</related>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings">&lt;smtp&gt; Element (Network Settings)</related>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/network-element-network-settings">&lt;network&gt; Element (Network Settings)</related>
       </Docs>
     </Member>
     <MemberGroup MemberName="Send">
@@ -2138,7 +2030,6 @@ The following code example demonstrates sending an email message asynchronously.
  -or-
 
  <see cref="P:System.Net.Mail.SmtpClient.Port" /> is zero.</exception>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/connectionmanagement-element-network-settings">connectionManagement Element (Network Settings)</related>
         <related type="Article" href="/dotnet/framework/network-programming/managing-connections">Managing Connections</related>
       </Docs>
     </Member>
@@ -2192,9 +2083,6 @@ The following code example demonstrates sending an email message asynchronously.
  ]]></format>
         </remarks>
         <related type="Article" href="/dotnet/framework/network-programming/integrated-windows-authentication-with-extended-protection">Integrated Windows Authentication with Extended Protection</related>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings">&lt;mailSettings&gt; Element (Network Settings)</related>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/smtp-element-network-settings">&lt;smtp&gt; Element (Network Settings)</related>
-        <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/network-element-network-settings">&lt;network&gt; Element (Network Settings)</related>
       </Docs>
     </Member>
     <Member MemberName="Timeout">
@@ -2292,7 +2180,7 @@ The following code example demonstrates sending an email message asynchronously.
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets or sets a <see cref="T:System.Boolean" /> value that controls whether the <see cref="P:System.Net.CredentialCache.DefaultCredentials" /> are sent with requests.</summary>
+        <summary>Gets or sets a value that indicates whether the <see cref="P:System.Net.CredentialCache.DefaultCredentials" /> are sent with requests.</summary>
         <value>
           <see langword="true" /> if the default credentials are used; otherwise <see langword="false" />. The default value is <see langword="false" />.</value>
         <remarks>
@@ -2301,14 +2189,10 @@ The following code example demonstrates sending an email message asynchronously.
 ## Remarks
  Some SMTP servers require that the client be authenticated before the server sends email on its behalf. Set this property to `true` when this <xref:System.Net.Mail.SmtpClient> object should, if requested by the server, authenticate using the default credentials of the currently logged on user. For client applications, this is the desired behavior in most scenarios.
 
- Credentials information can also be specified using the application and machine configuration files. For more information, see [&lt;mailSettings&gt; Element (Network Settings)](/dotnet/framework/configure-apps/file-schema/network/mailsettings-element-network-settings).
-
  If the <xref:System.Net.Mail.SmtpClient.UseDefaultCredentials> property is set to `false,` then the value set in the <xref:System.Net.Mail.SmtpClient.Credentials> property will be used for the credentials when connecting to the server. If the <xref:System.Net.Mail.SmtpClient.UseDefaultCredentials> property is set to `false` and the <xref:System.Net.Mail.SmtpClient.Credentials> property has not been set, then mail is sent to the server anonymously.
 
 > [!CAUTION]
->  If you provide credentials for basic authentication, they are sent to the server in clear text. This can present a security issue because your credentials can be seen, and then used by others.
-
-
+>  If you provide credentials for basic authentication, they are sent to the server in clear text. This can present a security issue because your credentials can be seen and used by others.
 
 ## Examples
  The following code example demonstrates using this property.

--- a/xml/System.Net.Mail/SmtpPermission.xml
+++ b/xml/System.Net.Mail/SmtpPermission.xml
@@ -49,10 +49,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The <xref:System.Net.Mail.SmtpPermission> and <xref:System.Net.Mail.SmtpPermissionAttribute> classes control access to SMTP host computers. The <xref:System.Net.Mail.SmtpClient> class demands an <xref:System.Net.Mail.SmtpPermission> when sending electronic mail to the SMTP host for delivery.
-
- The <xref:System.Net.Mail.SmtpAccess> enumeration specifies the level of access controlled by an instance of this permission.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -98,14 +94,7 @@
         <param name="unrestricted">
           <see langword="true" /> if the new permission is unrestricted; otherwise, <see langword="false" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.Mail.SmtpPermission" /> class with the specified state.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If `unrestricted` is `true`, the permission controls <xref:System.Net.Mail.SmtpAccess.Connect> access to SMTP servers. If unrestricted is `false`, the permission controls <xref:System.Net.Mail.SmtpAccess.None> access.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -139,14 +128,7 @@
       <Docs>
         <param name="access">One of the <see cref="T:System.Net.Mail.SmtpAccess" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.Mail.SmtpPermission" /> class using the specified access level.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The permission created by this constructor can be used to help secure access to SMTP servers.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -180,14 +162,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.Mail.SmtpPermission" /> class using the specified permission state value.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The permission created by this constructor can be used to give full access or prevent all access to SMTP servers.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Access">
@@ -258,14 +233,7 @@
       <Docs>
         <param name="access">One of the <see cref="T:System.Net.Mail.SmtpAccess" /> values.</param>
         <summary>Adds the specified access level value to the permission.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to modify access to Simple Mail Transport Protocol servers by adding to the state of this permission instance.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Copy">
@@ -300,14 +268,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>An <see cref="T:System.Net.Mail.SmtpPermission" /> that is identical to the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -344,14 +305,7 @@
       <Docs>
         <param name="securityElement">The XML encoding to use to set the state of the current permission.</param>
         <summary>Sets the state of the permission using the specified XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is used by the security system and is not normally called by application code.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="securityElement" /> does not describe an <see cref="T:System.Net.Mail.SmtpPermission" /> object.
 
@@ -397,14 +351,7 @@
         <param name="target">An <see cref="T:System.Security.IPermission" /> to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>An <see cref="T:System.Net.Mail.SmtpPermission" /> that represents the intersection of the current permission and the specified permission. Returns <see langword="null" /> if the intersection is empty or <paramref name="target" /> is <see langword="null" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the state they describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not an <see cref="T:System.Net.Mail.SmtpPermission" />.</exception>
       </Docs>
@@ -445,14 +392,7 @@
         <summary>Returns a value indicating whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a state that is wholly contained by the specified permission. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not an <see cref="T:System.Net.Mail.SmtpPermission" />.</exception>
       </Docs>
@@ -493,14 +433,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission has full access to all resources controlled by the permission instance.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -535,14 +468,7 @@
       <Docs>
         <summary>Creates an XML encoding of the state of the permission.</summary>
         <returns>A <see cref="T:System.Security.SecurityElement" /> that contains an XML encoding of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is used by the security system and is not normally called by application code.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -580,14 +506,7 @@
         <param name="target">An <see cref="T:System.Security.IPermission" /> to combine with the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new <see cref="T:System.Net.Mail.SmtpPermission" /> permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.Mail.SmtpPermission.Union*> method returns a permission that represents all the states represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not an <see cref="T:System.Net.Mail.SmtpPermission" />.</exception>
       </Docs>

--- a/xml/System.Net.Mail/SmtpPermissionAttribute.xml
+++ b/xml/System.Net.Mail/SmtpPermissionAttribute.xml
@@ -49,10 +49,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The <xref:System.Net.Mail.SmtpPermission> and <xref:System.Net.Mail.SmtpPermissionAttribute> classes control access to SMTP host computers. The <xref:System.Net.Mail.SmtpClient> class demands an <xref:System.Net.Mail.SmtpPermission> when sending electronic mail to the SMTP host for delivery.
-
- The <xref:System.Net.Mail.SmtpAccess> enumeration specifies the level of access controlled by an instance of this permission.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -88,14 +84,7 @@
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values that specifies the permission behavior.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.Mail.SmtpPermissionAttribute" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The security action defines which callers must have the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="action" /> is not a valid <see cref="T:System.Security.Permissions.SecurityAction" />.</exception>
       </Docs>
@@ -131,14 +120,7 @@
       <Docs>
         <summary>Gets or sets the level of access to SMTP servers controlled by the attribute.</summary>
         <value>A <see cref="T:System.String" /> value. Valid values are "Connect" and "None".</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If you specify an invalid value when setting this property, the <xref:System.Net.Mail.SmtpPermissionAttribute.CreatePermission*> method will throw an <xref:System.ArgumentException> when called by the system.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreatePermission">
@@ -173,16 +155,7 @@
       <Docs>
         <summary>Creates a permission object that can be stored with the <see cref="T:System.Security.Permissions.SecurityAction" /> in an assembly's metadata.</summary>
         <returns>An <see cref="T:System.Net.Mail.SmtpPermission" /> instance.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should only be called by the security system, never by application code.
-
- At compile time, attributes are converted into security declarations and stored in Microsoft intermediate language (MSIL) metadata. At run time, the security declarations in metadata are used to create permission objects that map to the state described in the metadata.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Net.NetworkInformation/NetworkChange.xml
+++ b/xml/System.Net.NetworkInformation/NetworkChange.xml
@@ -67,7 +67,7 @@
 
 ## Examples
  The following code example listens for address changes and displays the status of network interfaces when a <xref:System.Net.NetworkInformation.NetworkChange.NetworkAddressChanged> event occurs.
-  
+
  :::code language="csharp" source="~/snippets/csharp/System.Net.NetworkInformation/NetworkChange/Overview/changed.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Net.NetworkInformation/NetworkChange/Overview/changed.vb" id="Snippet1":::
 

--- a/xml/System.Net.NetworkInformation/NetworkInformationPermission.xml
+++ b/xml/System.Net.NetworkInformation/NetworkInformationPermission.xml
@@ -50,10 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This permission is used to secure data returned by the classes in the <xref:System.Net.NetworkInformation> namespace.
-
- For declarative security, use the <xref:System.Net.NetworkInformation.NetworkInformationPermissionAttribute> class.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -100,14 +96,7 @@
       <Docs>
         <param name="access">One of the <see cref="T:System.Net.NetworkInformation.NetworkInformationAccess" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.NetworkInformation.NetworkInformationPermission" /> class using the specified <see cref="T:System.Net.NetworkInformation.NetworkInformationAccess" /> value.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The permission created by this constructor can be used to secure access to network information.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -142,14 +131,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.NetworkInformation.NetworkInformationPermission" /> class with the specified <see cref="T:System.Security.Permissions.PermissionState" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The permission created by this constructor can be used to secure access to network information.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Access">
@@ -184,14 +166,7 @@
       <Docs>
         <summary>Gets the level of access to network information controlled by this permission.</summary>
         <value>One of the <see cref="T:System.Net.NetworkInformation.NetworkInformationAccess" /> values.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A <xref:System.Net.NetworkInformation.NetworkInformationPermission> created with <xref:System.Security.Permissions.PermissionState.Unrestricted?displayProperty=nameWithType> is given <xref:System.Net.NetworkInformation.NetworkInformationAccess.Ping> &#124; <xref:System.Net.NetworkInformation.NetworkInformationAccess.Read> access. A <xref:System.Net.NetworkInformation.NetworkInformationPermission> created with <xref:System.Security.Permissions.PermissionState.None?displayProperty=nameWithType> is given <xref:System.Net.NetworkInformation.NetworkInformationAccess.None> access.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AddPermission">
@@ -229,14 +204,7 @@
       <Docs>
         <param name="access">One of the <see cref="T:System.Net.NetworkInformation.NetworkInformationAccess" /> values.</param>
         <summary>Adds the specified value to this permission.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to modify access to network information by adding to the state of the current permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Copy">
@@ -272,14 +240,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of this permission.</summary>
         <returns>A <see cref="T:System.Net.NetworkInformation.NetworkInformationPermission" /> that is identical to the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -317,14 +278,7 @@
       <Docs>
         <param name="securityElement">A <see cref="T:System.Security.SecurityElement" /> that contains the XML encoding to use to set the state of the current permission.</param>
         <summary>Sets the state of this permission using the specified XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is used by the security system and is not normally called by application code.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="securityElement" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
@@ -375,14 +329,7 @@
         <param name="target">An <see cref="T:System.Security.IPermission" /> to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A <see cref="T:System.Net.NetworkInformation.NetworkInformationPermission" /> that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty or <paramref name="target" /> is <see langword="null" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the state they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not a <see cref="T:System.Net.NetworkInformation.NetworkInformationPermission" />.</exception>
       </Docs>
@@ -424,14 +371,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a state that is wholly contained by the specified permission. If this method returns true, the current permission represents no more access to the protected resource than does the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsUnrestricted">
@@ -471,14 +411,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission is created using the <xref:System.Net.NetworkInformation.NetworkInformationPermission.%23ctor*> constructor.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -514,14 +447,7 @@
       <Docs>
         <summary>Creates an XML encoding of the state of this permission.</summary>
         <returns>A <see cref="T:System.Security.SecurityElement" /> that contains the XML encoding of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is used by the security system and is not normally called by application code.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -560,14 +486,7 @@
         <param name="target">A <see cref="T:System.Net.NetworkInformation.NetworkInformationPermission" /> permission to combine with the current permission.</param>
         <summary>Creates a permission that is the union of this permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Net.NetworkInformation.NetworkInformationPermission.Union*> method returns a permission that represents all the states represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Net.NetworkInformation/NetworkInformationPermissionAttribute.xml
+++ b/xml/System.Net.NetworkInformation/NetworkInformationPermissionAttribute.xml
@@ -44,16 +44,12 @@
   <Docs>
     <summary>Allows security actions for <see cref="T:System.Net.NetworkInformation.NetworkInformationPermission" /> to be applied to code using declarative security.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This permission is used by classes that provide information about network connections and traffic statistics such as those in the <xref:System.Net.NetworkInformation> namespace.  
-  
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the <xref:System.Net.NetworkInformation.NetworkInformationPermission> class.  
-  
  ]]></format>
     </remarks>
   </Docs>
@@ -90,14 +86,7 @@
       <Docs>
         <param name="action">A <see cref="T:System.Security.Permissions.SecurityAction" /> value that specifies the permission behavior.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.NetworkInformation.NetworkInformationPermissionAttribute" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The security action defines which callers must have the permission.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Access">
@@ -132,20 +121,7 @@
       <Docs>
         <summary>Gets or sets the network information access level.</summary>
         <value>A string that specifies the access level.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The valid values for this property are shown in the following table.  
-  
-|Value|Description|  
-|-----------|-----------------|  
-|"Read"|Read access to network information.|  
-|"Full"|Full access to network information.|  
-|"None"|No access to network information.|  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreatePermission">
@@ -181,14 +157,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Net.NetworkInformation.NetworkInformationPermission" /> object.</summary>
         <returns>A <see cref="T:System.Net.NetworkInformation.NetworkInformationPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method should only be called by the security system, never by application code.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Net.NetworkInformation/PhysicalAddress.xml
+++ b/xml/System.Net.NetworkInformation/PhysicalAddress.xml
@@ -467,26 +467,16 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The `address` parameter must contain a string that can only consist of numbers and letters as hexadecimal digits. In .NET Framework, the letters must be uppercase.
- Some examples of string formats that are acceptable are as follows:
+ The `address` parameter must contain a string that can only consist of numbers and letters as hexadecimal digits. Some examples of string formats that are acceptable are as follows:
 
  `001122334455`
-
  `00-11-22-33-44-55`
-
- `0011.2233.4455` (.NET 5 and later versions only)
-
- `00:11:22:33:44:55` (.NET 5 and later versions only)
-
+ `0011.2233.4455`
+ `00:11:22:33:44:55`
  `F0-E1-D2-C3-B4-A5`
-
- `f0-e1-d2-c3-b4-a5` (.NET 5 and later versions only)
-
-In .NET Framework, an address that contains `f0-e1-d2-c3-b4-a5` will fail to parse and throw an exception.
+ `f0-e1-d2-c3-b4-a5`
 
  Use the <xref:System.Net.NetworkInformation.PhysicalAddress.GetAddressBytes*> method to retrieve the address from an existing <xref:System.Net.NetworkInformation.PhysicalAddress> instance.
-
-
 
 ## Examples
  The following code example creates a <xref:System.Net.NetworkInformation.PhysicalAddress> instance by calling the <xref:System.Net.NetworkInformation.PhysicalAddress.Parse*> method.

--- a/xml/System.Net.NetworkInformation/Ping.xml
+++ b/xml/System.Net.NetworkInformation/Ping.xml
@@ -114,10 +114,6 @@
 
  ]]></format>
     </remarks>
-    <related type="Article" href="/dotnet/framework/network-programming/how-to-ping-a-host">How to: Ping a Host</related>
-    <related type="Article" href="/dotnet/framework/network-programming/">Network Programming in the .NET Framework</related>
-    <related type="Article" href="/dotnet/framework/network-programming/network-programming-samples">Network Programming Samples</related>
-    <related type="Article" href="/dotnet/framework/network-programming/networkinformation">NetworkInformation</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Net.PeerToPeer.Collaboration/PeerCollaborationPermission.xml
+++ b/xml/System.Net.PeerToPeer.Collaboration/PeerCollaborationPermission.xml
@@ -49,10 +49,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The default <xref:System.Security.Permissions> allow all local and Intranet zone applications to access collaboration services, and no permission is granted for Internet zone applications. In other words, if the default permissions are not changed, all link-local and site-local applications have access to Peer-To-Peer collaboration services, but global applications have no access.
-
- This class is not derivable.
-
  ]]></format>
     </remarks>
     <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Copy" />
@@ -91,16 +87,7 @@
       <Docs>
         <param name="state">One of the values in the <see cref="T:System.Security.Permissions.PermissionState" /> enumeration.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" />. The initial <see cref="T:System.Security.Permissions.PermissionState" /> for this instance is passed when the constructor is called.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Instances of this type either have no access to the resource(s) protected by the permission, or they have unrestricted full access to those resources.
-
- If state is <xref:System.Security.Permissions.PermissionState.Unrestricted>, the <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission> instance passes all demands. If state contains any other value, the <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission> instance fails all demands.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.IsUnrestricted" />
         <altmember cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermissionAttribute" />
       </Docs>
@@ -137,14 +124,7 @@
       <Docs>
         <summary>Creates and returns a copy of the current <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" />.</summary>
         <returns>A <see cref="T:System.Object" /> that contains a copy of the current instance of <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission> instance grants the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Union(System.Security.IPermission)" />
       </Docs>
     </Member>
@@ -182,16 +162,7 @@
       <Docs>
         <param name="e">The XML encoding to use to reconstruct the permission.</param>
         <summary>Represents the XML object model for encoding security objects.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This class is intended to be a lightweight implementation of a simple XML object model for use within the security system, and not for use as a general XML object model.
-
- This class cannot be inherited.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The parameter is not a valid permission element.
 
 -or-
@@ -241,22 +212,7 @@ The parameter's version number is not supported.</exception>
         <param name="target">Permission to <see cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Intersect(System.Security.IPermission)" /> with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" /> and the specified <paramref name="target" /> permission.</summary>
         <returns>A new permission that represents the intersection of the current <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" /> and the specified <paramref name="target" /> permission. This new permission is a <see langword="null" /> reference (<see langword="Nothing" /> in Visual Basic) if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- The following statements are required to be `true` for all implementations of the <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Intersect*> method. X and Y represent <xref:System.Security.IPermission> object references that are not a `null` reference (`Nothing` in Visual Basic).
-
-- X.Intersect(X) returns a value equal to X.
-
-- X.Intersect(Y) returns the same value as Y.Intersect(X).
-
-- X.Intersect(a `null` reference) returns a `null` reference.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The target parameter is not a <see langword="null" /> reference (<see langword="Nothing" /> in Visual Basic) and is not an instance of the same class as the current permission.</exception>
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.IsSubsetOf(System.Security.IPermission)" />
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Union(System.Security.IPermission)" />
@@ -299,24 +255,7 @@ The parameter's version number is not supported.</exception>
         <summary>Determines whether the current <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" /> is a subset of the specified <paramref name="target" /> permission.</summary>
         <returns>
           <see langword="true" /> if the current <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" /> is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission> is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, a permission that represents access to "*C:\example.txt*" is a subset of a permission that represents access to "*C:\\*". If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- The following statements are required to be `true` for all implementations of the <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.IsSubsetOf*> method. X, Y, and Z represent <xref:System.Security.IPermission> objects that are not a `null` reference (`Nothing` in Visual Basic).
-
-- X.IsSubsetOf(X) returns `true`.
-
-- X.IsSubsetOf(Y) returns the same value as Y.IsSubsetOf(X) if and only if X and Y represent the same set of permissions.
-
-- If X.IsSubsetOf(Y) and Y.IsSubsetOf(Z) both return `true`, X.IsSubsetOf(Z) returns `true`.
-
- If X represents an empty <xref:System.Security.IPermission> object with a permission state of `None`, and Y represents an `IPermission` object that is a `null` reference (`Nothing` in Visual Basic), X.IsSubsetOf(Y) returns `true`. If Z is also an empty permission, the compound set operation X.Union(Z).IsSubsetOf(Y) also returns `true` because the <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Union*> of two empty permissions is an empty permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The parameter is a <see langword="null" /> reference (<see langword="Nothing" /> in Visual Basic).</exception>
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Intersect(System.Security.IPermission)" />
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Union(System.Security.IPermission)" />
@@ -359,14 +298,7 @@ The parameter's version number is not supported.</exception>
         <summary>Returns a value specifying whether the current <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" /> is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission represents access to any and all resources protected by the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Copy" />
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Union(System.Security.IPermission)" />
         <altmember cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermissionAttribute" />
@@ -404,14 +336,7 @@ The parameter's version number is not supported.</exception>
       <Docs>
         <summary>Creates an XML encoding of the <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" /> and its current state.</summary>
         <returns>An XML encoding of the permission, including any state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- In general, permission class methods are used by the infrastructure and are not intended for use in applications.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Copy" />
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.FromXml(System.Security.SecurityElement)" />
       </Docs>
@@ -451,22 +376,7 @@ The parameter's version number is not supported.</exception>
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" /> and the specified <paramref name="target" /> permission.</summary>
         <returns>A new permission that represents the <see cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Union(System.Security.IPermission)" /> of the current <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" /> and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Union*> is a permission that represents all the operations represented by both the current <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission> and the specified permission. Any demand that passes either permission passes their union.
-
- The following statements are required to be `true` for all implementations of the Union method. X and Y represent <xref:System.Security.IPermission> objects that are not a `null` reference (`Nothing` in Visual Basic).
-
-- X.Union(X) returns an object that has the same value as X.
-
-- X.Union(Y) returns an object that has the same value as the object returned by Y.Union(X).
-
-- X.Union(a `null` reference (`Nothing` in Visual Basic)) returns an object that has the same value as X.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The parameter is a <see langword="null" /> reference (<see langword="Nothing" /> in Visual Basic).</exception>
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.Intersect(System.Security.IPermission)" />
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission.IsSubsetOf(System.Security.IPermission)" />

--- a/xml/System.Net.PeerToPeer.Collaboration/PeerCollaborationPermissionAttribute.xml
+++ b/xml/System.Net.PeerToPeer.Collaboration/PeerCollaborationPermissionAttribute.xml
@@ -43,16 +43,12 @@
   <Docs>
     <summary>Allows security actions for <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission" /> to be applied to code using declarative security. This class cannot be inherited.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.  
-  
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.  
-  
  ]]></format>
     </remarks>
     <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermissionAttribute.CreatePermission" />
@@ -90,14 +86,7 @@
       <Docs>
         <param name="action">Specifies a <see cref="T:System.Security.Permissions.SecurityAction" /> value.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermissionAttribute" /> class with the specified <see cref="T:System.Security.Permissions.SecurityAction" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermissionAttribute> works with <xref:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermission> to allow or deny a peer access to the collaboration session.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermissionAttribute.CreatePermission" />
       </Docs>
     </Member>
@@ -133,14 +122,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.IPermission" />.</summary>
         <returns>A new <see cref="T:System.Security.IPermission" /> object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method is not called, and is included only to support inheritance from <xref:System.Security.Permissions.SecurityAttribute>.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <block subset="none" type="overrides">
           <para>When permissions are inherited <see cref="T:System.Security.Permissions.SecurityAttribute" />, <see cref="M:System.Net.PeerToPeer.Collaboration.PeerCollaborationPermissionAttribute.CreatePermission" /> must be overridden.</para>
         </block>

--- a/xml/System.Net.PeerToPeer/PnrpPermission.xml
+++ b/xml/System.Net.PeerToPeer/PnrpPermission.xml
@@ -49,17 +49,8 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The default permissions allow all local and Intranet zone applications to access PNRP services. If the default permissions are not changed, all link-local and site-local applications have access to Peer-to-Peer services, but global (internet) applications have no access.
-
- Instances of this type have two permission states: they either have no access to the resources protected by the permission, or they have unrestricted full access to those resources.
-
  ]]></format>
     </remarks>
-    <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.Copy" />
-    <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.FromXml(System.Security.SecurityElement)" />
-    <altmember cref="T:System.Net.PeerToPeer.PnrpPermissionAttribute" />
-    <altmember cref="N:System.Security.Permissions" />
-    <related type="Article" href="/windows/win32/p2psdk/pnrp-namespace-provider-api">PNRP Namespace Provider API</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -93,20 +84,7 @@
       <Docs>
         <param name="state">One of the values in the <see cref="T:System.Security.Permissions.PermissionState" /> enumeration.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.PeerToPeer.PnrpPermission" /> class with the supplied initial permission state.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Instances of this type have two permission states: they either have no access to the resource(s) protected by the permission, or they have unrestricted full access to those resources.
-
- If `state` is Unrestricted, the PnrpPermission instance passes all demands. If `state` contains any other value, the PnrpPermission instance fails all demands.
-
- ]]></format>
-        </remarks>
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.Copy" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.IsUnrestricted" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.ToXml" />
-        <altmember cref="T:System.Net.PeerToPeer.PnrpPermissionAttribute" />
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Copy">
@@ -141,26 +119,13 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current <see cref="T:System.Net.PeerToPeer.PnrpPermission" />.</summary>
         <returns>An object with an IPermission interface, whose instance contains a copy of the current instance of <see cref="T:System.Net.PeerToPeer.PnrpPermission" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- Instances of this type have two permission states: they either have no access to the resource(s) protected by the permission, or they have unrestricted full access to those resources.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The parameter is not a valid <see cref="T:System.Net.PeerToPeer.PnrpPermission" /> element.
 
 -or-
 
 The parameter's version number is not supported.</exception>
         <exception cref="T:System.ArgumentNullException">The parameter is a <see langword="null" /> reference (<see langword="Nothing" /> in Visual Basic).</exception>
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.FromXml(System.Security.SecurityElement)" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.ToXml" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.Union(System.Security.IPermission)" />
-        <related type="Article" href="/windows/win32/p2psdk/pnrp-namespace-provider-api">PNRP Namespace Provider API</related>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -197,25 +162,13 @@ The parameter's version number is not supported.</exception>
       <Docs>
         <param name="e">The XML encoding to use to reconstruct the permission.</param>
         <summary>Reconstructs a security object with a specified state from an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Represents the XML object model for encoding security objects. This class cannot be inherited.
-
- This class is intended to be a lightweight implementation of a simple XML object model for use within the security system, and not for use as a general XML object model.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The parameter is not a valid <see cref="T:System.Net.PeerToPeer.PnrpPermission" /> element.
 
 -or-
 
 The parameter's version number is not supported.</exception>
         <exception cref="T:System.ArgumentNullException">The parameter is a <see langword="null" /> reference (<see langword="Nothing" /> in Visual Basic).</exception>
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.Copy" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.ToXml" />
-        <altmember cref="T:System.Security.SecurityElement" />
       </Docs>
     </Member>
     <Member MemberName="Intersect">
@@ -253,26 +206,8 @@ The parameter's version number is not supported.</exception>
         <param name="target">A permission to <see cref="M:System.Net.PeerToPeer.PnrpPermission.Intersect(System.Security.IPermission)" /> with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current <see cref="T:System.Net.PeerToPeer.PnrpPermission" /> and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current <see cref="T:System.Net.PeerToPeer.PnrpPermission" /> and the specified permission. This new permission is a <see langword="null" /> reference (<see langword="Nothing" /> in Visual Basic) if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- The following statements are required to be `true` for all implementations of the Intersect method. X and Y represent <xref:System.Security.IPermission> object references that are not a `null` reference (Nothing in Visual Basic).
-
-- X.Intersect(X) returns a value equal to X.
-
-- X.Intersect(Y) returns the same value as Y.Intersect(X).
-
-- X.Intersect(a `null` reference (`Nothing` in Visual Basic)) returns a `null` reference (`Nothing` in Visual Basic).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The target parameter is not a <see langword="null" /> reference (<see langword="Nothing" /> in Visual Basic) and is not an instance of the same class as the current permission.</exception>
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.IsSubsetOf(System.Security.IPermission)" />
-        <altmember cref="T:System.Net.PeerToPeer.PnrpPermissionAttribute" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.Union(System.Security.IPermission)" />
       </Docs>
     </Member>
     <Member MemberName="IsSubsetOf">
@@ -311,29 +246,8 @@ The parameter's version number is not supported.</exception>
         <summary>Determines whether the current <see cref="T:System.Net.PeerToPeer.PnrpPermission" /> is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current <see cref="T:System.Net.PeerToPeer.PnrpPermission" /> is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-The current <xref:System.Net.PeerToPeer.PnrpPermission> is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, a permission that represents access to "*C:\example.txt*" is a subset of a permission that represents access to "*C:\\*". If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
-The following statements are required to be `true` for all implementations of the IsSubsetOf method. X, Y, and Z represent <xref:System.Security.IPermission> objects that are not a `null` reference (`Nothing` in Visual Basic).
-
-- `X.IsSubsetOf(X)` returns `true`.
-
-- `X.IsSubsetOf(Y)` returns the same value as `Y.IsSubsetOf(X)` if and only if X and Y represent the same set of permissions.
-
-- If `X.IsSubsetOf(Y)` and `Y.IsSubsetOf(Z)` both return `true`, `X.IsSubsetOf(Z)` returns `true`.
-
-If X represents an empty <xref:System.Security.IPermission> object with a permission state of *None*, and Y represents an <xref:System.Security.IPermission> object that is a `null` reference (`Nothing` in Visual Basic), `X.IsSubsetOf(Y)` returns `true`. If Z is also an empty permission, the compound set operation `X.Union(Z).IsSubsetOf(Y)` also returns `true` because the <xref:System.Net.PeerToPeer.PnrpPermission.Union*> of two empty permissions is an empty permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The target parameter is not a <see langword="null" /> reference (<see langword="Nothing" /> in Visual Basic) and is not an instance of the same class as the current permission.</exception>
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.FromXml(System.Security.SecurityElement)" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.Intersect(System.Security.IPermission)" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.ToXml" />
       </Docs>
     </Member>
     <Member MemberName="IsUnrestricted">
@@ -372,18 +286,7 @@ If X represents an empty <xref:System.Security.IPermission> object with a permis
         <summary>Returns a value specifying whether the current <see cref="T:System.Net.PeerToPeer.PnrpPermission" /> is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission represents access to any and all resources protected by the permission.
-
- ]]></format>
-        </remarks>
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.Copy" />
-        <altmember cref="T:System.Net.PeerToPeer.PnrpPermissionAttribute" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.ToXml" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.Union(System.Security.IPermission)" />
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -419,8 +322,6 @@ If X represents an empty <xref:System.Security.IPermission> object with a permis
         <summary>Creates an XML encoding of the <see cref="T:System.Net.PeerToPeer.PnrpPermission" /> and its current state.</summary>
         <returns>A <see cref="T:System.Security.SecurityElement" /> object that contains an XML encoding of the permission, including any state information.</returns>
         <remarks>To be added.</remarks>
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.Copy" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.FromXml(System.Security.SecurityElement)" />
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -458,27 +359,9 @@ If X represents an empty <xref:System.Security.IPermission> object with a permis
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current <see cref="T:System.Net.PeerToPeer.PnrpPermission" /> and the specified permission.</summary>
         <returns>A new permission that represents the <see cref="M:System.Net.PeerToPeer.PnrpPermission.Union(System.Security.IPermission)" /> of the current <see cref="T:System.Net.PeerToPeer.PnrpPermission" /> and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Net.PeerToPeer.PnrpPermission.Union*> is a permission that represents all the operations represented by both the current <xref:System.Net.PeerToPeer.PnrpPermission> and the specified permission. Any demand that passes either permission passes their union.
-
- The following statements are required to be `true` for all implementations of the Union method. X and Y represent <xref:System.Security.IPermission> objects that are not a `null` reference (`Nothing` in Visual Basic).
-
-- X.Union(X) returns an object that has the same value as X.
-
-- X.Union(Y) returns an object that has the same value as the object returned by Y.Union(X).
-
-- X.Union(a `null` reference (`Nothing` in Visual Basic)) returns an object that has the same value as X.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> parameter is invalid.</exception>
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.Intersect(System.Security.IPermission)" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.IsSubsetOf(System.Security.IPermission)" />
-        <altmember cref="M:System.Net.PeerToPeer.PnrpPermission.IsUnrestricted" />
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Net.PeerToPeer/PnrpPermissionAttribute.xml
+++ b/xml/System.Net.PeerToPeer/PnrpPermissionAttribute.xml
@@ -43,16 +43,12 @@
   <Docs>
     <summary>Allows security actions for <see cref="T:System.Net.PeerToPeer.PnrpPermission" /> to be applied to code using declarative security.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the security declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.  
-  
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.  
-  
  ]]></format>
     </remarks>
   </Docs>
@@ -88,14 +84,7 @@
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.PeerToPeer.PnrpPermissionAttribute" /> class with the specified <see cref="T:System.Security.Permissions.SecurityAction" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- <xref:System.Net.PeerToPeer.PnrpPermissionAttribute> works with <xref:System.Net.PeerToPeer.PnrpPermission> to allow or deny actions by the peer granted the permission and the permission attribute.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Net.PeerToPeer.PnrpPermissionAttribute.CreatePermission" />
         <altmember cref="T:System.Net.PeerToPeer.PnrpPermission" />
       </Docs>
@@ -133,11 +122,6 @@
         <summary>Creates and returns a new <see cref="T:System.Security.IPermission" />.</summary>
         <returns>A new <see cref="T:System.Security.IPermission" /> object.</returns>
         <remarks>To be added.</remarks>
-        <block subset="none" type="overrides">
-          <para>This method is not used, and is included only to support inheritance from <see cref="T:System.Security.Permissions.SecurityAttribute" /> at compile time or during interpretation.  
-  
- When this class inherits from <see cref="T:System.Security.Permissions.SecurityAttribute" />, it overrides <see cref="M:System.Security.Permissions.SecurityAttribute.CreatePermission" /> automatically at compile time or at run-time.</para>
-        </block>
         <altmember cref="T:System.Net.PeerToPeer.PnrpPermission" />
       </Docs>
     </Member>

--- a/xml/System.Net.Security/SslClientAuthenticationOptions.xml
+++ b/xml/System.Net.Security/SslClientAuthenticationOptions.xml
@@ -46,7 +46,7 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This property bag is used as argument for <xref:System.Net.Security.SslStream.AuthenticateAsClientAsync*> and, in .NET 5 and later versions, for <xref:System.Net.Security.SslStream.AuthenticateAsClient*>.
+ This property bag is used as argument for <xref:System.Net.Security.SslStream.AuthenticateAsClientAsync*> and <xref:System.Net.Security.SslStream.AuthenticateAsClient*>.
 
  The <xref:System.Net.Http.SocketsHttpHandler> uses this property bag in the <xref: System.Net.Http.SocketsHttpHandler.SslOptions> property.
 

--- a/xml/System.Net.Security/SslClientAuthenticationOptions.xml
+++ b/xml/System.Net.Security/SslClientAuthenticationOptions.xml
@@ -48,7 +48,7 @@
 ## Remarks
  This property bag is used as argument for <xref:System.Net.Security.SslStream.AuthenticateAsClientAsync*> and <xref:System.Net.Security.SslStream.AuthenticateAsClient*>.
 
- The <xref:System.Net.Http.SocketsHttpHandler> uses this property bag in the <xref: System.Net.Http.SocketsHttpHandler.SslOptions> property.
+The <xref:System.Net.Http.SocketsHttpHandler> uses this property bag in the <xref:System.Net.Http.SocketsHttpHandler.SslOptions> property.
 
  ]]></format>
     </remarks>

--- a/xml/System.Net.Security/SslStream.xml
+++ b/xml/System.Net.Security/SslStream.xml
@@ -89,7 +89,7 @@
 
 To opt out of the behavior that blocks insecure cipher and hashing algorithms for connections in order to maintain interoperability with your existing SSL3 services OR TLS w/ RC4 services, see [Cannot connect to a server by using the ServicePointManager or SslStream APIs after upgrade to the .NET Framework 4.6](https://support.microsoft.com/kb/3069494).
 
-Use the the overloads for methods that authenticate SslStreams that don't specify a TLS version, but instead use the TLS version defined as the system default in [SCHANNEL](/windows/win32/secauthn/secure-channel), as a way to be able to later modify the defaults, without the need to rebuild and redeploy your app.
+Use the overloads for methods that authenticate SslStreams that don't specify a TLS version, but instead use the TLS version defined as the system default in [SCHANNEL](/windows/win32/secauthn/secure-channel), as a way to be able to later modify the defaults, without the need to rebuild and redeploy your app.
 
 ## Examples
  The following code example demonstrates creating an <xref:System.Net.Sockets.TcpListener> that uses the <xref:System.Net.Security.SslStream> class to communicate with clients.
@@ -331,7 +331,7 @@ Use the the overloads for methods that authenticate SslStreams that don't specif
  The use of the Null cipher is required when the encryption policy is set to <xref:System.Net.Security.EncryptionPolicy.NoEncryption?displayProperty=nameWithType>.
 
 > [!NOTE]
-> .NET caches SSL sessions as they are created and attempts to reuse a cached session for subsequent requests, if possible. When attempting to reuse an SSL session, .NET uses the first element of the <xref:System.Security.Cryptography.X509Certificates.X509Certificate2Collection> provided during authentication (if there is one), or tries to reuse an anonymous sessions if the certificate collection is empty.
+> .NET caches SSL sessions as they are created and attempts to reuse a cached session for subsequent requests, if possible. When attempting to reuse an SSL session, .NET uses the first element of the <xref:System.Security.Cryptography.X509Certificates.X509Certificate2Collection> provided during authentication (if there is one), or tries to reuse an anonymous session if the certificate collection is empty.
 
 > [!NOTE]
 > Client certificates are not supported in the SSL version 2 protocol.
@@ -428,7 +428,7 @@ Use the the overloads for methods that authenticate SslStreams that don't specif
  The use of the Null cipher is required when the encryption policy is set to <xref:System.Net.Security.EncryptionPolicy.NoEncryption?displayProperty=nameWithType>.
 
 > [!NOTE]
-> .NET caches SSL sessions as they are created and attempts to reuse a cached session for subsequent requests, if possible. When attempting to reuse an SSL session, .NET uses the first element of the <xref:System.Security.Cryptography.X509Certificates.X509Certificate2Collection> provided during authentication (if there is one), or tries to reuse an anonymous sessions if the certificate collection is empty.
+> .NET caches SSL sessions as they are created and attempts to reuse a cached session for subsequent requests, if possible. When attempting to reuse an SSL session, .NET uses the first element of the <xref:System.Security.Cryptography.X509Certificates.X509Certificate2Collection> provided during authentication (if there is one), or tries to reuse an anonymous session if the certificate collection is empty.
 
 ## Examples
  The following code example demonstrates calling this constructor. This example is part of a larger example provided for the <xref:System.Net.Security.SslStream> class.

--- a/xml/System.Net.Security/SslStream.xml
+++ b/xml/System.Net.Security/SslStream.xml
@@ -87,15 +87,9 @@
 
  <xref:System.Net.Security.SslStream> assumes that a timeout along with any other <xref:System.IO.IOException> when one is thrown from the inner stream will be treated as fatal by its caller. Reusing a <xref:System.Net.Security.SslStream> instance after a timeout will return garbage. An application should <xref:System.IO.Stream.Close*> the <xref:System.Net.Security.SslStream> and throw an exception in these cases.
 
- The .NET Framework 4.6 includes a security feature that blocks insecure cipher and hashing algorithms for connections. Applications using TLS/SSL through APIs such as HttpClient, HttpWebRequest, FTPClient, SmtpClient, and SslStream and targeting .NET Framework 4.6 get the more-secure behavior by default.
+To opt out of the behavior that blocks insecure cipher and hashing algorithms for connections in order to maintain interoperability with your existing SSL3 services OR TLS w/ RC4 services, see [Cannot connect to a server by using the ServicePointManager or SslStream APIs after upgrade to the .NET Framework 4.6](https://support.microsoft.com/kb/3069494).
 
- Developers may want to opt out of this behavior in order to maintain interoperability with their existing SSL3 services OR TLS w/ RC4 services. [This article](https://support.microsoft.com/kb/3069494) explains how to modify your code so that the new behavior is disabled.
-
- The .NET Framework 4.7 adds new overloads for the methods that authenticate SslStreams that do not specify a TLS version, but instead use the TLS version defined as the system default in [SCHANNEL](/windows/win32/secauthn/secure-channel). Use these methods in your app as a way to be able to later modify the defaults as TLS version best practice changes over time, without the need to rebuild and redeploy your app.
-
- Also see [Transport Layer Security (TLS) best practices with the .NET Framework](/dotnet/framework/network-programming/tls).
-
-
+Use the the overloads for methods that authenticate SslStreams that don't specify a TLS version, but instead use the TLS version defined as the system default in [SCHANNEL](/windows/win32/secauthn/secure-channel), as a way to be able to later modify the defaults, without the need to rebuild and redeploy your app.
 
 ## Examples
  The following code example demonstrates creating an <xref:System.Net.Sockets.TcpListener> that uses the <xref:System.Net.Security.SslStream> class to communicate with clients.
@@ -337,12 +331,10 @@
  The use of the Null cipher is required when the encryption policy is set to <xref:System.Net.Security.EncryptionPolicy.NoEncryption?displayProperty=nameWithType>.
 
 > [!NOTE]
->  .NET caches SSL sessions as they are created and attempts to reuse a cached session for subsequent requests, if possible. When attempting to reuse an SSL session, the Framework uses the first element of the <xref:System.Security.Cryptography.X509Certificates.X509Certificate2Collection> provided during authentication (if there is one), or tries to reuse an anonymous sessions if the certificate collection is empty.
+> .NET caches SSL sessions as they are created and attempts to reuse a cached session for subsequent requests, if possible. When attempting to reuse an SSL session, .NET uses the first element of the <xref:System.Security.Cryptography.X509Certificates.X509Certificate2Collection> provided during authentication (if there is one), or tries to reuse an anonymous sessions if the certificate collection is empty.
 
 > [!NOTE]
->  Client certificates are not supported in the SSL version 2 protocol.
-
-
+> Client certificates are not supported in the SSL version 2 protocol.
 
 ## Examples
  The following code example creates an <xref:System.Net.Security.SslStream> and initiates the client portion of the authentication.
@@ -436,8 +428,7 @@
  The use of the Null cipher is required when the encryption policy is set to <xref:System.Net.Security.EncryptionPolicy.NoEncryption?displayProperty=nameWithType>.
 
 > [!NOTE]
->  .NET caches SSL sessions as they are created and attempts to reuse a cached session for subsequent requests, if possible. When attempting to reuse an SSL session, the Framework uses the first element of the <xref:System.Security.Cryptography.X509Certificates.X509Certificate2Collection> provided during authentication (if there is one), or tries to reuse an anonymous sessions if the certificate collection is empty.
-
+> .NET caches SSL sessions as they are created and attempts to reuse a cached session for subsequent requests, if possible. When attempting to reuse an SSL session, .NET uses the first element of the <xref:System.Security.Cryptography.X509Certificates.X509Certificate2Collection> provided during authentication (if there is one), or tries to reuse an anonymous sessions if the certificate collection is empty.
 
 ## Examples
  The following code example demonstrates calling this constructor. This example is part of a larger example provided for the <xref:System.Net.Security.SslStream> class.

--- a/xml/System.Net.Security/SslStream.xml
+++ b/xml/System.Net.Security/SslStream.xml
@@ -87,7 +87,7 @@
 
  <xref:System.Net.Security.SslStream> assumes that a timeout along with any other <xref:System.IO.IOException> when one is thrown from the inner stream will be treated as fatal by its caller. Reusing a <xref:System.Net.Security.SslStream> instance after a timeout will return garbage. An application should <xref:System.IO.Stream.Close*> the <xref:System.Net.Security.SslStream> and throw an exception in these cases.
 
-To opt out of the behavior that blocks insecure cipher and hashing algorithms for connections in order to maintain interoperability with your existing SSL3 services OR TLS w/ RC4 services, see [Cannot connect to a server by using the ServicePointManager or SslStream APIs after upgrade to the .NET Framework 4.6](https://support.microsoft.com/kb/3069494).
+To opt out of the behavior that blocks insecure cipher and hashing algorithms for connections in order to maintain interoperability with your existing SSL3 services OR TLS w/ RC4 services, see [Cannot connect to a server by using the ServicePointManager or SslStream APIs after upgrade to .NET Framework 4.6](https://support.microsoft.com/kb/3069494).
 
 Use the the overloads for methods that authenticate SslStreams that don't specify a TLS version, but instead use the TLS version defined as the system default in [SCHANNEL](/windows/win32/secauthn/secure-channel), as a way to be able to later modify the defaults, without the need to rebuild and redeploy your app.
 

--- a/xml/System.Net.Sockets/IPProtectionLevel.xml
+++ b/xml/System.Net.Sockets/IPProtectionLevel.xml
@@ -44,18 +44,17 @@
   <Docs>
     <summary>A value that enables restriction of an IPv6 socket to a specified scope, such as addresses with the same link local or site local prefix.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This option enables applications to place access restrictions on IPv6 sockets. Such restrictions enable an application running on a private LAN to simply and robustly harden itself against external attacks. This socket option widens or narrows the scope of a listening socket, enabling unrestricted access from public and private users when appropriate, or restricting access only to the same site, as required.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Remarks
+ This option enables applications to place access restrictions on IPv6 sockets. Such restrictions enable an application running on a private LAN to simply and robustly harden itself against external attacks. This socket option widens or narrows the scope of a listening socket, enabling unrestricted access from public and private users when appropriate, or restricting access only to the same site, as required.
+
  ]]></format>
     </remarks>
     <altmember cref="P:System.Net.IPAddress.IsIPv6Teredo" />
     <altmember cref="M:System.Net.Sockets.Socket.SetIPProtectionLevel(System.Net.Sockets.IPProtectionLevel)" />
     <altmember cref="M:System.Net.Sockets.TcpListener.AllowNatTraversal(System.Boolean)" />
     <altmember cref="M:System.Net.Sockets.UdpClient.AllowNatTraversal(System.Boolean)" />
-    <related type="Article" href="/dotnet/framework/configure-apps/file-schema/network/socket-element-network-settings">&lt;socket&gt; Element (Network Settings)</related>
   </Docs>
   <Members>
     <Member MemberName="EdgeRestricted">

--- a/xml/System.Net.Sockets/Socket.xml
+++ b/xml/System.Net.Sockets/Socket.xml
@@ -119,7 +119,7 @@ implementation, this may lead to unintended data interleaving for large or multi
         <Parameter Name="handle" Type="System.Net.Sockets.SafeSocketHandle" Index="0" FrameworkAlternate="net-10.0;net-11.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="handle">The socket handle for the socket that the <see cref="T:System.Net.Sockets.Socket" /> object will encapsulate.</param>
+        <param name="handle"> The socket handle for the socket that the <see cref="T:System.Net.Sockets.Socket" /> object will encapsulate.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.Sockets.Socket" /> class for the specified socket handle.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -181,7 +181,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="socketInformation" Type="System.Net.Sockets.SocketInformation" Index="0" FrameworkAlternate="net-10.0;net-11.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0;netcore-2.0;netcore-2.1;netcore-2.2;netcore-3.0;netcore-3.1" />
       </Parameters>
       <Docs>
-        <param name="socketInformation">The socket information returned by <see cref="M:System.Net.Sockets.Socket.DuplicateAndClose(System.Int32)" />.</param>
+        <param name="socketInformation"> The socket information returned by <see cref="M:System.Net.Sockets.Socket.DuplicateAndClose(System.Int32)" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Net.Sockets.Socket" /> class using the specified value returned from <see cref="M:System.Net.Sockets.Socket.DuplicateAndClose(System.Int32)" />.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -244,9 +244,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 > This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
-        <exception cref="T:System.Net.Sockets.SocketException">The combination of  <paramref name="socketType" /> and <paramref name="protocolType" /> results in an invalid socket.</exception>
+        <exception cref="T:System.Net.Sockets.SocketException"> The combination of  <paramref name="socketType" /> and <paramref name="protocolType" /> results in an invalid socket.</exception>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -313,7 +314,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.Net.Sockets.SocketException">The combination of <paramref name="addressFamily" />, <paramref name="socketType" />, and <paramref name="protocolType" /> results in an invalid socket.</exception>
+        <exception cref="T:System.Net.Sockets.SocketException"> The combination of <paramref name="addressFamily" />, <paramref name="socketType" />, and <paramref name="protocolType" /> results in an invalid socket.</exception>
         <altmember cref="T:System.Net.Sockets.SocketException" />
         <altmember cref="T:System.Net.Sockets.AddressFamily" />
         <altmember cref="T:System.Net.Sockets.ProtocolType" />
@@ -386,8 +387,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.InvalidOperationException">The accepting socket is not listening for connections. You must call <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> and <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" /> before calling <see cref="M:System.Net.Sockets.Socket.Accept" />.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.InvalidOperationException"> The accepting socket is not listening for connections. You must call <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> and <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" /> before calling <see cref="M:System.Net.Sockets.Socket.Accept" />.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />
         <altmember cref="P:System.Net.Sockets.Socket.RemoteEndPoint" />
         <altmember cref="M:System.Net.Sockets.Socket.BeginAccept(System.AsyncCallback,System.Object)" />
@@ -425,7 +426,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  You must call the <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> and <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" /> method before calling the <see cref="M:System.Net.Sockets.Socket.AcceptAsync(System.Net.Sockets.SocketAsyncEventArgs)" /> method.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="AcceptAsync">
@@ -462,7 +463,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="acceptSocket">The socket to use for accepting the connection.</param>
+        <param name="acceptSocket"> The socket to use for accepting the connection.</param>
         <summary>Accepts an incoming connection.</summary>
         <returns>An asynchronous task that completes with the accepted Socket.</returns>
         <remarks>To be added.</remarks>
@@ -470,7 +471,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  You must call the <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> and <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" /> method before calling the <see cref="M:System.Net.Sockets.Socket.AcceptAsync(System.Net.Sockets.SocketAsyncEventArgs)" /> method.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="AcceptAsync">
@@ -513,7 +514,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="e" Type="System.Net.Sockets.SocketAsyncEventArgs" />
       </Parameters>
       <Docs>
-        <param name="e">The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
+        <param name="e"> The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
         <summary>Begins an asynchronous operation to accept an incoming connection attempt.</summary>
         <returns>
           <see langword="true" /> if the I/O operation is pending. The <see cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" /> event on the <paramref name="e" /> parameter will be raised upon completion of the operation.
@@ -529,7 +530,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  The following properties and events on the <xref:System.Net.Sockets.SocketAsyncEventArgs?displayProperty=nameWithType> object are required:
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
 
  The caller can optionally specify an existing <xref:System.Net.Sockets.Socket> to use for the incoming connection by specifying the <xref:System.Net.Sockets.Socket> to use with the <xref:System.Net.Sockets.SocketAsyncEventArgs.AcceptSocket?displayProperty=nameWithType> property.
 
@@ -555,7 +556,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  This exception also occurs if the socket is already connected or a socket operation was already in progress using the specified <paramref name="e" /> parameter.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="T:System.Net.Sockets.SocketAsyncEventArgs" />
         <altmember cref="P:System.Net.Sockets.SocketAsyncEventArgs.AcceptSocket" />
         <altmember cref="P:System.Net.Sockets.SocketAsyncEventArgs.Buffer" />
@@ -605,8 +606,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  You must call the <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> and <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" /> method before calling the <see cref="M:System.Net.Sockets.Socket.AcceptAsync(System.Net.Sockets.SocketAsyncEventArgs)" /> method.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="AcceptAsync">
@@ -643,7 +644,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="acceptSocket">The socket to use for accepting the connection.</param>
+        <param name="acceptSocket"> The socket to use for accepting the connection.</param>
         <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         <summary>Accepts an incoming connection.</summary>
         <returns>An asynchronous task that completes with the accepted Socket.</returns>
@@ -652,8 +653,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  You must call the <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> and <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" /> method before calling the <see cref="M:System.Net.Sockets.Socket.AcceptAsync(System.Net.Sockets.SocketAsyncEventArgs)" /> method.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="AddressFamily">
@@ -754,7 +755,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </ReturnValue>
       <Docs>
         <summary>Gets the amount of data that has been received from the network and is available to be read.</summary>
-        <value>The number of bytes of data received from the network and available to be read.</value>
+        <value> The number of bytes of data received from the network and available to be read.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -774,7 +775,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Receive(System.Byte[],System.Int32,System.Net.Sockets.SocketFlags)" />
         <altmember cref="T:System.IO.Stream" />
         <altmember cref="F:System.Net.Sockets.SocketType.Dgram" />
@@ -838,7 +839,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="state" Type="System.Object" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0;netcore-2.0;netcore-2.1;netcore-2.2;netcore-3.0;netcore-3.1" />
       </Parameters>
       <Docs>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Begins an asynchronous operation to accept an incoming connection attempt.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> that references the asynchronous <see cref="T:System.Net.Sockets.Socket" /> creation.</returns>
@@ -871,8 +872,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.InvalidOperationException">The accepting socket is not listening for connections. You must call <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> and <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" /> before calling <see cref="M:System.Net.Sockets.Socket.BeginAccept(System.AsyncCallback,System.Object)" />.
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.InvalidOperationException"> The accepting socket is not listening for connections. You must call <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> and <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" /> before calling <see cref="M:System.Net.Sockets.Socket.BeginAccept(System.AsyncCallback,System.Object)" />.
 
  -or-
 
@@ -932,8 +933,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="state" Type="System.Object" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0;netcore-2.0;netcore-2.1;netcore-2.2;netcore-3.0;netcore-3.1" />
       </Parameters>
       <Docs>
-        <param name="receiveSize">The number of bytes to accept from the sender.</param>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="receiveSize"> The number of bytes to accept from the sender.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Begins an asynchronous operation to accept an incoming connection attempt and receives the first block of data sent by the client application.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> that references the asynchronous <see cref="T:System.Net.Sockets.Socket" /> creation.</returns>
@@ -959,15 +960,15 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
 > [!NOTE]
-> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.InvalidOperationException">The accepting socket is not listening for connections. You must call <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> and <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" /> before calling <see cref="M:System.Net.Sockets.Socket.BeginAccept(System.AsyncCallback,System.Object)" />.
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.InvalidOperationException"> The accepting socket is not listening for connections. You must call <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> and <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" /> before calling <see cref="M:System.Net.Sockets.Socket.BeginAccept(System.AsyncCallback,System.Object)" />.
 
  -or-
 
@@ -1030,9 +1031,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="state" Type="System.Object" Index="3" FrameworkAlternate="net-10.0;net-11.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0;netcore-2.0;netcore-2.1;netcore-2.2;netcore-3.0;netcore-3.1" />
       </Parameters>
       <Docs>
-        <param name="acceptSocket">The accepted <see cref="T:System.Net.Sockets.Socket" /> object. This value may be <see langword="null" />.</param>
-        <param name="receiveSize">The maximum number of bytes to receive.</param>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="acceptSocket"> The accepted <see cref="T:System.Net.Sockets.Socket" /> object. This value may be <see langword="null" />.</param>
+        <param name="receiveSize"> The maximum number of bytes to receive.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Begins an asynchronous operation to accept an incoming connection attempt from a specified socket and receives the first block of data sent by the client application.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> object that references the asynchronous <see cref="T:System.Net.Sockets.Socket" /> object creation.</returns>
@@ -1058,15 +1059,15 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
 > [!NOTE]
-> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.InvalidOperationException">The accepting socket is not listening for connections. You must call <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> and <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" /> before calling <see cref="M:System.Net.Sockets.Socket.BeginAccept(System.AsyncCallback,System.Object)" />.
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.InvalidOperationException"> The accepting socket is not listening for connections. You must call <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> and <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" /> before calling <see cref="M:System.Net.Sockets.Socket.BeginAccept(System.AsyncCallback,System.Object)" />.
 
  -or-
 
@@ -1148,7 +1149,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="remoteEP">An <see cref="T:System.Net.EndPoint" /> that represents the remote host.</param>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Begins an asynchronous request for a remote host connection.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> that references the asynchronous connection.</returns>
@@ -1174,18 +1175,18 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
 > [!NOTE]
-> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEP" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />, or an asynchronous operation is already in progress.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />, or an asynchronous operation is already in progress.</exception>
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="M:System.Net.Sockets.Socket.EndConnect(System.IAsyncResult)" />
         <altmember cref="M:System.Net.Sockets.Socket.BeginSendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint,System.AsyncCallback,System.Object)" />
@@ -1252,8 +1253,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="address">The <see cref="T:System.Net.IPAddress" /> of the remote host.</param>
-        <param name="port">The port number of the remote host.</param>
+        <param name="address"> The <see cref="T:System.Net.IPAddress" /> of the remote host.</param>
+        <param name="port"> The port number of the remote host.</param>
         <param name="requestCallback">An <see cref="T:System.AsyncCallback" /> delegate that references the method to invoke when the connect operation is complete.</param>
         <param name="state">A user-defined object that contains information about the connect operation. This object is passed to the <paramref name="requestCallback" /> delegate when the operation is complete.</param>
         <summary>Begins an asynchronous request for a remote host connection. The host is specified by an <see cref="T:System.Net.IPAddress" /> and a port number.</summary>
@@ -1281,23 +1282,23 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
-
-> [!NOTE]
 > If this socket has previously been disconnected, then <xref:System.Net.Sockets.Socket.BeginConnect*> must be called on a thread that will not exit until the operation is complete. This is a limitation of the underlying provider.
 
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="address" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.NotSupportedException">The <see cref="T:System.Net.Sockets.Socket" /> is not in the socket family.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The port number is not valid.</exception>
-        <exception cref="T:System.ArgumentException">The length of <paramref name="address" /> is zero.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />, or an asynchronous operation is already in progress.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The <see cref="T:System.Net.Sockets.Socket" /> is not in the socket family.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The port number is not valid.</exception>
+        <exception cref="T:System.ArgumentException"> The length of <paramref name="address" /> is zero.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />, or an asynchronous operation is already in progress.</exception>
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="M:System.Net.Sockets.Socket.EndConnect(System.IAsyncResult)" />
         <altmember cref="M:System.Net.Sockets.Socket.BeginSendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint,System.AsyncCallback,System.Object)" />
@@ -1365,7 +1366,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="addresses">At least one <see cref="T:System.Net.IPAddress" />, designating the remote host.</param>
-        <param name="port">The port number of the remote host.</param>
+        <param name="port"> The port number of the remote host.</param>
         <param name="requestCallback">An <see cref="T:System.AsyncCallback" /> delegate that references the method to invoke when the connect operation is complete.</param>
         <param name="state">A user-defined object that contains information about the connect operation. This object is passed to the <paramref name="requestCallback" /> delegate when the operation is complete.</param>
         <summary>Begins an asynchronous request for a remote host connection. The host is specified by an <see cref="T:System.Net.IPAddress" /> array and a port number.</summary>
@@ -1393,23 +1394,23 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
-
-> [!NOTE]
 > If this socket has previously been disconnected, then <xref:System.Net.Sockets.Socket.BeginConnect*> must be called on a thread that will not exit until the operation is complete. This is a limitation of the underlying provider.
 
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="addresses" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.NotSupportedException">This method is valid for sockets that use <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" />.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The port number is not valid.</exception>
-        <exception cref="T:System.ArgumentException">The length of <paramref name="addresses" /> is zero.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />, or an asynchronous operation is already in progress.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The port number is not valid.</exception>
+        <exception cref="T:System.ArgumentException"> The length of <paramref name="addresses" /> is zero.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />, or an asynchronous operation is already in progress.</exception>
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="M:System.Net.Sockets.Socket.EndConnect(System.IAsyncResult)" />
         <altmember cref="M:System.Net.Sockets.Socket.BeginSendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint,System.AsyncCallback,System.Object)" />
@@ -1476,8 +1477,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="host">The name of the remote host.</param>
-        <param name="port">The port number of the remote host.</param>
+        <param name="host"> The name of the remote host.</param>
+        <param name="port"> The port number of the remote host.</param>
         <param name="requestCallback">An <see cref="T:System.AsyncCallback" /> delegate that references the method to invoke when the connect operation is complete.</param>
         <param name="state">A user-defined object that contains information about the connect operation. This object is passed to the <paramref name="requestCallback" /> delegate when the operation is complete.</param>
         <summary>Begins an asynchronous request for a remote host connection. The host is specified by a host name and a port number.</summary>
@@ -1505,22 +1506,22 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
-
-> [!NOTE]
 > If this socket has previously been disconnected, then <xref:System.Net.Sockets.Socket.BeginConnect*> must be called on a thread that will not exit until the operation is complete. This is a limitation of the underlying provider.
 
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="host" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.NotSupportedException">This method is valid for sockets in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The port number is not valid.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />, or an asynchronous operation is already in progress.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The port number is not valid.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />, or an asynchronous operation is already in progress.</exception>
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="M:System.Net.Sockets.Socket.EndConnect(System.IAsyncResult)" />
         <altmember cref="M:System.Net.Sockets.Socket.BeginSendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint,System.AsyncCallback,System.Object)" />
@@ -1580,7 +1581,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       <Docs>
         <param name="reuseSocket">
           <see langword="true" /> if this socket can be reused after the connection is closed; otherwise, <see langword="false" />.</param>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Begins an asynchronous request to disconnect from a remote endpoint.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> object that references the asynchronous operation.</returns>
@@ -1600,9 +1601,12 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginReceive">
@@ -1694,9 +1698,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
-
-> [!NOTE]
 > All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
@@ -1704,6 +1705,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -1795,9 +1799,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
-
-> [!NOTE]
 > All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
@@ -1805,6 +1806,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -1882,8 +1886,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for the received data.</param>
-        <param name="offset">The zero-based position in the <paramref name="buffer" /> parameter at which to store the received data.</param>
-        <param name="size">The number of bytes to receive.</param>
+        <param name="offset"> The zero-based position in the <paramref name="buffer" /> parameter at which to store the received data.</param>
+        <param name="size"> The number of bytes to receive.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="callback">An <see cref="T:System.AsyncCallback" /> delegate that references the method to invoke when the operation is complete.</param>
         <param name="state">A user-defined object that contains information about the receive operation. This object is passed to the <see cref="M:System.Net.Sockets.Socket.EndReceive(System.IAsyncResult)" /> delegate when the operation is complete.</param>
@@ -1906,9 +1910,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
-
-> [!NOTE]
 > All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
@@ -1916,6 +1917,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -2000,8 +2004,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for the received data.</param>
-        <param name="offset">The location in <paramref name="buffer" /> to store the received data.</param>
-        <param name="size">The number of bytes to receive.</param>
+        <param name="offset"> The location in <paramref name="buffer" /> to store the received data.</param>
+        <param name="size"> The number of bytes to receive.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="errorCode">A <see cref="T:System.Net.Sockets.SocketError" /> object that stores the socket error.</param>
         <param name="callback">An <see cref="T:System.AsyncCallback" /> delegate that references the method to invoke when the operation is complete.</param>
@@ -2025,9 +2029,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
-
-> [!NOTE]
 > All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
@@ -2035,6 +2036,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -2127,11 +2131,11 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for the received data.</param>
-        <param name="offset">The zero-based position in the <paramref name="buffer" /> parameter at which to store the data.</param>
-        <param name="size">The number of bytes to receive.</param>
+        <param name="offset"> The zero-based position in the <paramref name="buffer" /> parameter at which to store the data.</param>
+        <param name="size"> The number of bytes to receive.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="remoteEP">A reference to an <see cref="T:System.Net.EndPoint" /> of the same type as the endpoint of the remote host to be updated on synchronous receive.</param>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Begins to asynchronously receive data from a specified network device.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> that references the asynchronous read.</returns>
@@ -2162,10 +2166,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
 > [!NOTE]
-> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -2189,7 +2193,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  -or-
 
  <paramref name="size" /> is greater than the length of <paramref name="buffer" /> minus the value of the <paramref name="offset" /> parameter.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.EndReceiveFrom(System.IAsyncResult,System.Net.EndPoint@)" />
         <altmember cref="T:System.AsyncCallback" />
@@ -2260,11 +2264,11 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for the received data.</param>
-        <param name="offset">The zero-based position in the <paramref name="buffer" /> parameter at which to store the data.</param>
-        <param name="size">The number of bytes to receive.</param>
+        <param name="offset"> The zero-based position in the <paramref name="buffer" /> parameter at which to store the data.</param>
+        <param name="size"> The number of bytes to receive.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="remoteEP">A reference to an <see cref="T:System.Net.EndPoint" /> of the same type as the endpoint of the remote host to be updated on synchronous receive.</param>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Begins to asynchronously receive the specified number of bytes of data into the specified location of the data buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />, and stores the endpoint and packet information.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> that references the asynchronous read.</returns>
@@ -2287,10 +2291,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
 > [!NOTE]
-> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -2314,7 +2318,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  -or-
 
  <paramref name="size" /> is greater than the length of <paramref name="buffer" /> minus the value of the <paramref name="offset" /> parameter.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginSend">
@@ -2385,7 +2389,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       <Docs>
         <param name="buffers">An array of type <see cref="T:System.Byte" /> that contains the data to send.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Sends data asynchronously to a connected <see cref="T:System.Net.Sockets.Socket" />.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> that references the asynchronous send.</returns>
@@ -2408,9 +2412,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
-
-> [!NOTE]
 > All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
@@ -2422,13 +2423,16 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffers" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="buffers" /> is empty.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="M:System.Net.Sockets.Socket.EndSend(System.IAsyncResult)" />
@@ -2491,7 +2495,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <param name="buffers">An array of type <see cref="T:System.Byte" /> that contains the data to send.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="errorCode">A <see cref="T:System.Net.Sockets.SocketError" /> object that stores the socket error.</param>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Sends data asynchronously to a connected <see cref="T:System.Net.Sockets.Socket" />.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> that references the asynchronous send.</returns>
@@ -2514,9 +2518,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
-
-> [!NOTE]
 > All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
@@ -2528,13 +2529,16 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffers" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="buffers" /> is empty.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="M:System.Net.Sockets.Socket.EndSend(System.IAsyncResult)" />
@@ -2604,10 +2608,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the data to send.</param>
-        <param name="offset">The zero-based position in the <paramref name="buffer" /> parameter at which to begin sending data.</param>
-        <param name="size">The number of bytes to send.</param>
+        <param name="offset"> The zero-based position in the <paramref name="buffer" /> parameter at which to begin sending data.</param>
+        <param name="size"> The number of bytes to send.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Sends data asynchronously to a connected <see cref="T:System.Net.Sockets.Socket" />.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> that references the asynchronous send.</returns>
@@ -2630,9 +2634,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
-
-> [!NOTE]
 > All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
@@ -2643,6 +2644,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -2662,7 +2666,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  -or-
 
  <paramref name="size" /> is greater than the length of <paramref name="buffer" /> minus the value of the <paramref name="offset" /> parameter.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="M:System.Net.Sockets.Socket.EndSend(System.IAsyncResult)" />
@@ -2725,11 +2729,11 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the data to send.</param>
-        <param name="offset">The zero-based position in the <paramref name="buffer" /> parameter at which to begin sending data.</param>
-        <param name="size">The number of bytes to send.</param>
+        <param name="offset"> The zero-based position in the <paramref name="buffer" /> parameter at which to begin sending data.</param>
+        <param name="size"> The number of bytes to send.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="errorCode">A <see cref="T:System.Net.Sockets.SocketError" /> object that stores the socket error.</param>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Sends data asynchronously to a connected <see cref="T:System.Net.Sockets.Socket" />.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> that references the asynchronous send.</returns>
@@ -2755,9 +2759,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
-
-> [!NOTE]
 > `state` is an instantiation of a user-defined class.
 
 > [!NOTE]
@@ -2765,6 +2766,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -2784,7 +2788,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  -or-
 
  <paramref name="size" /> is greater than the length of <paramref name="buffer" /> minus the value of the <paramref name="offset" /> parameter.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="M:System.Net.Sockets.Socket.EndSend(System.IAsyncResult)" />
@@ -2853,7 +2857,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="fileName">A string that contains the path and name of the file to send. This parameter can be <see langword="null" />.</param>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Sends the file <paramref name="fileName" /> to a connected <see cref="T:System.Net.Sockets.Socket" /> object using the <see cref="F:System.Net.Sockets.TransmitFileOptions.UseDefaultWorkerThread" /> flag.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> object that represents the asynchronous send.</returns>
@@ -2880,9 +2884,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.NotSupportedException">The socket is not connected to a remote host.</exception>
-        <exception cref="T:System.IO.FileNotFoundException">The file <paramref name="fileName" /> was not found.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not connected to a remote host.</exception>
+        <exception cref="T:System.IO.FileNotFoundException"> The file <paramref name="fileName" /> was not found.</exception>
       </Docs>
     </Member>
     <Member MemberName="BeginSendFile">
@@ -2937,8 +2941,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="fileName">A string that contains the path and name of the file to be sent. This parameter can be <see langword="null" />.</param>
-        <param name="preBuffer">The data to be sent before the file is sent. This parameter can be <see langword="null" />.</param>
-        <param name="postBuffer">The data to be sent after the file is sent. This parameter can be <see langword="null" />.</param>
+        <param name="preBuffer"> The data to be sent before the file is sent. This parameter can be <see langword="null" />.</param>
+        <param name="postBuffer"> The data to be sent after the file is sent. This parameter can be <see langword="null" />.</param>
         <param name="flags">A bitwise combination of the enumeration values.</param>
         <param name="callback">An <see cref="T:System.AsyncCallback" /> delegate to be invoked when this operation completes. This parameter can be <see langword="null" />.</param>
         <param name="state">A user-defined object that contains state information for this request. This parameter can be <see langword="null" />.</param>
@@ -2967,15 +2971,18 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.NotSupportedException">The operating system is not Windows NT or later.
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The operating system is not Windows NT or later.
 
 -or-
 
  The socket is not connected to a remote host.</exception>
-        <exception cref="T:System.IO.FileNotFoundException">The file <paramref name="fileName" /> was not found.</exception>
+        <exception cref="T:System.IO.FileNotFoundException"> The file <paramref name="fileName" /> was not found.</exception>
       </Docs>
     </Member>
     <Member MemberName="BeginSendTo">
@@ -3040,11 +3047,11 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the data to send.</param>
-        <param name="offset">The zero-based position in <paramref name="buffer" /> at which to begin sending data.</param>
-        <param name="size">The number of bytes to send.</param>
+        <param name="offset"> The zero-based position in <paramref name="buffer" /> at which to begin sending data.</param>
+        <param name="size"> The number of bytes to send.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="remoteEP">An <see cref="T:System.Net.EndPoint" /> that represents the remote device.</param>
-        <param name="callback">The <see cref="T:System.AsyncCallback" /> delegate.</param>
+        <param name="callback"> The <see cref="T:System.AsyncCallback" /> delegate.</param>
         <param name="state">An object that contains state information for this request.</param>
         <summary>Sends data asynchronously to a specific remote host.</summary>
         <returns>An <see cref="T:System.IAsyncResult" /> that references the asynchronous send.</returns>
@@ -3073,6 +3080,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -3095,7 +3105,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  -or-
 
  <paramref name="size" /> is greater than the length of <paramref name="buffer" /> minus the value of the <paramref name="offset" /> parameter.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.EndSendTo(System.IAsyncResult)" />
         <altmember cref="T:System.AsyncCallback" />
@@ -3147,7 +3157,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="localEP" Type="System.Net.EndPoint" />
       </Parameters>
       <Docs>
-        <param name="localEP">The local <see cref="T:System.Net.EndPoint" /> to associate with the <see cref="T:System.Net.Sockets.Socket" />.</param>
+        <param name="localEP"> The local <see cref="T:System.Net.EndPoint" /> to associate with the <see cref="T:System.Net.Sockets.Socket" />.</param>
         <summary>Associates a <see cref="T:System.Net.Sockets.Socket" /> with a local endpoint.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -3170,7 +3180,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException> when calling the <xref:System.Net.Sockets.Socket.Bind*> method, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example binds a <xref:System.Net.Sockets.Socket> using the specified local endpoint.
@@ -3183,7 +3194,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <exception cref="T:System.ArgumentNullException">
           <paramref name="localEP" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
         <altmember cref="T:System.Net.IPEndPoint" />
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
@@ -3244,10 +3255,13 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="CancelConnectAsync">
@@ -3289,7 +3303,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="e" Type="System.Net.Sockets.SocketAsyncEventArgs" />
       </Parameters>
       <Docs>
-        <param name="e">The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object used to request the connection to the remote host by calling one of the <see cref="M:System.Net.Sockets.Socket.ConnectAsync(System.Net.Sockets.SocketType,System.Net.Sockets.ProtocolType,System.Net.Sockets.SocketAsyncEventArgs)" /> methods.</param>
+        <param name="e"> The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object used to request the connection to the remote host by calling one of the <see cref="M:System.Net.Sockets.Socket.ConnectAsync(System.Net.Sockets.SocketType,System.Net.Sockets.ProtocolType,System.Net.Sockets.SocketAsyncEventArgs)" /> methods.</param>
         <summary>Cancels an asynchronous request for a remote host connection.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -3299,9 +3313,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="e" /> parameter cannot be null and the <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> cannot be null.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="e" /> parameter cannot be null and the <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> cannot be null.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
       </Docs>
     </Member>
@@ -3367,7 +3381,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > To set the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to `false`, create a <xref:System.Net.Sockets.LingerOption>, set the enabled property to `true`, and set the <xref:System.Net.Sockets.LingerOption.LingerTime> property to the desired time out period. Use this <xref:System.Net.Sockets.LingerOption> along with the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to call the <xref:System.Net.Sockets.Socket.SetSocketOption*> method.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example closes a <xref:System.Net.Sockets.Socket>.
@@ -3435,7 +3450,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > To set the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to `false`, create a <xref:System.Net.Sockets.LingerOption>, set the enabled property to `true`, and set the <xref:System.Net.Sockets.LingerOption.LingerTime> property to the desired time-out period. Use this <xref:System.Net.Sockets.LingerOption> along with the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to call the <xref:System.Net.Sockets.Socket.SetSocketOption*> method.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates how to close a <xref:System.Net.Sockets.Socket>.
@@ -3518,8 +3534,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
 
-
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 ## Examples
  The following code example connects to a remote endpoint and then verifies the connection.
 
@@ -3531,9 +3547,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEP" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Send(System.Byte[],System.Int32,System.Net.Sockets.SocketFlags)" />
         <altmember cref="M:System.Net.Sockets.Socket.SendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Receive(System.Byte[],System.Int32,System.Net.Sockets.SocketFlags)" />
@@ -3585,8 +3601,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="port" Type="System.Int32" />
       </Parameters>
       <Docs>
-        <param name="address">The IP address of the remote host.</param>
-        <param name="port">The port number of the remote host.</param>
+        <param name="address"> The IP address of the remote host.</param>
+        <param name="port"> The port number of the remote host.</param>
         <summary>Establishes a connection to a remote host. The host is specified by an IP address and a port number.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -3604,6 +3620,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example connects to a remote endpoint and then verifies the connection.
 
@@ -3613,12 +3632,12 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="address" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The port number is not valid.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The port number is not valid.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.NotSupportedException">This method is valid for sockets in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
-        <exception cref="T:System.ArgumentException">The length of <paramref name="address" /> is zero.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />.</exception>
+        <exception cref="T:System.ArgumentException"> The length of <paramref name="address" /> is zero.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />.</exception>
       </Docs>
     </Member>
     <Member MemberName="Connect">
@@ -3662,8 +3681,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="port" Type="System.Int32" />
       </Parameters>
       <Docs>
-        <param name="addresses">The IP addresses of the remote host.</param>
-        <param name="port">The port number of the remote host.</param>
+        <param name="addresses"> The IP addresses of the remote host.</param>
+        <param name="port"> The port number of the remote host.</param>
         <summary>Establishes a connection to a remote host. The host is specified by an array of IP addresses and a port number.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -3681,6 +3700,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example connects to a remote endpoint and then verifies the connection.
 
@@ -3690,12 +3712,12 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="addresses" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The port number is not valid.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The port number is not valid.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.NotSupportedException">The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
-        <exception cref="T:System.ArgumentException">The length of <paramref name="addresses" /> is zero.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
+        <exception cref="T:System.ArgumentException"> The length of <paramref name="addresses" /> is zero.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />.</exception>
       </Docs>
     </Member>
     <Member MemberName="Connect">
@@ -3739,8 +3761,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="port" Type="System.Int32" />
       </Parameters>
       <Docs>
-        <param name="host">The name of the remote host.</param>
-        <param name="port">The port number of the remote host.</param>
+        <param name="host"> The name of the remote host.</param>
+        <param name="port"> The port number of the remote host.</param>
         <summary>Establishes a connection to a remote host. The host is specified by a host name and a port number.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -3760,6 +3782,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example connects to a remote endpoint and then verifies the connection.
 
@@ -3769,11 +3794,11 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="host" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The port number is not valid.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The port number is not valid.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.NotSupportedException">The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ConnectAsync">
@@ -3813,15 +3838,15 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="remoteEP" Type="System.Net.EndPoint" Index="0" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="remoteEP">The endpoint to connect to.</param>
+        <param name="remoteEP"> The endpoint to connect to.</param>
         <summary>Establishes a connection to a remote host.</summary>
         <returns>An asynchronous task that completes when the connection is established.</returns>
         <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />.</remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="remoteEP" /> parameter cannot be null.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="remoteEP" /> parameter cannot be null.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.NotSupportedException">The local endpoint and the <paramref name="remoteEP" /> parameter are not the same address family.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The local endpoint and the <paramref name="remoteEP" /> parameter are not the same address family.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
       </Docs>
     </Member>
@@ -3865,7 +3890,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="e" Type="System.Net.Sockets.SocketAsyncEventArgs" />
       </Parameters>
       <Docs>
-        <param name="e">The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
+        <param name="e"> The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
         <summary>Begins an asynchronous request for a connection to a remote host.</summary>
         <returns>
           <see langword="true" /> if the I/O operation is pending. The <see cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" /> event on the <paramref name="e" /> parameter will be raised upon completion of the operation.
@@ -3889,9 +3914,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  The following properties and events on the <xref:System.Net.Sockets.SocketAsyncEventArgs?displayProperty=nameWithType> object are required:
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
-
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint*?displayProperty=nameWithType>
 
  Optionally, a buffer may be provided that will atomically be sent on the socket after the <xref:System.Net.Sockets.Socket.ConnectAsync*> method succeeds. In this case, the <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer?displayProperty=nameWithType> property needs to be set to the buffer containing the data to send and the <xref:System.Net.Sockets.SocketAsyncEventArgs.Count?displayProperty=nameWithType> property needs to be set to the number of bytes of data to send from the buffer. Once a connection is established, this buffer of data is sent.
 
@@ -3907,11 +3931,11 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentException">An argument is not valid. This exception occurs if multiple buffers are specified, the <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.BufferList" /> property is not null.</exception>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="e" /> parameter cannot be null and the <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> cannot be null.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> is listening or a socket operation was already in progress using the <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object specified in the <paramref name="e" /> parameter.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="e" /> parameter cannot be null and the <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> cannot be null.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> is listening or a socket operation was already in progress using the <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object specified in the <paramref name="e" /> parameter.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.NotSupportedException">The local endpoint and the <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> are not the same address family.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The local endpoint and the <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> are not the same address family.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
         <altmember cref="T:System.Net.Sockets.SocketAsyncEventArgs" />
         <altmember cref="P:System.Net.Sockets.SocketAsyncEventArgs.Buffer" />
@@ -3949,18 +3973,18 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="remoteEP">The endpoint to connect to.</param>
+        <param name="remoteEP"> The endpoint to connect to.</param>
         <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         <summary>Establishes a connection to a remote host.</summary>
         <returns>An asynchronous task that completes when the connection is established.</returns>
         <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />.</remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="remoteEP" /> parameter cannot be null.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="remoteEP" /> parameter cannot be null.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.NotSupportedException">The local endpoint and the <paramref name="remoteEP" /> parameter are not the same address family.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The local endpoint and the <paramref name="remoteEP" /> parameter are not the same address family.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="ConnectAsync">
@@ -3991,22 +4015,22 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="port" Type="System.Int32" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="address">The IPAddress of the remote host to connect to.</param>
-        <param name="port">The port on the remote host to connect to.</param>
+        <param name="address"> The IPAddress of the remote host to connect to.</param>
+        <param name="port"> The port on the remote host to connect to.</param>
         <summary>Establishes a connection to a remote host.</summary>
         <returns>An asynchronous task that completes when the connection is established.</returns>
         <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Net.Sockets.Socket.Connect(System.Net.IPAddress,System.Int32)" />.</remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter cannot be null.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="address" /> parameter cannot be null.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="port" /> is less than <see cref="F:System.Net.IPEndPoint.MinPort" />.
 
  -or-
 
  <paramref name="port" /> is greater than <see cref="F:System.Net.IPEndPoint.MaxPort" />.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
-        <exception cref="T:System.NotSupportedException">The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
       </Docs>
     </Member>
@@ -4039,22 +4063,22 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="addresses">A list of IPAddresses for the remote host that will be used to attempt to connect to the remote host.</param>
-        <param name="port">The port on the remote host to connect to.</param>
+        <param name="port"> The port on the remote host to connect to.</param>
         <summary>Establishes a connection to a remote host.</summary>
         <returns>An asynchronous task that completes when the connection is established.</returns>
         <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Net.Sockets.Socket.Connect(System.Net.IPAddress[],System.Int32)" />.</remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="addresses" /> parameter cannot be null.</exception>
-        <exception cref="T:System.ArgumentException">The <paramref name="addresses" /> parameter cannot be empty array.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="addresses" /> parameter cannot be null.</exception>
+        <exception cref="T:System.ArgumentException"> The <paramref name="addresses" /> parameter cannot be empty array.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="port" /> is less than <see cref="F:System.Net.IPEndPoint.MinPort" />.
 
  -or-
 
  <paramref name="port" /> is greater than <see cref="F:System.Net.IPEndPoint.MaxPort" />.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
-        <exception cref="T:System.NotSupportedException">The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
       </Docs>
     </Member>
@@ -4086,22 +4110,22 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="port" Type="System.Int32" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="host">The hostname of the remote host to connect to.</param>
-        <param name="port">The port on the remote host to connect to.</param>
+        <param name="host"> The hostname of the remote host to connect to.</param>
+        <param name="port"> The port on the remote host to connect to.</param>
         <summary>Establishes a connection to a remote host.</summary>
         <returns>An asynchronous task that completes when the connection is established.</returns>
         <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Net.Sockets.Socket.Connect(System.String,System.Int32)" />.</remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="host" /> parameter cannot be null.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="host" /> parameter cannot be null.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="port" /> is less than <see cref="F:System.Net.IPEndPoint.MinPort" />.
 
  -or-
 
  <paramref name="port" /> is greater than <see cref="F:System.Net.IPEndPoint.MaxPort" />.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
-        <exception cref="T:System.NotSupportedException">The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
       </Docs>
     </Member>
@@ -4134,24 +4158,24 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="address">The IPAddress of the remote host to connect to.</param>
-        <param name="port">The port on the remote host to connect to.</param>
+        <param name="address"> The IPAddress of the remote host to connect to.</param>
+        <param name="port"> The port on the remote host to connect to.</param>
         <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         <summary>Establishes a connection to a remote host.</summary>
         <returns>An asynchronous task that completes when the connection is established.</returns>
         <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Net.Sockets.Socket.Connect(System.Net.IPAddress,System.Int32)" />.</remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="address" /> parameter cannot be null.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="address" /> parameter cannot be null.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="port" /> is less than <see cref="F:System.Net.IPEndPoint.MinPort" />.
 
  -or-
 
  <paramref name="port" /> is greater than <see cref="F:System.Net.IPEndPoint.MaxPort" />.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="ConnectAsync">
@@ -4184,25 +4208,25 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       </Parameters>
       <Docs>
         <param name="addresses">A list of IPAddresses for the remote host that will be used to attempt to connect to the remote host.</param>
-        <param name="port">The port on the remote host to connect to.</param>
+        <param name="port"> The port on the remote host to connect to.</param>
         <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         <summary>Establishes a connection to a remote host.</summary>
         <returns>An asynchronous task that completes when the connection is established.</returns>
         <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Net.Sockets.Socket.Connect(System.Net.IPAddress[],System.Int32)" />.</remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="addresses" /> parameter cannot be null.</exception>
-        <exception cref="T:System.ArgumentException">The <paramref name="addresses" /> parameter cannot be empty array.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="addresses" /> parameter cannot be null.</exception>
+        <exception cref="T:System.ArgumentException"> The <paramref name="addresses" /> parameter cannot be empty array.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="port" /> is less than <see cref="F:System.Net.IPEndPoint.MinPort" />.
 
  -or-
 
  <paramref name="port" /> is greater than <see cref="F:System.Net.IPEndPoint.MaxPort" />.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
-        <exception cref="T:System.NotSupportedException">The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="ConnectAsync">
@@ -4248,7 +4272,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
       <Docs>
         <param name="socketType">One of the <see cref="T:System.Net.Sockets.SocketType" /> values.</param>
         <param name="protocolType">One of the <see cref="T:System.Net.Sockets.ProtocolType" /> values.</param>
-        <param name="e">The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
+        <param name="e"> The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
         <summary>Begins an asynchronous request for a connection to a remote host.</summary>
         <returns>
           <see langword="true" /> if the I/O operation is pending. The <see cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" /> event on the <paramref name="e" /> parameter will be raised upon completion of the operation.
@@ -4272,9 +4296,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  The following properties and events on the <xref:System.Net.Sockets.SocketAsyncEventArgs?displayProperty=nameWithType> object are required:
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint*?displayProperty=nameWithType>
 
  Optionally, a buffer may be provided that will atomically be sent on the socket after the <xref:System.Net.Sockets.Socket.ConnectAsync*> method succeeds. In this case, the <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer?displayProperty=nameWithType> property needs to be set to the buffer containing the data to send and the <xref:System.Net.Sockets.SocketAsyncEventArgs.Count?displayProperty=nameWithType> property needs to be set to the number of bytes of data to send from the buffer. Once a connection is established, this buffer of data is sent.
 
@@ -4290,11 +4314,11 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentException">An argument is not valid. This exception occurs if multiple buffers are specified, the <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.BufferList" /> property is not null.</exception>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="e" /> parameter cannot be null and the <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> cannot be null.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> is listening or a socket operation was already in progress using the <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object specified in the <paramref name="e" /> parameter.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="e" /> parameter cannot be null and the <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> cannot be null.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> is listening or a socket operation was already in progress using the <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object specified in the <paramref name="e" /> parameter.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.NotSupportedException">The local endpoint and the <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> are not the same address family.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The local endpoint and the <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> are not the same address family.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
       </Docs>
     </Member>
@@ -4327,25 +4351,25 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="host">The hostname of the remote host to connect to.</param>
-        <param name="port">The port on the remote host to connect to.</param>
+        <param name="host"> The hostname of the remote host to connect to.</param>
+        <param name="port"> The port on the remote host to connect to.</param>
         <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         <summary>Establishes a connection to a remote host.</summary>
         <returns>An asynchronous task that completes when the connection is established.</returns>
         <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Net.Sockets.Socket.Connect(System.String,System.Int32)" />.</remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="host" /> parameter cannot be null.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="host" /> parameter cannot be null.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="port" /> is less than <see cref="F:System.Net.IPEndPoint.MinPort" />.
 
  -or-
 
  <paramref name="port" /> is greater than <see cref="F:System.Net.IPEndPoint.MaxPort" />.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
-        <exception cref="T:System.NotSupportedException">The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> is listening.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="ConnectAsync">
@@ -4506,7 +4530,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example creates a socket for synchronous communication and sends some data to a remote host. It then calls <xref:System.Net.Sockets.Socket.Shutdown*>, to stop the send and receive activity, and <xref:System.Net.Sockets.Socket.Disconnect*>, to close the socket connection.
@@ -4515,7 +4540,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
       </Docs>
     </Member>
@@ -4558,7 +4583,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="e" Type="System.Net.Sockets.SocketAsyncEventArgs" Index="0" FrameworkAlternate="net-10.0;net-11.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0;netcore-2.0;netcore-2.1;netcore-2.2;netcore-3.0;netcore-3.1" />
       </Parameters>
       <Docs>
-        <param name="e">The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
+        <param name="e"> The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
         <summary>Begins an asynchronous request to disconnect from a remote endpoint.</summary>
         <returns>
           <see langword="true" /> if the I/O operation is pending. The <see cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" /> event on the <paramref name="e" /> parameter will be raised upon completion of the operation.
@@ -4572,9 +4597,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="e" /> parameter cannot be null.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="e" /> parameter cannot be null.</exception>
         <exception cref="T:System.InvalidOperationException">A socket operation was already in progress using the <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object specified in the <paramref name="e" /> parameter.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
         <altmember cref="T:System.Net.Sockets.SocketAsyncEventArgs" />
         <altmember cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" />
@@ -4613,9 +4638,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <summary>Disconnects a connected socket from the remote host.</summary>
         <returns>An asynchronous task that completes when the socket is disconnected.</returns>
         <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Net.Sockets.Socket.Disconnect(System.Boolean)" />.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="Dispose">
@@ -4736,6 +4761,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.Sockets.Socket> references. This method invokes the `Dispose()` method of each referenced object.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <block subset="none" type="overrides">
@@ -4801,9 +4829,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.NotSupportedException">The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> family.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> family.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="DualMode">
@@ -4846,7 +4874,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <value>
           <see langword="true" /> if the <see cref="T:System.Net.Sockets.Socket" /> is a dual-mode socket; otherwise, <see langword="false" />. The default is <see langword="true" /> if the socket was created by calling the <see cref="M:System.Net.Sockets.Socket.#ctor(System.Net.Sockets.SocketType,System.Net.Sockets.ProtocolType)" /> constructor and the operating system supports IPv6; otherwise, the default is <see langword="false" />.</value>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.NotSupportedException">The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> address family.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> address family.</exception>
       </Docs>
     </Member>
     <Member MemberName="DuplicateAndClose">
@@ -4894,9 +4922,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <Parameter Name="targetProcessId" Type="System.Int32" Index="0" FrameworkAlternate="net-10.0;net-11.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0;netcore-2.0;netcore-2.1;netcore-2.2;netcore-3.0;netcore-3.1" />
       </Parameters>
       <Docs>
-        <param name="targetProcessId">The ID of the target process where a duplicate of the socket reference is created.</param>
+        <param name="targetProcessId"> The ID of the target process where a duplicate of the socket reference is created.</param>
         <summary>Duplicates the socket reference for the target process, and closes the socket for this process.</summary>
-        <returns>The socket reference to be passed to the target process.</returns>
+        <returns> The socket reference to be passed to the target process.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -4977,7 +5005,7 @@ Duplication of the socket reference failed.</exception>
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">This option is valid for a datagram socket only.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="EndAccept">
@@ -5188,7 +5216,7 @@ Duplication of the socket reference failed.</exception>
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the bytes transferred.</param>
-        <param name="bytesTransferred">The number of bytes transferred.</param>
+        <param name="bytesTransferred"> The number of bytes transferred.</param>
         <param name="asyncResult">An <see cref="T:System.IAsyncResult" /> object that stores state information for this asynchronous operation as well as any user defined data.</param>
         <summary>Asynchronously accepts an incoming connection attempt and creates a new <see cref="T:System.Net.Sockets.Socket" /> object to handle remote host communication. This method returns a buffer that contains the initial data and the number of bytes transferred.</summary>
         <returns>A <see cref="T:System.Net.Sockets.Socket" /> object to handle communication with the remote host.</returns>
@@ -5368,7 +5396,7 @@ Duplication of the socket reference failed.</exception>
 -or-
 
 .NET 7+ only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.Net.WebException">The disconnect request has timed out.</exception>
+        <exception cref="T:System.Net.WebException"> The disconnect request has timed out.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="EndReceive">
@@ -5423,7 +5451,7 @@ Duplication of the socket reference failed.</exception>
       <Docs>
         <param name="asyncResult">An <see cref="T:System.IAsyncResult" /> that stores state information and any user defined data for this asynchronous operation.</param>
         <summary>Ends a pending asynchronous read.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown. If zero bytes are requested, receive operations may complete immediately or may not complete until at least one byte is available (but without consuming any data).</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown. If zero bytes are requested, receive operations may complete immediately or may not complete until at least one byte is available (but without consuming any data).</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -5439,10 +5467,10 @@ Duplication of the socket reference failed.</exception>
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
-> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -5507,7 +5535,7 @@ Duplication of the socket reference failed.</exception>
         <param name="asyncResult">An <see cref="T:System.IAsyncResult" /> that stores state information and any user defined data for this asynchronous operation.</param>
         <param name="errorCode">A <see cref="T:System.Net.Sockets.SocketError" /> object that stores the socket error.</param>
         <summary>Ends a pending asynchronous read.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown. If zero bytes are requested, receive operations may complete immediately or may not complete until at least one byte is available (but without consuming any data).</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown. If zero bytes are requested, receive operations may complete immediately or may not complete until at least one byte is available (but without consuming any data).</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -5523,10 +5551,10 @@ Duplication of the socket reference failed.</exception>
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
-> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -5590,9 +5618,9 @@ Duplication of the socket reference failed.</exception>
       </Parameters>
       <Docs>
         <param name="asyncResult">An <see cref="T:System.IAsyncResult" /> that stores state information and any user defined data for this asynchronous operation.</param>
-        <param name="endPoint">The source <see cref="T:System.Net.EndPoint" />.</param>
+        <param name="endPoint"> The source <see cref="T:System.Net.EndPoint" />.</param>
         <summary>Ends a pending asynchronous read from a specific endpoint.</summary>
-        <returns>If successful, the number of bytes received. If unsuccessful, returns 0.</returns>
+        <returns> If successful, the number of bytes received. If unsuccessful, returns 0.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -5669,10 +5697,10 @@ Duplication of the socket reference failed.</exception>
       <Docs>
         <param name="asyncResult">An <see cref="T:System.IAsyncResult" /> that stores state information and any user defined data for this asynchronous operation.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values for the received packet.</param>
-        <param name="endPoint">The source <see cref="T:System.Net.EndPoint" />.</param>
-        <param name="ipPacketInformation">The <see cref="T:System.Net.IPAddress" /> and interface of the received packet.</param>
+        <param name="endPoint"> The source <see cref="T:System.Net.EndPoint" />.</param>
+        <param name="ipPacketInformation"> The <see cref="T:System.Net.IPAddress" /> and interface of the received packet.</param>
         <summary>Ends a pending asynchronous read from a specific endpoint. This method also reveals more information about the packet than <see cref="M:System.Net.Sockets.Socket.EndReceiveFrom(System.IAsyncResult,System.Net.EndPoint@)" />.</summary>
-        <returns>If successful, the number of bytes received. If unsuccessful, returns 0.</returns>
+        <returns> If successful, the number of bytes received. If unsuccessful, returns 0.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -5686,9 +5714,6 @@ Duplication of the socket reference failed.</exception>
 
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
-
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -5761,7 +5786,7 @@ Duplication of the socket reference failed.</exception>
       <Docs>
         <param name="asyncResult">An <see cref="T:System.IAsyncResult" /> that stores state information for this asynchronous operation.</param>
         <summary>Ends a pending asynchronous send.</summary>
-        <returns>If successful, the number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />; otherwise, an invalid <see cref="T:System.Net.Sockets.Socket" /> error.</returns>
+        <returns> If successful, the number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />; otherwise, an invalid <see cref="T:System.Net.Sockets.Socket" /> error.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -5779,13 +5804,13 @@ Duplication of the socket reference failed.</exception>
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application.
-
-> [!NOTE]
 > All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
 > The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -5850,7 +5875,7 @@ Duplication of the socket reference failed.</exception>
         <param name="asyncResult">An <see cref="T:System.IAsyncResult" /> that stores state information for this asynchronous operation.</param>
         <param name="errorCode">A <see cref="T:System.Net.Sockets.SocketError" /> object that stores the socket error.</param>
         <summary>Ends a pending asynchronous send.</summary>
-        <returns>If successful, the number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />; otherwise, an invalid <see cref="T:System.Net.Sockets.Socket" /> error.</returns>
+        <returns> If successful, the number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />; otherwise, an invalid <see cref="T:System.Net.Sockets.Socket" /> error.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -5951,6 +5976,9 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.NotSupportedException">.NET 8+ only: The socket is not connected to a remote host.</exception>
@@ -6009,7 +6037,7 @@ Duplication of the socket reference failed.</exception>
       <Docs>
         <param name="asyncResult">An <see cref="T:System.IAsyncResult" /> that stores state information and any user defined data for this asynchronous operation.</param>
         <summary>Ends a pending asynchronous send to a specific location.</summary>
-        <returns>If successful, the number of bytes sent; otherwise, an invalid <see cref="T:System.Net.Sockets.Socket" /> error.</returns>
+        <returns> If successful, the number of bytes sent; otherwise, an invalid <see cref="T:System.Net.Sockets.Socket" /> error.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -6023,6 +6051,9 @@ Duplication of the socket reference failed.</exception>
 
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -6097,7 +6128,7 @@ Duplication of the socket reference failed.</exception>
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.InvalidOperationException">
           <see cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" /> has been called for this <see cref="T:System.Net.Sockets.Socket" />.</exception>
       </Docs>
@@ -6182,11 +6213,11 @@ Duplication of the socket reference failed.</exception>
         <Parameter Name="optionValue" Type="System.Span&lt;System.Byte&gt;" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="optionLevel">The platform-defined option level.</param>
-        <param name="optionName">The platform-defined option name.</param>
-        <param name="optionValue">The span into which the retrieved option value should be stored.</param>
+        <param name="optionLevel"> The platform-defined option level.</param>
+        <param name="optionName"> The platform-defined option name.</param>
+        <param name="optionValue"> The span into which the retrieved option value should be stored.</param>
         <summary>Gets a socket option value using platform-specific level and name identifiers.</summary>
-        <returns>The number of bytes written into <paramref name="optionValue" /> for a successfully retrieved value.</returns>
+        <returns> The number of bytes written into <paramref name="optionValue" /> for a successfully retrieved value.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -6198,7 +6229,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 
           ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
       </Docs>
     </Member>
@@ -6268,7 +6299,8 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example retrieves the <xref:System.Net.Sockets.LingerOption> and <xref:System.Net.Sockets.Socket.Send*> time-out values and displays them to the console.
@@ -6283,7 +6315,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
  -or-
 
  <paramref name="optionName" /> was set to the unsupported value <see cref="F:System.Net.Sockets.SocketOptionName.MaxConnections" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.SetSocketOption(System.Net.Sockets.SocketOptionLevel,System.Net.Sockets.SocketOptionName,System.Int32)" />
         <altmember cref="T:System.Net.Sockets.SocketOptionName" />
         <altmember cref="T:System.Net.Sockets.SocketOptionLevel" />
@@ -6344,7 +6376,8 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 
  When the length of the `optionValue` array is smaller than the number of bytes required to store the value of the specified <xref:System.Net.Sockets.Socket> option, <xref:System.Net.Sockets.Socket.GetSocketOption*> will throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error. Use this overload for any sockets that are represented by Boolean values or integers.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example retrieves the <xref:System.Net.Sockets.LingerOption> and <xref:System.Net.Sockets.Socket.Send*> time-out values and displays them to the console.
@@ -6359,7 +6392,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 -or-
 
  In .NET Compact Framework applications, the Windows CE default buffer space is set to 32768 bytes. You can change the per socket buffer space by calling <see cref="Overload:System.Net.Sockets.Socket.SetSocketOption" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.SetSocketOption(System.Net.Sockets.SocketOptionLevel,System.Net.Sockets.SocketOptionName,System.Int32)" />
         <altmember cref="T:System.Net.Sockets.SocketOptionName" />
         <altmember cref="T:System.Net.Sockets.SocketOptionLevel" />
@@ -6410,7 +6443,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
       <Docs>
         <param name="optionLevel">One of the <see cref="T:System.Net.Sockets.SocketOptionLevel" /> values.</param>
         <param name="optionName">One of the <see cref="T:System.Net.Sockets.SocketOptionName" /> values.</param>
-        <param name="optionLength">The length, in bytes, of the expected return value.</param>
+        <param name="optionLength"> The length, in bytes, of the expected return value.</param>
         <summary>Returns the value of the specified <see cref="T:System.Net.Sockets.Socket" /> option in an array.</summary>
         <returns>An array of type <see cref="T:System.Byte" /> that contains the value of the socket option.</returns>
         <remarks>
@@ -6422,7 +6455,8 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example retrieves the <xref:System.Net.Sockets.LingerOption> and <xref:System.Net.Sockets.Socket.Send*> time-out values and displays them to the console.
@@ -6437,7 +6471,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 -or-
 
  In .NET Compact Framework applications, the Windows CE default buffer space is set to 32768 bytes. You can change the per socket buffer space by calling <see cref="Overload:System.Net.Sockets.Socket.SetSocketOption" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.SetSocketOption(System.Net.Sockets.SocketOptionLevel,System.Net.Sockets.SocketOptionName,System.Int32)" />
         <altmember cref="T:System.Net.Sockets.SocketOptionName" />
         <altmember cref="T:System.Net.Sockets.SocketOptionLevel" />
@@ -6543,7 +6577,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
         <param name="optionInValue">A <see cref="T:System.Byte" /> array that contains the input data required by the operation.</param>
         <param name="optionOutValue">A <see cref="T:System.Byte" /> array that contains the output data returned by the operation.</param>
         <summary>Sets low-level operating modes for the <see cref="T:System.Net.Sockets.Socket" /> using numerical control codes.</summary>
-        <returns>The number of bytes in the <paramref name="optionOutValue" /> parameter.</returns>
+        <returns> The number of bytes in the <paramref name="optionOutValue" /> parameter.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -6553,7 +6587,8 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example compares the results of FIONREAD and the Available property.
@@ -6563,7 +6598,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.InvalidOperationException">An attempt was made to change the blocking mode without using the <see cref="P:System.Net.Sockets.Socket.Blocking" /> property.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
       </Docs>
@@ -6615,7 +6650,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
         <param name="optionInValue">An array of type <see cref="T:System.Byte" /> that contains the input data required by the operation.</param>
         <param name="optionOutValue">An array of type <see cref="T:System.Byte" /> that contains the output data returned by the operation.</param>
         <summary>Sets low-level operating modes for the <see cref="T:System.Net.Sockets.Socket" /> using the <see cref="T:System.Net.Sockets.IOControlCode" /> enumeration to specify control codes.</summary>
-        <returns>The number of bytes in the <paramref name="optionOutValue" /> parameter.</returns>
+        <returns> The number of bytes in the <paramref name="optionOutValue" /> parameter.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -6625,7 +6660,8 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example compares the results of calling <xref:System.Net.Sockets.Socket.IOControl*> with <xref:System.Net.Sockets.IOControlCode.DataToRead> and the <xref:System.Net.Sockets.Socket.Available> property.
@@ -6635,7 +6671,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.InvalidOperationException">An attempt was made to change the blocking mode without using the <see cref="P:System.Net.Sockets.Socket.Blocking" /> property.</exception>
       </Docs>
     </Member>
@@ -6776,7 +6812,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="Listen">
@@ -6858,7 +6894,7 @@ The maximum length of the pending connections queue is determined automatically.
         <Parameter Name="backlog" Type="System.Int32" />
       </Parameters>
       <Docs>
-        <param name="backlog">The maximum length of the pending connections queue.</param>
+        <param name="backlog"> The maximum length of the pending connections queue.</param>
         <summary>Places a <see cref="T:System.Net.Sockets.Socket" /> in a listening state.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -6872,9 +6908,10 @@ The maximum length of the pending connections queue is determined automatically.
 > You must call the <xref:System.Net.Sockets.Socket.Bind*> method before calling <xref:System.Net.Sockets.Socket.Listen*>, or <xref:System.Net.Sockets.Socket.Listen*> will throw a <xref:System.Net.Sockets.SocketException>.
 
 > [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
+> [!NOTE]
 > The backlog parameter is limited to different values depending on the Operating System. You may specify a higher value, but the backlog will be limited based on the Operating System.
-
-
 
 ## Examples
  The following code example uses <xref:System.Net.Sockets.Socket> to listen for incoming connections.
@@ -6885,7 +6922,7 @@ The maximum length of the pending connections queue is determined automatically.
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="F:System.Net.Sockets.SocketOptionName.MaxConnections" />
         <altmember cref="M:System.Net.Sockets.Socket.Accept" />
         <altmember cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" />
@@ -6937,7 +6974,7 @@ The maximum length of the pending connections queue is determined automatically.
       </ReturnValue>
       <Docs>
         <summary>Gets the local endpoint.</summary>
-        <value>The <see cref="T:System.Net.EndPoint" /> that the <see cref="T:System.Net.Sockets.Socket" /> is using for communications.</value>
+        <value> The <see cref="T:System.Net.EndPoint" /> that the <see cref="T:System.Net.Sockets.Socket" /> is using for communications.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -6949,7 +6986,8 @@ The maximum length of the pending connections queue is determined automatically.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example retrieves and displays the local and remote endpoints.
@@ -6960,7 +6998,7 @@ The maximum length of the pending connections queue is determined automatically.
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="T:System.Net.EndPoint" />
         <altmember cref="T:System.Net.IPEndPoint" />
         <altmember cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" />
@@ -7022,8 +7060,8 @@ The maximum length of the pending connections queue is determined automatically.
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.NotSupportedException">The <see cref="T:System.Net.Sockets.Socket" /> is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The <see cref="T:System.Net.Sockets.Socket" /> is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
       </Docs>
     </Member>
     <Member MemberName="NoDelay">
@@ -7086,7 +7124,7 @@ The maximum length of the pending connections queue is determined automatically.
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the <see cref="T:System.Net.Sockets.Socket" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="OSSupportsIPv4">
@@ -7263,10 +7301,10 @@ The maximum length of the pending connections queue is determined automatically.
         <Parameter Name="mode" Type="System.Net.Sockets.SelectMode" />
       </Parameters>
       <Docs>
-        <param name="microSeconds">The time to wait for a response, in microseconds.</param>
+        <param name="microSeconds"> The time to wait for a response, in microseconds.</param>
         <param name="mode">One of the <see cref="T:System.Net.Sockets.SelectMode" /> values.</param>
         <summary>Determines the status of the <see cref="T:System.Net.Sockets.Socket" />.</summary>
-        <returns>The status of the <see cref="T:System.Net.Sockets.Socket" /> based on the polling mode value passed in the <paramref name="mode" /> parameter.
+        <returns> The status of the <see cref="T:System.Net.Sockets.Socket" /> based on the polling mode value passed in the <paramref name="mode" /> parameter.
           <ul><li>For <see cref="F:System.Net.Sockets.SelectMode.SelectRead" />, it returns <see langword="true" /> if <see cref="M:System.Net.Sockets.Socket.Listen" /> has been called and a connection is pending, if data is available for reading, or if the connection has been closed, reset, or terminated.</li><li>For <see cref="F:System.Net.Sockets.SelectMode.SelectWrite" />, it returns <see langword="true" /> if processing a <see cref="Overload:System.Net.Sockets.Socket.Connect" /> and the connection has succeeded or if data can be sent.</li><li>For <see cref="F:System.Net.Sockets.SelectMode.SelectError" />, it returns <see langword="true" /> if processing a <see cref="Overload:System.Net.Sockets.Socket.Connect" /> that does not block and the connection has failed, or if <see cref="F:System.Net.Sockets.SocketOptionName.OutOfBandInline" /> is not set and out-of-band data is available.</li><li>Otherwise, it returns <see langword="false" />.</li></ul></returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -7280,6 +7318,9 @@ The maximum length of the pending connections queue is determined automatically.
 > [!NOTE]
 > This method cannot detect certain kinds of connection problems, such as a broken network cable, or that the remote host was shut down ungracefully. You must attempt to send or receive data to detect these kinds of errors.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example creates a socket, connects to a server, and uses <xref:System.Net.Sockets.Socket.Poll*> to check the status of the socket.
 
@@ -7288,9 +7329,9 @@ The maximum length of the pending connections queue is determined automatically.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.NotSupportedException">The <paramref name="mode" /> parameter is not one of the <see cref="T:System.Net.Sockets.SelectMode" /> values.</exception>
+        <exception cref="T:System.NotSupportedException"> The <paramref name="mode" /> parameter is not one of the <see cref="T:System.Net.Sockets.SelectMode" /> values.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket. See remarks below.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="T:System.Net.Sockets.SelectMode" />
         <altmember cref="M:System.Net.Sockets.Socket.Poll(System.Int32,System.Net.Sockets.SelectMode)" />
       </Docs>
@@ -7322,16 +7363,16 @@ The maximum length of the pending connections queue is determined automatically.
         <Parameter Name="mode" Type="System.Net.Sockets.SelectMode" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="timeout">The time to wait for a response.</param>
+        <param name="timeout"> The time to wait for a response.</param>
         <param name="mode">One of the <see cref="T:System.Net.Sockets.SelectMode" /> values.</param>
         <summary>Determines the status of the <see cref="T:System.Net.Sockets.Socket" />.</summary>
-        <returns>The status of the <see cref="T:System.Net.Sockets.Socket" /> based on the polling mode value passed in the <paramref name="mode" /> parameter. Returns <see langword="true" /> if any of the following conditions occur before the <paramref name="timeout" /> expires, otherwise, <see langword="false" />.
+        <returns> The status of the <see cref="T:System.Net.Sockets.Socket" /> based on the polling mode value passed in the <paramref name="mode" /> parameter. Returns <see langword="true" /> if any of the following conditions occur before the <paramref name="timeout" /> expires, otherwise, <see langword="false" />.
             <ul><li>For <see cref="F:System.Net.Sockets.SelectMode.SelectRead" />, it returns <see langword="true" /> if <see cref="M:System.Net.Sockets.Socket.Listen" /> has been called and a connection is pending, if data is available for reading, or if the connection has been closed, reset, or terminated.</li><li>For <see cref="F:System.Net.Sockets.SelectMode.SelectWrite" />, it returns <see langword="true" /> if processing a <see cref="Overload:System.Net.Sockets.Socket.Connect" /> and the connection has succeeded or if data can be sent.</li><li>For <see cref="F:System.Net.Sockets.SelectMode.SelectError" />, it returns <see langword="true" /> if processing a <see cref="Overload:System.Net.Sockets.Socket.Connect" /> that does not block and the connection has failed, or if <see cref="F:System.Net.Sockets.SocketOptionName.OutOfBandInline" /> is not set and out-of-band data is available.</li><li>Otherwise, it returns <see langword="false" />.</li></ul></returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="timeout" /> is less than -1 milliseconds or greater than <see cref="F:System.Int32.MaxValue" /> milliseconds.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="ProtocolType">
@@ -7445,7 +7486,7 @@ The maximum length of the pending connections queue is determined automatically.
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for the received data.</param>
         <summary>Receives data from a bound <see cref="T:System.Net.Sockets.Socket" /> into a receive buffer.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -7465,7 +7506,8 @@ The maximum length of the pending connections queue is determined automatically.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example receives data on a connected <xref:System.Net.Sockets.Socket>.
@@ -7478,7 +7520,7 @@ The maximum length of the pending connections queue is determined automatically.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffer" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.ReceiveFrom(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint@)" />
@@ -7536,7 +7578,7 @@ The maximum length of the pending connections queue is determined automatically.
       <Docs>
         <param name="buffers">A list of <see cref="T:System.ArraySegment`1" />s of type <see cref="T:System.Byte" /> that contains the received data.</param>
         <summary>Receives data from a bound <see cref="T:System.Net.Sockets.Socket" /> into the list of receive buffers.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -7556,12 +7598,15 @@ The maximum length of the pending connections queue is determined automatically.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <altCompliant cref="M:System.Net.Sockets.Socket.Receive(System.Byte[])" />
-        <exception cref="T:System.ArgumentNullException">The <paramref name="buffers" /> parameter is <see langword="null" />.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="buffers" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred while attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="Receive">
@@ -7597,7 +7642,7 @@ The maximum length of the pending connections queue is determined automatically.
       <Docs>
         <param name="buffer">A span of bytes that is the storage location for the received data.</param>
         <summary>Receives data from a bound <see cref="T:System.Net.Sockets.Socket" /> into a receive buffer.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -7617,10 +7662,14 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.ReceiveFrom(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint@)" />
@@ -7674,7 +7723,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for the received data.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <summary>Receives data from a bound <see cref="T:System.Net.Sockets.Socket" /> into a receive buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -7694,7 +7743,8 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example specifies a data buffer, and <xref:System.Net.Sockets.SocketFlags> for receiving data on a connected <xref:System.Net.Sockets.Socket>.
@@ -7707,7 +7757,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffer" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.ReceiveFrom(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint@)" />
@@ -7767,7 +7817,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <param name="buffers">A list of <see cref="T:System.ArraySegment`1" />s of type <see cref="T:System.Byte" /> that contains the received data.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <summary>Receives data from a bound <see cref="T:System.Net.Sockets.Socket" /> into the list of receive buffers, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -7787,7 +7837,8 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates how to receive data on a connected <xref:System.Net.Sockets.Socket>.
@@ -7804,7 +7855,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
  <paramref name="buffers" />.Count is zero.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred while attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.ReceiveFrom(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint@)" />
         <altmember cref="P:System.Net.Sockets.Socket.Available" />
@@ -7847,7 +7898,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <param name="buffer">A span of bytes that is the storage location for the received data.</param>
         <param name="socketFlags">A bitwise combination of the enumeration values that specifies send and receive behaviors.</param>
         <summary>Receives data from a bound <see cref="T:System.Net.Sockets.Socket" /> into a receive buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 ## Remarks
@@ -7867,10 +7918,13 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.ReceiveFrom(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint@)" />
@@ -7923,10 +7977,10 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for the received data.</param>
-        <param name="size">The number of bytes to receive.</param>
+        <param name="size"> The number of bytes to receive.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <summary>Receives the specified number of bytes of data from a bound <see cref="T:System.Net.Sockets.Socket" /> into a receive buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -7946,7 +8000,8 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following receives the data found into `buffer`, and specifies <xref:System.Net.Sockets.SocketFlags.None> for <xref:System.Net.Sockets.SocketFlags>.
@@ -7961,7 +8016,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="size" /> exceeds the size of <paramref name="buffer" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.ReceiveFrom(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint@)" />
@@ -8023,7 +8078,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="errorCode">A <see cref="T:System.Net.Sockets.SocketError" /> object that stores the socket error.</param>
         <summary>Receives data from a bound <see cref="T:System.Net.Sockets.Socket" /> into the list of receive buffers, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -8043,6 +8098,9 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <altCompliant cref="M:System.Net.Sockets.Socket.Receive(System.Byte[],System.Net.Sockets.SocketFlags)" />
@@ -8053,7 +8111,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
  <paramref name="buffers" />.Count is zero.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred while attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.ReceiveFrom(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint@)" />
         <altmember cref="P:System.Net.Sockets.Socket.Available" />
@@ -8098,7 +8156,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <param name="socketFlags">A bitwise combination of the enumeration values that specifies send and receive behaviors.</param>
         <param name="errorCode">When this method returns, contains one of the enumeration values that defines error codes for the socket.</param>
         <summary>Receives data from a bound <see cref="T:System.Net.Sockets.Socket" /> into a receive buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 ## Remarks
@@ -8118,10 +8176,13 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.ReceiveFrom(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint@)" />
@@ -8175,11 +8236,11 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for received data.</param>
-        <param name="offset">The location in <paramref name="buffer" /> to store the received data.</param>
-        <param name="size">The number of bytes to receive.</param>
+        <param name="offset"> The location in <paramref name="buffer" /> to store the received data.</param>
+        <param name="size"> The number of bytes to receive.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <summary>Receives the specified number of bytes from a bound <see cref="T:System.Net.Sockets.Socket" /> into the specified offset position of the receive buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -8197,7 +8258,8 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example specifies a data buffer, an offset, a size, and a socket flag before receiving data on a connected <xref:System.Net.Sockets.Socket>.
@@ -8233,7 +8295,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  -or-
 
  An operating system error occurs while accessing the <see cref="T:System.Net.Sockets.Socket" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.ReceiveFrom(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint@)" />
@@ -8287,12 +8349,12 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for the received data.</param>
-        <param name="offset">The position in the <paramref name="buffer" /> parameter to store the received data.</param>
-        <param name="size">The number of bytes to receive.</param>
+        <param name="offset"> The position in the <paramref name="buffer" /> parameter to store the received data.</param>
+        <param name="size"> The number of bytes to receive.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="errorCode">A <see cref="T:System.Net.Sockets.SocketError" /> object that stores the socket error.</param>
         <summary>Receives data from a bound <see cref="T:System.Net.Sockets.Socket" /> into a receive buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
+        <returns> The total number of bytes received. The method returns zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -8306,6 +8368,9 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  If you are using a connection-oriented <xref:System.Net.Sockets.Socket>, the <xref:System.Net.Sockets.Socket.Receive*> method will read as much data as is available, up to the number of bytes specified by the size parameter. If the remote host shuts down the <xref:System.Net.Sockets.Socket> connection with the <xref:System.Net.Sockets.Socket.Shutdown*> method, and all available data has been received, the <xref:System.Net.Sockets.Socket.Receive*> method will complete immediately and return zero bytes.
 
  If you are using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.Net.Sockets.Socket.Receive*> will read the first queued datagram from the destination address you specify in the <xref:System.Net.Sockets.Socket.Connect*> method. If the datagram you receive is larger than the size of the `buffer` parameter, `buffer` gets filled with the first part of the message, the excess data is lost and a <xref:System.Net.Sockets.SocketException> is thrown.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -8325,7 +8390,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  -or-
 
  <paramref name="size" /> is greater than the length of <paramref name="buffer" /> minus the value of the <paramref name="offset" /> parameter.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.ReceiveFrom(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint@)" />
@@ -8366,11 +8431,11 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <Parameter Name="buffer" Type="System.ArraySegment&lt;System.Byte&gt;" Index="0" FrameworkAlternate="net-10.0;net-11.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <summary>Receives data from a connected socket.</summary>
         <returns>A task that represents the asynchronous receive operation. The value of its <see cref="P:System.Threading.Tasks.Task`1.Result" /> property contains the total number of bytes read into <paramref name="buffer" /> between zero (0) and the number of bytes requested. The result value is zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown. If zero bytes are requested, receive operations may complete immediately or may not complete until at least one byte is available (but without consuming any data).</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
       </Docs>
     </Member>
@@ -8411,8 +8476,8 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <summary>Receives data from a connected socket.</summary>
         <returns>A task that represents the asynchronous receive operation. The value of its <see cref="P:System.Threading.Tasks.Task`1.Result" /> property contains the total number of bytes read into the buffers between zero (0) and the number of bytes requested. The result value is zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown. If zero bytes are requested, receive operations may complete immediately or may not complete until at least one byte is available (but without consuming any data).</returns>
         <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Net.Sockets.Socket.Receive(System.Collections.Generic.IList{System.ArraySegment{System.Byte}})" />.</remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="buffers" /> parameter was null.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="buffers" /> parameter was null.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
       </Docs>
     </Member>
@@ -8456,7 +8521,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <Parameter Name="e" Type="System.Net.Sockets.SocketAsyncEventArgs" />
       </Parameters>
       <Docs>
-        <param name="e">The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
+        <param name="e"> The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
         <summary>Begins an asynchronous request to receive data from a connected <see cref="T:System.Net.Sockets.Socket" /> object.</summary>
         <returns>
           <see langword="true" /> if the I/O operation is pending. The <see cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" /> event on the <paramref name="e" /> parameter will be raised upon completion of the operation.
@@ -8474,13 +8539,13 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
  The following properties and events on the <xref:System.Net.Sockets.SocketAsyncEventArgs?displayProperty=nameWithType> object are required to successfully call this method:
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType> or <xref:System.Net.Sockets.SocketAsyncEventArgs.BufferList*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType> or <xref:System.Net.Sockets.SocketAsyncEventArgs.BufferList*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Count*?displayProperty=nameWithType> if <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType> is set
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Count*?displayProperty=nameWithType> if <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType> is set
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Offset*?displayProperty=nameWithType> if <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType> is set
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Offset*?displayProperty=nameWithType> if <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType> is set
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
 
  The caller may set the <xref:System.Net.Sockets.SocketAsyncEventArgs.UserToken?displayProperty=nameWithType> property to any user state object desired before calling the <xref:System.Net.Sockets.Socket.ReceiveAsync*> method, so that the information will be retrievable in the callback method. If the callback needs more information than a single object, a small class can be created to hold the other required state information as members.
 
@@ -8494,7 +8559,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         </remarks>
         <exception cref="T:System.ArgumentException">An argument was invalid. The <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.Buffer" /> or <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.BufferList" /> properties on the <paramref name="e" /> parameter must reference valid buffers. One or the other of these properties may be set, but not both at the same time.</exception>
         <exception cref="T:System.InvalidOperationException">A socket operation was already in progress using the <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object specified in the <paramref name="e" /> parameter.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
         <altmember cref="T:System.Net.Sockets.SocketAsyncEventArgs" />
         <altmember cref="P:System.Net.Sockets.SocketAsyncEventArgs.Buffer" />
@@ -8539,13 +8604,13 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <Parameter Name="socketFlags" Type="System.Net.Sockets.SocketFlags" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when receiving the data.</param>
         <summary>Receives data from a connected socket.</summary>
         <returns>A task that represents the asynchronous receive operation. The value of its <see cref="P:System.Threading.Tasks.Task`1.Result" /> property contains the total number of bytes read into <paramref name="buffer" /> between zero (0) and the number of bytes requested. The result value is zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown. If zero bytes are requested, receive operations may complete immediately or may not complete until at least one byte is available (but without consuming any data).
 </returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
       </Docs>
     </Member>
@@ -8590,8 +8655,8 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <returns>A task that represents the asynchronous receive operation. The value of its <see cref="P:System.Threading.Tasks.Task`1.Result" /> property contains the total number of bytes read into <paramref name="buffer" /> between zero (0) and the number of bytes requested. The result value is zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown. If zero bytes are requested, receive operations may complete immediately or may not complete until at least one byte is available (but without consuming any data).
 </returns>
         <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Net.Sockets.Socket.Receive(System.Collections.Generic.IList{System.ArraySegment{System.Byte}},System.Net.Sockets.SocketFlags)" />.</remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="buffers" /> parameter was null.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="buffers" /> parameter was null.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
       </Docs>
     </Member>
@@ -8621,14 +8686,14 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         <summary>Receives data from a connected socket.</summary>
         <returns>A <see cref="T:System.Threading.Tasks.ValueTask`1" /> that represents the asynchronous receive operation. The value of its <see cref="P:System.Threading.Tasks.ValueTask`1.Result" /> property contains the total number of bytes read into <paramref name="buffer" /> between zero (0) and the number of bytes requested. The result value is zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown. If zero bytes are requested, receive operations may complete immediately or may not complete until at least one byte is available (but without consuming any data).</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="ReceiveAsync">
@@ -8659,15 +8724,15 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when receiving the data.</param>
         <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         <summary>Receives data from a connected socket.</summary>
         <returns>A <see cref="T:System.Threading.Tasks.ValueTask`1" /> that represents the asynchronous receive operation. The value of its <see cref="P:System.Threading.Tasks.ValueTask`1.Result" /> property contains the total number of bytes read into <paramref name="buffer" /> between zero (0) and the number of bytes requested. The result value is zero (0) only if zero bytes were requested or if no more bytes are available because the peer socket performed a graceful shutdown. If zero bytes are requested, receive operations may complete immediately or may not complete until at least one byte is available (but without consuming any data).</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="ReceiveBufferSize">
@@ -8725,8 +8790,8 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The value specified for a set operation is less than 0.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The value specified for a set operation is less than 0.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ReceiveFrom">
@@ -8784,7 +8849,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for received data.</param>
         <param name="remoteEP">A reference to an <see cref="T:System.Net.EndPoint" /> of the same type as the endpoint of the remote host to be updated on successful receive.</param>
         <summary>Receives a datagram into the data buffer and stores the endpoint.</summary>
-        <returns>The number of bytes received.</returns>
+        <returns> The number of bytes received.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -8810,7 +8875,8 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 > The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example receives a connectionless datagram from a remote host.
@@ -8827,7 +8893,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
  <paramref name="remoteEP" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Receive(System.Byte[],System.Int32,System.Net.Sockets.SocketFlags)" />
@@ -8874,12 +8940,12 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <param name="buffer">A span of bytes that is the storage location for received data.</param>
         <param name="remoteEP">A reference to an <see cref="T:System.Net.EndPoint" /> of the same type as the endpoint of the remote host to be updated on successful receive.</param>
         <summary>Receives a datagram into the data buffer and stores the endpoint.</summary>
-        <returns>The number of bytes received.</returns>
+        <returns> The number of bytes received.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <c>remoteEP</c> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="ReceiveFrom">
@@ -8929,7 +8995,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="remoteEP">A reference to an <see cref="T:System.Net.EndPoint" /> of the same type as the endpoint of the remote host to be updated on successful receive.</param>
         <summary>Receives a datagram into the data buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />, and stores the endpoint.</summary>
-        <returns>The number of bytes received.</returns>
+        <returns> The number of bytes received.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -8955,7 +9021,8 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 > The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example receives a connectionless datagram from a remote host. <xref:System.Net.Sockets.SocketFlags> are passed to the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method.
@@ -8972,7 +9039,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
  <paramref name="remoteEP" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Receive(System.Byte[],System.Int32,System.Net.Sockets.SocketFlags)" />
@@ -9022,12 +9089,12 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="remoteEP">A reference to an <see cref="T:System.Net.EndPoint" /> of the same type as the endpoint of the remote host to be updated on successful receive.</param>
         <summary>Receives a datagram into the data buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />, and stores the endpoint.</summary>
-        <returns>The number of bytes received.</returns>
+        <returns> The number of bytes received.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <c>remoteEP</c> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="ReceiveFrom">
@@ -9068,12 +9135,12 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="receivedAddress">A <see cref="T:System.Net.SocketAddress" /> instance that gets updated with the value of the remote peer when this method returns.</param>
         <summary>Receives a datagram into the data buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />, and stores the endpoint.</summary>
-        <returns>The number of bytes received.</returns>
+        <returns> The number of bytes received.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="receivedAddress" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="ReceiveFrom">
@@ -9121,11 +9188,11 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for received data.</param>
-        <param name="size">The number of bytes to receive.</param>
+        <param name="size"> The number of bytes to receive.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="remoteEP">A reference to an <see cref="T:System.Net.EndPoint" /> of the same type as the endpoint of the remote host to be updated on successful receive.</param>
         <summary>Receives the specified number of bytes into the data buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />, and stores the endpoint.</summary>
-        <returns>The number of bytes received.</returns>
+        <returns> The number of bytes received.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -9148,7 +9215,8 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 > The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example receives a connectionless datagram from a remote host. The buffer size, and <xref:System.Net.Sockets.SocketFlags> are passed to the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method.
@@ -9180,7 +9248,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  -or-
 
  An operating system error occurs while accessing the <see cref="T:System.Net.Sockets.Socket" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Receive(System.Byte[],System.Int32,System.Net.Sockets.SocketFlags)" />
@@ -9236,12 +9304,12 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for received data.</param>
-        <param name="offset">The position in the <paramref name="buffer" /> parameter to store the received data.</param>
-        <param name="size">The number of bytes to receive.</param>
+        <param name="offset"> The position in the <paramref name="buffer" /> parameter to store the received data.</param>
+        <param name="size"> The number of bytes to receive.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="remoteEP">A reference to an <see cref="T:System.Net.EndPoint" /> of the same type as the endpoint of the remote host to be updated on successful receive.</param>
         <summary>Receives the specified number of bytes of data into the specified location of the data buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />, and stores the endpoint.</summary>
-        <returns>The number of bytes received.</returns>
+        <returns> The number of bytes received.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -9262,7 +9330,8 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 > The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example receives a connectionless datagram from a remote host. The offset, buffer size, and <xref:System.Net.Sockets.SocketFlags> are passed to the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method.
@@ -9302,7 +9371,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  -or-
 
  An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Receive(System.Byte[],System.Int32,System.Net.Sockets.SocketFlags)" />
         <altmember cref="P:System.Net.Sockets.Socket.Available" />
@@ -9351,7 +9420,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <Parameter Name="e" Type="System.Net.Sockets.SocketAsyncEventArgs" />
       </Parameters>
       <Docs>
-        <param name="e">The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
+        <param name="e"> The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
         <summary>Begins to asynchronously receive data from a specified network device.</summary>
         <returns>
           <see langword="true" /> if the I/O operation is pending. The <see cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" /> event on the <paramref name="e" /> parameter will be raised upon completion of the operation.
@@ -9369,15 +9438,15 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
  The following properties and events on the <xref:System.Net.Sockets.SocketAsyncEventArgs?displayProperty=nameWithType> object are required to successfully call this method:
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Count*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Count*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Offset*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Offset*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
 
  The caller may set the <xref:System.Net.Sockets.SocketAsyncEventArgs.UserToken?displayProperty=nameWithType> property to any user state object desired before calling the <xref:System.Net.Sockets.Socket.ReceiveFromAsync*> method, so that the information will be retrievable in the callback method. If the callback needs more information than a single object, a small class can be created to hold the other required state information as members.
 
@@ -9387,9 +9456,9 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentNullException">The <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> cannot be null.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> cannot be null.</exception>
         <exception cref="T:System.InvalidOperationException">A socket operation was already in progress using the <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object specified in the <paramref name="e" /> parameter.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
         <altmember cref="T:System.Net.Sockets.SocketAsyncEventArgs" />
         <altmember cref="P:System.Net.Sockets.SocketAsyncEventArgs.Buffer" />
@@ -9434,7 +9503,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <Parameter Name="remoteEndPoint" Type="System.Net.EndPoint" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         <summary>Receives data and returns the endpoint of the sending host.</summary>
         <returns>An asynchronous task that completes with a <see cref="T:System.Net.Sockets.SocketReceiveFromResult" /> containing the number of bytes received and the endpoint of the sending host.</returns>
@@ -9442,7 +9511,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEndPoint" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
       </Docs>
     </Member>
@@ -9482,7 +9551,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <Parameter Name="remoteEndPoint" Type="System.Net.EndPoint" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when receiving the data.</param>
         <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         <summary>Receives data and returns the endpoint of the sending host.</summary>
@@ -9491,7 +9560,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEndPoint" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
       </Docs>
     </Member>
@@ -9529,7 +9598,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         <summary>Receives data and returns the endpoint of the sending host.</summary>
@@ -9538,9 +9607,9 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEndPoint" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="ReceiveFromAsync">
@@ -9579,7 +9648,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="3" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when receiving the data.</param>
         <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
@@ -9589,9 +9658,9 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEndPoint" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="ReceiveFromAsync">
@@ -9628,7 +9697,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="3" FrameworkAlternate="net-10.0;net-11.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values that will be used when receiving the data.</param>
         <param name="receivedAddress">A <see cref="T:System.Net.SocketAddress" /> instance that gets updated with the value of the remote peer when this method returns.</param>
         <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
@@ -9638,8 +9707,8 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="receivedAddress" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="ReceiveMessageFrom">
@@ -9684,12 +9753,12 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
         <param name="remoteEP">A reference to an <see cref="T:System.Net.EndPoint" /> of the same type as the endpoint of the remote host to be updated on successful receive.</param>
         <param name="ipPacketInformation">An <see cref="T:System.Net.Sockets.IPPacketInformation" /> holding address and interface information.</param>
         <summary>Receives the specified number of bytes of data into the specified location of the data buffer, using the specified <paramref name="socketFlags" />, and stores the endpoint and packet information.</summary>
-        <returns>The number of bytes received.</returns>
+        <returns> The number of bytes received.</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.ArgumentNullException">The <see cref="T:System.Net.EndPoint" /> remoteEP is <see langword="null" />.</exception>
-        <exception cref="T:System.ArgumentException">The <see cref="P:System.Net.Sockets.Socket.AddressFamily" /> of the <see cref="T:System.Net.EndPoint" /> used in <see cref="M:System.Net.Sockets.Socket.ReceiveMessageFrom(System.Span{System.Byte},System.Net.Sockets.SocketFlags@,System.Net.EndPoint@,System.Net.Sockets.IPPacketInformation@)" /> needs to match the <see cref="P:System.Net.Sockets.Socket.AddressFamily" /> of the <see cref="T:System.Net.EndPoint" /> used in SendTo.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> object is not in blocking mode and cannot accept this synchronous call.
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <see cref="T:System.Net.EndPoint" /> remoteEP is <see langword="null" />.</exception>
+        <exception cref="T:System.ArgumentException"> The <see cref="P:System.Net.Sockets.Socket.AddressFamily" /> of the <see cref="T:System.Net.EndPoint" /> used in <see cref="M:System.Net.Sockets.Socket.ReceiveMessageFrom(System.Span{System.Byte},System.Net.Sockets.SocketFlags@,System.Net.EndPoint@,System.Net.Sockets.IPPacketInformation@)" /> needs to match the <see cref="P:System.Net.Sockets.Socket.AddressFamily" /> of the <see cref="T:System.Net.EndPoint" /> used in SendTo.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> object is not in blocking mode and cannot accept this synchronous call.
 You must call the Bind method before performing this operation.</exception>
       </Docs>
     </Member>
@@ -9739,13 +9808,13 @@ You must call the Bind method before performing this operation.</exception>
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that is the storage location for received data.</param>
-        <param name="offset">The position in the <paramref name="buffer" /> parameter to store the received data.</param>
-        <param name="size">The number of bytes to receive.</param>
+        <param name="offset"> The position in the <paramref name="buffer" /> parameter to store the received data.</param>
+        <param name="size"> The number of bytes to receive.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="remoteEP">A reference to an <see cref="T:System.Net.EndPoint" /> of the same type as the endpoint of the remote host to be updated on successful receive.</param>
         <param name="ipPacketInformation">An <see cref="T:System.Net.Sockets.IPPacketInformation" /> holding address and interface information.</param>
         <summary>Receives the specified number of bytes of data into the specified location of the data buffer, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />, and stores the endpoint and packet information.</summary>
-        <returns>The number of bytes received.</returns>
+        <returns> The number of bytes received.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -9764,6 +9833,9 @@ You must call the Bind method before performing this operation.</exception>
 
 > [!NOTE]
 > The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -9801,7 +9873,7 @@ You must call the Bind method before performing this operation.</exception>
  -or-
 
  An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.ReceiveFrom(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint@)" />
         <altmember cref="P:System.Net.Sockets.Socket.Available" />
@@ -9849,7 +9921,7 @@ You must call the Bind method before performing this operation.</exception>
         <Parameter Name="e" Type="System.Net.Sockets.SocketAsyncEventArgs" />
       </Parameters>
       <Docs>
-        <param name="e">The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
+        <param name="e"> The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
         <summary>Begins to asynchronously receive the specified number of bytes of data into the specified location in the data buffer, using the specified <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.SocketFlags" />, and stores the endpoint and packet information.</summary>
         <returns>
           <see langword="true" /> if the I/O operation is pending. The <see cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" /> event on the <paramref name="e" /> parameter will be raised upon completion of the operation.
@@ -9865,15 +9937,15 @@ You must call the Bind method before performing this operation.</exception>
 
  The following properties and events on the <xref:System.Net.Sockets.SocketAsyncEventArgs?displayProperty=nameWithType> object are required to successfully call this method:
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Count*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Count*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Offset*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Offset*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
 
  The caller may set the <xref:System.Net.Sockets.SocketAsyncEventArgs.UserToken?displayProperty=nameWithType> property to any user state object desired before calling the <xref:System.Net.Sockets.Socket.ReceiveMessageFromAsync*> method, so that the information will be retrievable in the callback method. If the callback needs more information than a single object, a small class can be created to hold the other required state information as members.
 
@@ -9887,8 +9959,8 @@ You must call the Bind method before performing this operation.</exception>
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentNullException">The <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> cannot be null.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> cannot be null.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
         <altmember cref="T:System.Net.Sockets.SocketAsyncEventArgs" />
         <altmember cref="P:System.Net.Sockets.SocketAsyncEventArgs.Buffer" />
@@ -9933,12 +10005,12 @@ You must call the Bind method before performing this operation.</exception>
         <Parameter Name="remoteEndPoint" Type="System.Net.EndPoint" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         <summary>Receives data and returns additional information about the sender of the message.</summary>
         <returns>An asynchronous task that completes with a <see cref="T:System.Net.Sockets.SocketReceiveMessageFromResult" /> containing the number of bytes received and additional information about the sending host.</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEndPoint" /> is <see langword="null" />.</exception>
         <exception cref="T:System.InvalidOperationException">You must call the Bind method before performing this operation.</exception>
@@ -9980,13 +10052,13 @@ You must call the Bind method before performing this operation.</exception>
         <Parameter Name="remoteEndPoint" Type="System.Net.EndPoint" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when receiving the data.</param>
         <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         <summary>Receives data and returns additional information about the sender of the message.</summary>
         <returns>An asynchronous task that completes with a <see cref="T:System.Net.Sockets.SocketReceiveMessageFromResult" /> containing the number of bytes received and additional information about the sending host.</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEndPoint" /> is <see langword="null" />.</exception>
         <exception cref="T:System.InvalidOperationException">You must call the Bind method before performing this operation.</exception>
@@ -10026,17 +10098,17 @@ You must call the Bind method before performing this operation.</exception>
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         <summary>Receives data and returns additional information about the sender of the message.</summary>
         <returns>An asynchronous task that completes with a <see cref="T:System.Net.Sockets.SocketReceiveMessageFromResult" /> containing the number of bytes received and additional information about the sending host.</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEndPoint" /> is <see langword="null" />.</exception>
         <exception cref="T:System.InvalidOperationException">You must call the Bind method before performing this operation.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="ReceiveMessageFromAsync">
@@ -10075,18 +10147,18 @@ You must call the Bind method before performing this operation.</exception>
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="3" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the received data.</param>
+        <param name="buffer"> The buffer for the received data.</param>
         <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when receiving the data.</param>
         <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         <summary>Receives data and returns additional information about the sender of the message.</summary>
         <returns>An asynchronous task that completes with a <see cref="T:System.Net.Sockets.SocketReceiveMessageFromResult" /> containing the number of bytes received and additional information about the sending host.</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEndPoint" /> is <see langword="null" />.</exception>
         <exception cref="T:System.InvalidOperationException">You must call the Bind method before performing this operation.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="ReceiveTimeout">
@@ -10127,14 +10199,15 @@ You must call the Bind method before performing this operation.</exception>
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that specifies the amount of time after which a synchronous <see cref="Overload:System.Net.Sockets.Socket.Receive" /> call will time out.</summary>
-        <value>The time-out value, in milliseconds. The default value is 0, which indicates an infinite time-out period. Specifying -1 also indicates an infinite time-out period.</value>
+        <value> The time-out value, in milliseconds. The default value is 0, which indicates an infinite time-out period. Specifying -1 also indicates an infinite time-out period.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  This option applies to synchronous <xref:System.Net.Sockets.Socket.Receive*> calls only. If the time-out period is exceeded, the <xref:System.Net.Sockets.Socket.Receive*> method will throw a <xref:System.Net.Sockets.SocketException>.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates the use of the <xref:System.Net.Sockets.Socket.ReceiveTimeout> property.
@@ -10144,8 +10217,8 @@ You must call the Bind method before performing this operation.</exception>
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The value specified for a set operation is less than -1.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The value specified for a set operation is less than -1.</exception>
       </Docs>
     </Member>
     <Member MemberName="RemoteEndPoint">
@@ -10194,7 +10267,7 @@ You must call the Bind method before performing this operation.</exception>
       </ReturnValue>
       <Docs>
         <summary>Gets the remote endpoint.</summary>
-        <value>The <see cref="T:System.Net.EndPoint" /> with which the <see cref="T:System.Net.Sockets.Socket" /> is communicating.</value>
+        <value> The <see cref="T:System.Net.EndPoint" /> with which the <see cref="T:System.Net.Sockets.Socket" /> is communicating.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -10214,7 +10287,7 @@ You must call the Bind method before performing this operation.</exception>
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="T:System.Net.EndPoint" />
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Accept" />
@@ -10307,7 +10380,7 @@ You must call the Bind method before performing this operation.</exception>
         <param name="checkRead">An <see cref="T:System.Collections.IList" /> of <see cref="T:System.Net.Sockets.Socket" /> instances to check for readability.</param>
         <param name="checkWrite">An <see cref="T:System.Collections.IList" /> of <see cref="T:System.Net.Sockets.Socket" /> instances to check for writability.</param>
         <param name="checkError">An <see cref="T:System.Collections.IList" /> of <see cref="T:System.Net.Sockets.Socket" /> instances to check for errors.</param>
-        <param name="microSeconds">The time-out value, in microseconds. A -1 value indicates an infinite time-out.</param>
+        <param name="microSeconds"> The time-out value, in microseconds. A -1 value indicates an infinite time-out.</param>
         <summary>Determines the status of one or more sockets.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -10342,14 +10415,14 @@ You must call the Bind method before performing this operation.</exception>
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="checkRead" />, <paramref name="checkWrite" />, and <paramref name="checkError" /> parameters are all <see langword="null" /> or empty. At least one of <paramref name="checkRead" />, <paramref name="checkWrite" />, or <paramref name="checkError" /> must contain at least one <see cref="T:System.Net.Sockets.Socket" />.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="checkRead" />, <paramref name="checkWrite" />, and <paramref name="checkError" /> parameters are all <see langword="null" /> or empty. At least one of <paramref name="checkRead" />, <paramref name="checkWrite" />, or <paramref name="checkError" /> must contain at least one <see cref="T:System.Net.Sockets.Socket" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException">.NET 5 and later: One or more sockets are disposed.</exception>
         <altmember cref="T:System.Collections.IList" />
         <altmember cref="M:System.Net.Sockets.Socket.Accept" />
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Poll(System.Int32,System.Net.Sockets.SelectMode)" />
-        <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="checkRead" />, <paramref name="checkWrite" />, or <paramref name="checkError" /> parameter contains too many sockets.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The <paramref name="checkRead" />, <paramref name="checkWrite" />, or <paramref name="checkError" /> parameter contains too many sockets.</exception>
       </Docs>
     </Member>
     <Member MemberName="Select">
@@ -10384,12 +10457,12 @@ You must call the Bind method before performing this operation.</exception>
         <param name="checkRead">An <see cref="T:System.Collections.IList" /> of <see cref="T:System.Net.Sockets.Socket" /> instances to check for readability.</param>
         <param name="checkWrite">An <see cref="T:System.Collections.IList" /> of <see cref="T:System.Net.Sockets.Socket" /> instances to check for writability.</param>
         <param name="checkError">An <see cref="T:System.Collections.IList" /> of <see cref="T:System.Net.Sockets.Socket" /> instances to check for errors.</param>
-        <param name="timeout">The timeout value. A value equal to -1 microseconds indicates an infinite timeout.</param>
+        <param name="timeout"> The timeout value. A value equal to -1 microseconds indicates an infinite timeout.</param>
         <summary>Determines the status of one or more sockets.</summary>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="checkRead" />, <paramref name="checkWrite" />, and <paramref name="checkError" /> parameters are all <see langword="null" /> or empty. At least one of <paramref name="checkRead" />, <paramref name="checkWrite" />, or <paramref name="checkError" /> must contain at least one <see cref="T:System.Net.Sockets.Socket" />.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="checkRead" />, <paramref name="checkWrite" />, or <paramref name="checkError" /> parameter contains too many sockets.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="timeout" /> was less than -1 microseconds or greater than <see cref="F:System.Int32.MaxValue" /> microseconds</exception>
+        <exception cref="T:System.ArgumentNullException"> The <paramref name="checkRead" />, <paramref name="checkWrite" />, and <paramref name="checkError" /> parameters are all <see langword="null" /> or empty. At least one of <paramref name="checkRead" />, <paramref name="checkWrite" />, or <paramref name="checkError" /> must contain at least one <see cref="T:System.Net.Sockets.Socket" />.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The <paramref name="checkRead" />, <paramref name="checkWrite" />, or <paramref name="checkError" /> parameter contains too many sockets.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The <paramref name="timeout" /> was less than -1 microseconds or greater than <see cref="F:System.Int32.MaxValue" /> microseconds</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException">One or more sockets was disposed.</exception>
       </Docs>
@@ -10447,7 +10520,7 @@ You must call the Bind method before performing this operation.</exception>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the data to be sent.</param>
         <summary>Sends data to a connected <see cref="T:System.Net.Sockets.Socket" />.</summary>
-        <returns>The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
+        <returns> The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -10482,7 +10555,7 @@ You must call the Bind method before performing this operation.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffer" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.SendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint)" />
         <altmember cref="T:System.Net.Sockets.SocketFlags" />
@@ -10538,7 +10611,7 @@ You must call the Bind method before performing this operation.</exception>
       <Docs>
         <param name="buffers">A list of <see cref="T:System.ArraySegment`1" />s of type <see cref="T:System.Byte" /> that contains the data to be sent.</param>
         <summary>Sends the set of buffers in the list to a connected <see cref="T:System.Net.Sockets.Socket" />.</summary>
-        <returns>The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
+        <returns> The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -10570,7 +10643,7 @@ You must call the Bind method before performing this operation.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="buffers" /> is empty.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket. See remarks section below.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="Send">
@@ -10606,7 +10679,7 @@ You must call the Bind method before performing this operation.</exception>
       <Docs>
         <param name="buffer">A span of bytes that contains the data to be sent.</param>
         <summary>Sends data to a connected <see cref="T:System.Net.Sockets.Socket" />.</summary>
-        <returns>The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
+        <returns> The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -10623,15 +10696,18 @@ If you're using a connectionless protocol and plan to send data to several diffe
 If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.Send*> will block until all of the bytes in the buffer are sent, unless a time-out was set by using <xref:System.Net.Sockets.Socket.SendTimeout*?displayProperty=nameWithType>. If the time-out value was exceeded, the <xref:System.Net.Sockets.Socket.Send*> call will throw a <xref:System.Net.Sockets.SocketException>. In nonblocking mode, <xref:System.Net.Sockets.Socket.Send*> may complete successfully even if it sends less than the number of bytes in the buffer. It is your application's responsibility to keep track of the number of bytes sent and to retry the operation until the application sends the bytes in the buffer. There's also no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.Send*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!IMPORTANT]
->The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.SendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint)" />
         <altmember cref="T:System.Net.Sockets.SocketFlags" />
@@ -10683,7 +10759,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the data to be sent.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <summary>Sends data to a connected <see cref="T:System.Net.Sockets.Socket" /> using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
+        <returns> The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -10718,7 +10794,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffer" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.SendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint)" />
         <altmember cref="T:System.Net.Sockets.SocketFlags" />
@@ -10776,7 +10852,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <param name="buffers">A list of <see cref="T:System.ArraySegment`1" />s of type <see cref="T:System.Byte" /> that contains the data to be sent.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <summary>Sends the set of buffers in the list to a connected <see cref="T:System.Net.Sockets.Socket" />, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
+        <returns> The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -10806,7 +10882,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <exception cref="T:System.ArgumentException">
           <paramref name="buffers" /> is empty.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="Send">
@@ -10844,16 +10920,10 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <param name="buffer">A span of bytes that contains the data to be sent.</param>
         <param name="socketFlags">A bitwise combination of the enumeration values that specifies send and receive behaviors.</param>
         <summary>Sends data to a connected <see cref="T:System.Net.Sockets.Socket" /> using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-
-
- ]]></format>
-        </remarks>
+        <returns> The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.SendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint)" />
         <altmember cref="T:System.Net.Sockets.SocketFlags" />
@@ -10904,10 +10974,10 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the data to be sent.</param>
-        <param name="size">The number of bytes to send.</param>
+        <param name="size"> The number of bytes to send.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <summary>Sends the specified number of bytes of data to a connected <see cref="T:System.Net.Sockets.Socket" />, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
+        <returns> The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 ## Remarks
@@ -10926,7 +10996,10 @@ With a connection-oriented protocol, <xref:System.Net.Sockets.Socket.Send*> will
 > You must ensure that the size does not exceed the maximum packet size of the underlying service provider. If it does, the datagram won't be sent and <xref:System.Net.Sockets.Socket.Send*> will throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!IMPORTANT]
->The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
 
@@ -10947,7 +11020,7 @@ The following code example sends the data found in buffer, and specifies <xref:S
  -or-
 
  An operating system error occurs while accessing the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.SendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint)" />
         <altmember cref="T:System.Net.Sockets.SocketFlags" />
@@ -11007,7 +11080,7 @@ The following code example sends the data found in buffer, and specifies <xref:S
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="errorCode">A <see cref="T:System.Net.Sockets.SocketError" /> object that stores the socket error.</param>
         <summary>Sends the set of buffers in the list to a connected <see cref="T:System.Net.Sockets.Socket" />, using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
+        <returns> The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -11037,7 +11110,7 @@ The following code example sends the data found in buffer, and specifies <xref:S
         <exception cref="T:System.ArgumentException">
           <paramref name="buffers" /> is empty.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="Send">
@@ -11077,7 +11150,7 @@ The following code example sends the data found in buffer, and specifies <xref:S
         <param name="socketFlags">A bitwise combination of the enumeration values that specifies send and receive behaviors.</param>
         <param name="errorCode">When this method returns, contains one of the enumeration values that defines error codes for the socket.</param>
         <summary>Sends data to a connected <see cref="T:System.Net.Sockets.Socket" /> using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
+        <returns> The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 ## Remarks
@@ -11093,15 +11166,18 @@ If you're using a connectionless protocol and plan to send data to several diffe
 If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.Send*> will block until all of the bytes in the buffer are sent, unless a time-out was set by using <xref:System.Net.Sockets.Socket.SendTimeout*?displayProperty=nameWithType>. If the time-out value was exceeded, the <xref:System.Net.Sockets.Socket.Send*> call will throw a <xref:System.Net.Sockets.SocketException>. In nonblocking mode, <xref:System.Net.Sockets.Socket.Send*> may complete successfully even if it sends less than the number of bytes in the buffer. It is your application's responsibility to keep track of the number of bytes sent and to retry the operation until the application sends the bytes in the buffer. There's also no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.Send*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you've obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you've obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!IMPORTANT]
->The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.SendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint)" />
         <altmember cref="T:System.Net.Sockets.SocketFlags" />
@@ -11153,11 +11229,11 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the data to be sent.</param>
-        <param name="offset">The position in the data buffer at which to begin sending data.</param>
-        <param name="size">The number of bytes to send.</param>
+        <param name="offset"> The position in the data buffer at which to begin sending data.</param>
+        <param name="size"> The number of bytes to send.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <summary>Sends the specified number of bytes of data to a connected <see cref="T:System.Net.Sockets.Socket" />, starting at the specified offset, and using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
+        <returns> The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -11213,7 +11289,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  -or-
 
  An operating system error occurs while accessing the <see cref="T:System.Net.Sockets.Socket" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.SendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint)" />
         <altmember cref="T:System.Net.Sockets.SocketFlags" />
@@ -11265,12 +11341,12 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the data to be sent.</param>
-        <param name="offset">The position in the data buffer at which to begin sending data.</param>
-        <param name="size">The number of bytes to send.</param>
+        <param name="offset"> The position in the data buffer at which to begin sending data.</param>
+        <param name="size"> The number of bytes to send.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
         <param name="errorCode">A <see cref="T:System.Net.Sockets.SocketError" /> object that stores the socket error.</param>
         <summary>Sends the specified number of bytes of data to a connected <see cref="T:System.Net.Sockets.Socket" />, starting at the specified offset, and using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
+        <returns> The number of bytes sent to the <see cref="T:System.Net.Sockets.Socket" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -11326,7 +11402,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  -or-
 
  An operating system error occurs while accessing the <see cref="T:System.Net.Sockets.Socket" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.SendTo(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.Net.EndPoint)" />
         <altmember cref="T:System.Net.Sockets.SocketFlags" />
@@ -11365,12 +11441,12 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="buffer" Type="System.ArraySegment&lt;System.Byte&gt;" Index="0" FrameworkAlternate="net-10.0;net-11.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the data to send.</param>
+        <param name="buffer"> The buffer for the data to send.</param>
         <summary>Sends data on a connected socket.</summary>
         <returns>An asynchronous task that completes with the number of bytes sent.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendAsync">
@@ -11413,7 +11489,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffers" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendAsync">
@@ -11456,7 +11532,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="e" Type="System.Net.Sockets.SocketAsyncEventArgs" />
       </Parameters>
       <Docs>
-        <param name="e">The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
+        <param name="e"> The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
         <summary>Sends data asynchronously to a connected <see cref="T:System.Net.Sockets.Socket" /> object.</summary>
         <returns>
           <see langword="true" /> if the I/O operation is pending. The <see cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" /> event on the <paramref name="e" /> parameter will be raised upon completion of the operation.
@@ -11472,13 +11548,13 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
  The following properties and events on the <xref:System.Net.Sockets.SocketAsyncEventArgs?displayProperty=nameWithType> object are required to successfully call this method:
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType> or <xref:System.Net.Sockets.SocketAsyncEventArgs.BufferList*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType> or <xref:System.Net.Sockets.SocketAsyncEventArgs.BufferList*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Count*?displayProperty=nameWithType> if <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType> is set
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Count*?displayProperty=nameWithType> if <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType> is set
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Offset*?displayProperty=nameWithType> if <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType> is set
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Offset*?displayProperty=nameWithType> if <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType> is set
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
 
  The caller may set the <xref:System.Net.Sockets.SocketAsyncEventArgs.UserToken?displayProperty=nameWithType> property to any user state object desired before calling the <xref:System.Net.Sockets.Socket.SendAsync*> method, so that the information will be retrievable in the callback method. If the callback needs more information than a single object, a small class can be created to hold the other required state information as members.
 
@@ -11492,10 +11568,10 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentException">The <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.Buffer" /> or <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.BufferList" /> properties on the <paramref name="e" /> parameter must reference valid buffers. One or the other of these properties may be set, but not both at the same time.</exception>
+        <exception cref="T:System.ArgumentException"> The <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.Buffer" /> or <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.BufferList" /> properties on the <paramref name="e" /> parameter must reference valid buffers. One or the other of these properties may be set, but not both at the same time.</exception>
         <exception cref="T:System.InvalidOperationException">A socket operation was already in progress using the <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object specified in the <paramref name="e" /> parameter.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">The <see cref="T:System.Net.Sockets.Socket" /> is not yet connected or was not obtained via an <see cref="M:System.Net.Sockets.Socket.Accept" />, <see cref="M:System.Net.Sockets.Socket.AcceptAsync(System.Net.Sockets.SocketAsyncEventArgs)" />,or <see cref="Overload:System.Net.Sockets.Socket.BeginAccept" />, method.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.Net.Sockets.SocketException"> The <see cref="T:System.Net.Sockets.Socket" /> is not yet connected or was not obtained via an <see cref="M:System.Net.Sockets.Socket.Accept" />, <see cref="M:System.Net.Sockets.Socket.AcceptAsync(System.Net.Sockets.SocketAsyncEventArgs)" />,or <see cref="Overload:System.Net.Sockets.Socket.BeginAccept" />, method.</exception>
         <altmember cref="T:System.Net.Sockets.SocketAsyncEventArgs" />
         <altmember cref="P:System.Net.Sockets.SocketAsyncEventArgs.Buffer" />
         <altmember cref="P:System.Net.Sockets.SocketAsyncEventArgs.BufferList" />
@@ -11539,13 +11615,13 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="socketFlags" Type="System.Net.Sockets.SocketFlags" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the data to send.</param>
+        <param name="buffer"> The buffer for the data to send.</param>
         <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when sending the data.</param>
         <summary>Sends data on a connected socket.</summary>
         <returns>An asynchronous task that completes with the number of bytes sent.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendAsync">
@@ -11591,7 +11667,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffers" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendAsync">
@@ -11620,12 +11696,12 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the data to send.</param>
+        <param name="buffer"> The buffer for the data to send.</param>
         <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         <summary>Sends data on a connected socket.</summary>
         <returns>An asynchronous task that completes with the number of bytes sent.</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendAsync">
@@ -11656,15 +11732,15 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the data to send.</param>
+        <param name="buffer"> The buffer for the data to send.</param>
         <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when sending the data.</param>
         <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         <summary>Sends data on a connected socket.</summary>
         <returns>An asynchronous task that completes with the number of bytes sent.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendBufferSize">
@@ -11712,8 +11788,6 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 ## Remarks
  A larger buffer size might delay the recognition of connection difficulties. Consider increasing the buffer size if you are transferring large files, or you are using a high bandwidth, high latency connection (such as a satellite broadband provider.)
 
-
-
 ## Examples
  The following code example demonstrates the use of the <xref:System.Net.Sockets.Socket.SendBufferSize> property.
 
@@ -11722,8 +11796,8 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The value specified for a set operation is less than 0.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The value specified for a set operation is less than 0.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="SendFile">
@@ -11795,6 +11869,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example creates and connects a socket and then sends a file to the remote host. The file "test.txt" is located in the root directory of the local machine.
 
@@ -11802,10 +11879,10 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.NotSupportedException">The socket is not connected to a remote host.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> object is not in blocking mode and cannot accept this synchronous call.</exception>
-        <exception cref="T:System.IO.FileNotFoundException">The file <paramref name="fileName" /> was not found.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not connected to a remote host.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> object is not in blocking mode and cannot accept this synchronous call.</exception>
+        <exception cref="T:System.IO.FileNotFoundException"> The file <paramref name="fileName" /> was not found.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
       </Docs>
     </Member>
@@ -11852,9 +11929,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="flags" Type="System.Net.Sockets.TransmitFileOptions" Index="3" FrameworkAlternate="net-10.0;net-11.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0;netcore-2.0;netcore-2.1;netcore-2.2;netcore-3.0;netcore-3.1" />
       </Parameters>
       <Docs>
-        <param name="fileName">The path and name of the file to be sent. This parameter can be <see langword="null" />.</param>
-        <param name="preBuffer">The data to be sent before the file is sent. This parameter can be <see langword="null" />.</param>
-        <param name="postBuffer">The data to be sent after the file is sent. This parameter can be <see langword="null" />.</param>
+        <param name="fileName"> The path and name of the file to be sent. This parameter can be <see langword="null" />.</param>
+        <param name="preBuffer"> The data to be sent before the file is sent. This parameter can be <see langword="null" />.</param>
+        <param name="postBuffer"> The data to be sent after the file is sent. This parameter can be <see langword="null" />.</param>
         <param name="flags">A bitwise combination of the enumeration values that specifies how the file is transferred.</param>
         <summary>Sends the file <paramref name="fileName" /> and buffers of data to a connected <see cref="T:System.Net.Sockets.Socket" /> object using the specified <see cref="T:System.Net.Sockets.TransmitFileOptions" /> value.</summary>
         <remarks>
@@ -11876,6 +11953,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example creates and connects a socket. The file "test.txt" is located in the root directory of the local machine. In this example, we create a prebuffer and postbuffer of data and send them to the remote host with the file. The default <xref:System.Net.Sockets.TransmitFileOptions> are used.
 
@@ -11883,14 +11963,14 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.NotSupportedException">The operating system is not Windows NT or later.
+        <exception cref="T:System.NotSupportedException"> The operating system is not Windows NT or later.
 
 -or-
 
  The socket is not connected to a remote host.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> object is not in blocking mode and cannot accept this synchronous call.</exception>
-        <exception cref="T:System.IO.FileNotFoundException">The file <paramref name="fileName" /> was not found.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> object is not in blocking mode and cannot accept this synchronous call.</exception>
+        <exception cref="T:System.IO.FileNotFoundException"> The file <paramref name="fileName" /> was not found.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
       </Docs>
     </Member>
@@ -11937,10 +12017,10 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <param name="flags">One or more of <see cref="T:System.Net.Sockets.TransmitFileOptions" /> values.</param>
         <summary>Sends the file <paramref name="fileName" /> and buffers of data to a connected <see cref="T:System.Net.Sockets.Socket" /> object using the specified <see cref="T:System.Net.Sockets.TransmitFileOptions" /> value.</summary>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.NotSupportedException">The <see cref="T:System.Net.Sockets.Socket" /> object is not connected to a remote host.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> object is not in blocking mode and cannot accept this synchronous call.</exception>
-        <exception cref="T:System.IO.FileNotFoundException">The file <paramref name="fileName" /> was not found.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The <see cref="T:System.Net.Sockets.Socket" /> object is not connected to a remote host.</exception>
+        <exception cref="T:System.InvalidOperationException"> The <see cref="T:System.Net.Sockets.Socket" /> object is not in blocking mode and cannot accept this synchronous call.</exception>
+        <exception cref="T:System.IO.FileNotFoundException"> The file <paramref name="fileName" /> was not found.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
       </Docs>
     </Member>
@@ -11976,11 +12056,11 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <summary>Sends the file <paramref name="fileName" /> to a connected <see cref="T:System.Net.Sockets.Socket" /> object.</summary>
         <returns>A value task that represents the asynchronous send file operation.</returns>
         <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Net.Sockets.Socket.SendFile(System.String)" />.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.NotSupportedException">The <see cref="T:System.Net.Sockets.Socket" /> object is not connected to a remote host.</exception>
-        <exception cref="T:System.IO.FileNotFoundException">The file <paramref name="fileName" /> was not found.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The <see cref="T:System.Net.Sockets.Socket" /> object is not connected to a remote host.</exception>
+        <exception cref="T:System.IO.FileNotFoundException"> The file <paramref name="fileName" /> was not found.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendFileAsync">
@@ -12028,11 +12108,11 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <summary>Sends the file <paramref name="fileName" /> and buffers of data to a connected <see cref="T:System.Net.Sockets.Socket" /> object using the specified <see cref="T:System.Net.Sockets.TransmitFileOptions" /> value.</summary>
         <returns>A value task that represents the asynchronous send file operation.</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.NotSupportedException">The <see cref="T:System.Net.Sockets.Socket" /> object is not connected to a remote host.</exception>
-        <exception cref="T:System.IO.FileNotFoundException">The file <paramref name="fileName" /> was not found.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The <see cref="T:System.Net.Sockets.Socket" /> object is not connected to a remote host.</exception>
+        <exception cref="T:System.IO.FileNotFoundException"> The file <paramref name="fileName" /> was not found.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendPacketsAsync">
@@ -12075,7 +12155,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="e" Type="System.Net.Sockets.SocketAsyncEventArgs" />
       </Parameters>
       <Docs>
-        <param name="e">The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
+        <param name="e"> The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
         <summary>Sends a collection of files or in memory data buffers asynchronously to a connected <see cref="T:System.Net.Sockets.Socket" /> object.</summary>
         <returns>
           <see langword="true" /> if the I/O operation is pending. The <see cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" /> event on the <paramref name="e" /> parameter will be raised upon completion of the operation.
@@ -12095,9 +12175,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
  The following properties and events on the <xref:System.Net.Sockets.SocketAsyncEventArgs?displayProperty=nameWithType> object are required to successfully call this method:
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.SendPacketsElements*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.SendPacketsElements*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
 
  The caller may set the <xref:System.Net.Sockets.SocketAsyncEventArgs.UserToken?displayProperty=nameWithType> property to any user state object desired before calling the <xref:System.Net.Sockets.Socket.SendPacketsAsync*> method, so that the information will be retrievable in the callback method. If the callback needs more information than a single object, a small class can be created to hold the other required state information as members.
 
@@ -12113,10 +12193,10 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.IO.FileNotFoundException">The file specified in the <see cref="P:System.Net.Sockets.SendPacketsElement.FilePath" /> property was not found.</exception>
+        <exception cref="T:System.IO.FileNotFoundException"> The file specified in the <see cref="P:System.Net.Sockets.SendPacketsElement.FilePath" /> property was not found.</exception>
         <exception cref="T:System.InvalidOperationException">A socket operation was already in progress using the <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object specified in the <paramref name="e" /> parameter.</exception>
-        <exception cref="T:System.NotSupportedException">The <see cref="T:System.Net.Sockets.Socket" /> is not connected to a remote host.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.NotSupportedException"> The <see cref="T:System.Net.Sockets.Socket" /> is not connected to a remote host.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">A connectionless <see cref="T:System.Net.Sockets.Socket" /> is being used and the file being sent exceeds the maximum packet size of the underlying transport.</exception>
         <altmember cref="T:System.Net.Sockets.SocketAsyncEventArgs" />
         <altmember cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" />
@@ -12163,7 +12243,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that specifies the amount of time after which a synchronous <see cref="Overload:System.Net.Sockets.Socket.Send" /> call will time out.</summary>
-        <value>The time-out value, in milliseconds. If you set the property with a value between 1 and 499, the value will be changed to 500. The default value is 0, which indicates an infinite time-out period. Specifying -1 also indicates an infinite time-out period.</value>
+        <value> The time-out value, in milliseconds. If you set the property with a value between 1 and 499, the value will be changed to 500. The default value is 0, which indicates an infinite time-out period. Specifying -1 also indicates an infinite time-out period.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -12178,8 +12258,8 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The value specified for a set operation is less than -1.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The value specified for a set operation is less than -1.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="SendTo">
@@ -12235,9 +12315,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the data to be sent.</param>
-        <param name="remoteEP">The <see cref="T:System.Net.EndPoint" /> that represents the destination for the data.</param>
+        <param name="remoteEP"> The <see cref="T:System.Net.EndPoint" /> that represents the destination for the data.</param>
         <summary>Sends data to the specified endpoint.</summary>
-        <returns>The number of bytes sent.</returns>
+        <returns> The number of bytes sent.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -12255,6 +12335,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example sends a connectionless datagram to the specified remote host.
 
@@ -12270,7 +12353,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
  <paramref name="remoteEP" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Send(System.Byte[],System.Int32,System.Net.Sockets.SocketFlags)" />
@@ -12315,14 +12398,14 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
       </Parameters>
       <Docs>
         <param name="buffer">A span of bytes that contains the data to be sent.</param>
-        <param name="remoteEP">The <see cref="T:System.Net.EndPoint" /> that represents the destination for the data.</param>
+        <param name="remoteEP"> The <see cref="T:System.Net.EndPoint" /> that represents the destination for the data.</param>
         <summary>Sends data to the specified endpoint.</summary>
-        <returns>The number of bytes sent.</returns>
+        <returns> The number of bytes sent.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <c>remoteEP</c> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendTo">
@@ -12370,9 +12453,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the data to be sent.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
-        <param name="remoteEP">The <see cref="T:System.Net.EndPoint" /> that represents the destination location for the data.</param>
+        <param name="remoteEP"> The <see cref="T:System.Net.EndPoint" /> that represents the destination location for the data.</param>
         <summary>Sends data to a specific endpoint using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent.</returns>
+        <returns> The number of bytes sent.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -12390,6 +12473,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example sends a connectionless datagram to the specified remote host. <xref:System.Net.Sockets.SocketFlags> are passed to the <xref:System.Net.Sockets.Socket.SendTo*> method.
 
@@ -12405,7 +12491,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
  <paramref name="remoteEP" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Send(System.Byte[],System.Int32,System.Net.Sockets.SocketFlags)" />
@@ -12452,14 +12538,14 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
       <Docs>
         <param name="buffer">A span of bytes that contains the data to be sent.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
-        <param name="remoteEP">The <see cref="T:System.Net.EndPoint" /> that represents the destination for the data.</param>
+        <param name="remoteEP"> The <see cref="T:System.Net.EndPoint" /> that represents the destination for the data.</param>
         <summary>Sends data to a specific endpoint using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent.</returns>
+        <returns> The number of bytes sent.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <c>remoteEP</c> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendTo">
@@ -12498,14 +12584,14 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
       <Docs>
         <param name="buffer">A span of bytes that contains the data to be sent.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values that will be used when sending the data.</param>
-        <param name="socketAddress">The <see cref="T:System.Net.SocketAddress" /> that represents the destination for the data.</param>
+        <param name="socketAddress"> The <see cref="T:System.Net.SocketAddress" /> that represents the destination for the data.</param>
         <summary>Sends data to a specific endpoint using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent.</returns>
+        <returns> The number of bytes sent.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="socketAddress" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendTo">
@@ -12553,11 +12639,11 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the data to be sent.</param>
-        <param name="size">The number of bytes to send.</param>
+        <param name="size"> The number of bytes to send.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
-        <param name="remoteEP">The <see cref="T:System.Net.EndPoint" /> that represents the destination location for the data.</param>
+        <param name="remoteEP"> The <see cref="T:System.Net.EndPoint" /> that represents the destination location for the data.</param>
         <summary>Sends the specified number of bytes of data to the specified endpoint using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent.</returns>
+        <returns> The number of bytes sent.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -12575,6 +12661,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example sends a connectionless datagram to the specified remote host. The size and <xref:System.Net.Sockets.SocketFlags> are passed to the <xref:System.Net.Sockets.Socket.SendTo*> method.
 
@@ -12589,9 +12678,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  -or-
 
  <paramref name="remoteEP" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.ArgumentOutOfRangeException">The specified <paramref name="size" /> exceeds the size of <paramref name="buffer" />.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The specified <paramref name="size" /> exceeds the size of <paramref name="buffer" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Send(System.Byte[],System.Int32,System.Net.Sockets.SocketFlags)" />
@@ -12646,12 +12735,12 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
       </Parameters>
       <Docs>
         <param name="buffer">An array of type <see cref="T:System.Byte" /> that contains the data to be sent.</param>
-        <param name="offset">The position in the data buffer at which to begin sending data.</param>
-        <param name="size">The number of bytes to send.</param>
+        <param name="offset"> The position in the data buffer at which to begin sending data.</param>
+        <param name="size"> The number of bytes to send.</param>
         <param name="socketFlags">A bitwise combination of the <see cref="T:System.Net.Sockets.SocketFlags" /> values.</param>
-        <param name="remoteEP">The <see cref="T:System.Net.EndPoint" /> that represents the destination location for the data.</param>
+        <param name="remoteEP"> The <see cref="T:System.Net.EndPoint" /> that represents the destination location for the data.</param>
         <summary>Sends the specified number of bytes of data to the specified endpoint, starting at the specified location in the buffer, and using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
-        <returns>The number of bytes sent.</returns>
+        <returns> The number of bytes sent.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -12668,6 +12757,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example sends a connectionless datagram to the specified remote host. The offset, size, and <xref:System.Net.Sockets.SocketFlags> are passed to the <xref:System.Net.Sockets.Socket.SendTo*> method.
@@ -12703,7 +12795,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  -or-
 
  An operating system error occurs while accessing the <see cref="T:System.Net.Sockets.Socket" />.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller in the call stack does not have the required permissions.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="M:System.Net.Sockets.Socket.Bind(System.Net.EndPoint)" />
@@ -12753,7 +12845,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="e" Type="System.Net.Sockets.SocketAsyncEventArgs" />
       </Parameters>
       <Docs>
-        <param name="e">The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
+        <param name="e"> The <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object to use for this asynchronous socket operation.</param>
         <summary>Sends data asynchronously to a specific remote host.</summary>
         <returns>
           <see langword="true" /> if the I/O operation is pending. The <see cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" /> event on the <paramref name="e" /> parameter will be raised upon completion of the operation.
@@ -12769,15 +12861,15 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
  The following properties and events on the <xref:System.Net.Sockets.SocketAsyncEventArgs?displayProperty=nameWithType> object are required to successfully call this method:
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Buffer*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Count*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Count*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Offset*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Offset*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint*?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint*?displayProperty=nameWithType>
 
--   <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
+- <xref:System.Net.Sockets.SocketAsyncEventArgs.Completed?displayProperty=nameWithType>
 
  The caller may set the <xref:System.Net.Sockets.SocketAsyncEventArgs.UserToken?displayProperty=nameWithType> property to any user state object desired before calling the <xref:System.Net.Sockets.Socket.SendToAsync*> method, so that the information will be retrievable in the callback method. If the callback needs more information than a single object, a small class can be created to hold the other required state information as members.
 
@@ -12793,10 +12885,10 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentNullException">The <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> cannot be null.</exception>
+        <exception cref="T:System.ArgumentNullException"> The <see cref="P:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint" /> cannot be null.</exception>
         <exception cref="T:System.InvalidOperationException">A socket operation was already in progress using the <see cref="T:System.Net.Sockets.SocketAsyncEventArgs" /> object specified in the <paramref name="e" /> parameter.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">The protocol specified is connection-oriented, but the <see cref="T:System.Net.Sockets.Socket" /> is not yet connected.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.Net.Sockets.SocketException"> The protocol specified is connection-oriented, but the <see cref="T:System.Net.Sockets.Socket" /> is not yet connected.</exception>
         <altmember cref="T:System.Net.Sockets.SocketAsyncEventArgs" />
         <altmember cref="P:System.Net.Sockets.SocketAsyncEventArgs.Buffer" />
         <altmember cref="E:System.Net.Sockets.SocketAsyncEventArgs.Completed" />
@@ -12840,15 +12932,15 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="remoteEP" Type="System.Net.EndPoint" Index="1" FrameworkAlternate="net-10.0;net-11.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the data to send.</param>
-        <param name="remoteEP">The remote host to which to send the data.</param>
+        <param name="buffer"> The buffer for the data to send.</param>
+        <param name="remoteEP"> The remote host to which to send the data.</param>
         <summary>Sends data to the specified remote host.</summary>
         <returns>An asynchronous task that completes with the number of bytes sent.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEP" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendToAsync">
@@ -12887,16 +12979,16 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="remoteEP" Type="System.Net.EndPoint" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the data to send.</param>
+        <param name="buffer"> The buffer for the data to send.</param>
         <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when sending the data.</param>
-        <param name="remoteEP">The remote host to which to send the data.</param>
+        <param name="remoteEP"> The remote host to which to send the data.</param>
         <summary>Sends data to the specified remote host.</summary>
         <returns>An asynchronous task that completes with the number of bytes sent.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEP" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendToAsync">
@@ -12933,8 +13025,8 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the data to send.</param>
-        <param name="remoteEP">The remote host to which to send the data.</param>
+        <param name="buffer"> The buffer for the data to send.</param>
+        <param name="remoteEP"> The remote host to which to send the data.</param>
         <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         <summary>Sends data to the specified remote host.</summary>
         <returns>An asynchronous task that completes with the number of bytes sent.</returns>
@@ -12942,8 +13034,8 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEP" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendToAsync">
@@ -12982,9 +13074,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="3" FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the data to send.</param>
+        <param name="buffer"> The buffer for the data to send.</param>
         <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when sending the data.</param>
-        <param name="remoteEP">The remote host to which to send the data.</param>
+        <param name="remoteEP"> The remote host to which to send the data.</param>
         <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         <summary>Sends data to the specified remote host.</summary>
         <returns>An asynchronous task that completes with the number of bytes sent.</returns>
@@ -12992,8 +13084,8 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEP" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="SendToAsync">
@@ -13030,9 +13122,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" Index="3" FrameworkAlternate="net-10.0;net-11.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="buffer">The buffer for the data to send.</param>
+        <param name="buffer"> The buffer for the data to send.</param>
         <param name="socketFlags">A bitwise combination of <see cref="T:System.Net.Sockets.SocketFlags" /> values that will be used when sending the data.</param>
-        <param name="socketAddress">The <see cref="T:System.Net.SocketAddress" /> that represents the destination for the data.</param>
+        <param name="socketAddress"> The <see cref="T:System.Net.SocketAddress" /> that represents the destination for the data.</param>
         <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         <summary>Sends data to a specific endpoint using the specified <see cref="T:System.Net.Sockets.SocketFlags" />.</summary>
         <returns>An asynchronous task that completes with the number of bytes sent.</returns>
@@ -13040,8 +13132,8 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <exception cref="T:System.ArgumentNullException">
           <paramref name="socketAddress" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.OperationCanceledException"> The cancellation token was canceled. This exception is stored into the returned task.</exception>
       </Docs>
     </Member>
     <Member MemberName="SetIPProtectionLevel">
@@ -13088,7 +13180,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="level" Type="System.Net.Sockets.IPProtectionLevel" Index="0" FrameworkAlternate="net-10.0;net-11.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0;netcore-2.0;netcore-2.1;netcore-2.2;netcore-3.0;netcore-3.1" />
       </Parameters>
       <Docs>
-        <param name="level">The IP protection level to set on this socket.</param>
+        <param name="level"> The IP protection level to set on this socket.</param>
         <summary>Sets the IP protection level on a socket.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -13106,8 +13198,8 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentException">The <paramref name="level" /> argument is set to <see cref="F:System.Net.Sockets.IPProtectionLevel.Unspecified" />.</exception>
-        <exception cref="T:System.NotSupportedException">The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> address families.</exception>
+        <exception cref="T:System.ArgumentException"> The <paramref name="level" /> argument is set to <see cref="F:System.Net.Sockets.IPProtectionLevel.Unspecified" />.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> address families.</exception>
         <altmember cref="P:System.Net.IPAddress.IsIPv6Teredo" />
         <altmember cref="T:System.Net.Sockets.IPProtectionLevel" />
         <altmember cref="F:System.Net.Sockets.SocketOptionName.IPProtectionLevel" />
@@ -13145,9 +13237,9 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
         <Parameter Name="optionValue" Type="System.ReadOnlySpan&lt;System.Byte&gt;" Index="2" FrameworkAlternate="net-10.0;net-11.0;net-5.0;net-6.0;net-7.0;net-8.0;net-9.0" />
       </Parameters>
       <Docs>
-        <param name="optionLevel">The platform-defined option level.</param>
-        <param name="optionName">The platform-defined option name.</param>
-        <param name="optionValue">The value to which the option should be set.</param>
+        <param name="optionLevel"> The platform-defined option level.</param>
+        <param name="optionName"> The platform-defined option name.</param>
+        <param name="optionValue"> The value to which the option should be set.</param>
         <summary>Sets a socket option value using platform-specific level and name identifiers.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -13160,7 +13252,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
 
           ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
       </Docs>
     </Member>
@@ -13218,7 +13310,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
       <Docs>
         <param name="optionLevel">One of the <see cref="T:System.Net.Sockets.SocketOptionLevel" /> values.</param>
         <param name="optionName">One of the <see cref="T:System.Net.Sockets.SocketOptionName" /> values.</param>
-        <param name="optionValue">The value of the option, represented as a <see cref="T:System.Boolean" />.</param>
+        <param name="optionValue"> The value of the option, represented as a <see cref="T:System.Boolean" />.</param>
         <summary>Sets the specified <see cref="T:System.Net.Sockets.Socket" /> option to the specified <see cref="T:System.Boolean" /> value.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
@@ -13232,44 +13324,37 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
 
  <xref:System.Net.Sockets.SocketOptionLevel.Socket?displayProperty=nameWithType> options that can be set using this overload.
 
--   <xref:System.Net.Sockets.SocketOptionName.AcceptConnection>
+- <xref:System.Net.Sockets.SocketOptionName.AcceptConnection>
+- <xref:System.Net.Sockets.SocketOptionName.Broadcast>
+- <xref:System.Net.Sockets.SocketOptionName.DontLinger>
+- <xref:System.Net.Sockets.SocketOptionName.Debug>
+- <xref:System.Net.Sockets.SocketOptionName.KeepAlive>
+- <xref:System.Net.Sockets.SocketOptionName.OutOfBandInline>
+- <xref:System.Net.Sockets.SocketOptionName.ReuseAddress>
 
--   <xref:System.Net.Sockets.SocketOptionName.Broadcast>
+<xref:System.Net.Sockets.SocketOptionLevel.IP?displayProperty=nameWithType> options that can be set using this overload.
 
--   <xref:System.Net.Sockets.SocketOptionName.DontLinger>
+- <xref:System.Net.Sockets.SocketOptionName.HeaderIncluded>
+- <xref:System.Net.Sockets.SocketOptionName.MulticastLoopback>
+- <xref:System.Net.Sockets.SocketOptionName.UseLoopback>
 
--   <xref:System.Net.Sockets.SocketOptionName.Debug>
+<xref:System.Net.Sockets.SocketOptionLevel.Tcp?displayProperty=nameWithType> options that can be set using this overload.
 
--   <xref:System.Net.Sockets.SocketOptionName.KeepAlive>
+- <xref:System.Net.Sockets.SocketOptionName.BsdUrgent>
+- <xref:System.Net.Sockets.SocketOptionName.Expedited>
+- <xref:System.Net.Sockets.SocketOptionName.NoDelay>
 
--   <xref:System.Net.Sockets.SocketOptionName.OutOfBandInline>
+<xref:System.Net.Sockets.SocketOptionLevel.Udp?displayProperty=nameWithType> options that can be set using this overload.
 
--   <xref:System.Net.Sockets.SocketOptionName.ReuseAddress>
+- <xref:System.Net.Sockets.SocketOptionName.NoChecksum>
 
- <xref:System.Net.Sockets.SocketOptionLevel.IP?displayProperty=nameWithType> options that can be set using this overload.
-
--   <xref:System.Net.Sockets.SocketOptionName.HeaderIncluded>
-
--   <xref:System.Net.Sockets.SocketOptionName.MulticastLoopback>
-
--   <xref:System.Net.Sockets.SocketOptionName.UseLoopback>
-
- <xref:System.Net.Sockets.SocketOptionLevel.Tcp?displayProperty=nameWithType> options that can be set using this overload.
-
--   <xref:System.Net.Sockets.SocketOptionName.BsdUrgent>
-
--   <xref:System.Net.Sockets.SocketOptionName.Expedited>
-
--   <xref:System.Net.Sockets.SocketOptionName.NoDelay>
-
- <xref:System.Net.Sockets.SocketOptionLevel.Udp?displayProperty=nameWithType> options that can be set using this overload.
-
--   <xref:System.Net.Sockets.SocketOptionName.NoChecksum>
-
- For more information on these options, refer to the <xref:System.Net.Sockets.SocketOptionName> enumeration.
+For more information on these options, refer to the <xref:System.Net.Sockets.SocketOptionName> enumeration.
 
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example opens a socket and enables the `DontLinger` and the `OutOfBandInline` socket options.
@@ -13278,7 +13363,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
       </Docs>
     </Member>
@@ -13347,7 +13432,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="T:System.Net.Sockets.SocketOptionName" />
         <altmember cref="T:System.Net.Sockets.SocketOptionLevel" />
         <altmember cref="M:System.Net.Sockets.Socket.GetSocketOption(System.Net.Sockets.SocketOptionLevel,System.Net.Sockets.SocketOptionName)" />
@@ -13410,70 +13495,52 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
 
  <xref:System.Net.Sockets.SocketOptionLevel.Socket?displayProperty=nameWithType> options that can be set using this overload.
 
--   <xref:System.Net.Sockets.SocketOptionName.Broadcast>
+- <xref:System.Net.Sockets.SocketOptionName.Broadcast>
+- <xref:System.Net.Sockets.SocketOptionName.DontLinger>
+- <xref:System.Net.Sockets.SocketOptionName.Debug>
+- <xref:System.Net.Sockets.SocketOptionName.Error>
+- <xref:System.Net.Sockets.SocketOptionName.KeepAlive>
+- <xref:System.Net.Sockets.SocketOptionName.OutOfBandInline>
+- <xref:System.Net.Sockets.SocketOptionName.ReceiveBuffer>
+- <xref:System.Net.Sockets.SocketOptionName.ReceiveTimeout>
+- <xref:System.Net.Sockets.SocketOptionName.ReuseAddress>
+- <xref:System.Net.Sockets.SocketOptionName.SendBuffer>
+- <xref:System.Net.Sockets.SocketOptionName.SendTimeout>
+- <xref:System.Net.Sockets.SocketOptionName.Type>
 
--   <xref:System.Net.Sockets.SocketOptionName.DontLinger>
+<xref:System.Net.Sockets.SocketOptionLevel.IP?displayProperty=nameWithType> options that can be set using this overload.
 
--   <xref:System.Net.Sockets.SocketOptionName.Debug>
+- <xref:System.Net.Sockets.SocketOptionName.HeaderIncluded>
+- <xref:System.Net.Sockets.SocketOptionName.IPOptions>
+- <xref:System.Net.Sockets.SocketOptionName.IpTimeToLive>
+- <xref:System.Net.Sockets.SocketOptionName.MulticastInterface>
+- <xref:System.Net.Sockets.SocketOptionName.MulticastLoopback>
+- <xref:System.Net.Sockets.SocketOptionName.MulticastTimeToLive>
+- <xref:System.Net.Sockets.SocketOptionName.TypeOfService>
+- <xref:System.Net.Sockets.SocketOptionName.UseLoopback>
 
--   <xref:System.Net.Sockets.SocketOptionName.Error>
+<xref:System.Net.Sockets.SocketOptionLevel.Tcp?displayProperty=nameWithType> options that can be set using this overload.
 
--   <xref:System.Net.Sockets.SocketOptionName.KeepAlive>
+- <xref:System.Net.Sockets.SocketOptionName.BsdUrgent>
+- <xref:System.Net.Sockets.SocketOptionName.Expedited>
+- <xref:System.Net.Sockets.SocketOptionName.NoDelay>
 
--   <xref:System.Net.Sockets.SocketOptionName.OutOfBandInline>
+<xref:System.Net.Sockets.SocketOptionLevel.Udp?displayProperty=nameWithType> options that can be set using this overload.
 
--   <xref:System.Net.Sockets.SocketOptionName.ReceiveBuffer>
+- <xref:System.Net.Sockets.SocketOptionName.ChecksumCoverage>
+- <xref:System.Net.Sockets.SocketOptionName.NoChecksum>
 
--   <xref:System.Net.Sockets.SocketOptionName.ReceiveTimeout>
+<xref:System.Net.Sockets.SocketOptionLevel.IPv6?displayProperty=nameWithType> options that can be set using this overload.
 
--   <xref:System.Net.Sockets.SocketOptionName.ReuseAddress>
+- <xref:System.Net.Sockets.SocketOptionName.HopLimit>
 
--   <xref:System.Net.Sockets.SocketOptionName.SendBuffer>
-
--   <xref:System.Net.Sockets.SocketOptionName.SendTimeout>
-
--   <xref:System.Net.Sockets.SocketOptionName.Type>
-
- <xref:System.Net.Sockets.SocketOptionLevel.IP?displayProperty=nameWithType> options that can be set using this overload.
-
--   <xref:System.Net.Sockets.SocketOptionName.HeaderIncluded>
-
--   <xref:System.Net.Sockets.SocketOptionName.IPOptions>
-
--   <xref:System.Net.Sockets.SocketOptionName.IpTimeToLive>
-
--   <xref:System.Net.Sockets.SocketOptionName.MulticastInterface>
-
--   <xref:System.Net.Sockets.SocketOptionName.MulticastLoopback>
-
--   <xref:System.Net.Sockets.SocketOptionName.MulticastTimeToLive>
-
--   <xref:System.Net.Sockets.SocketOptionName.TypeOfService>
-
--   <xref:System.Net.Sockets.SocketOptionName.UseLoopback>
-
- <xref:System.Net.Sockets.SocketOptionLevel.Tcp?displayProperty=nameWithType> options that can be set using this overload.
-
--   <xref:System.Net.Sockets.SocketOptionName.BsdUrgent>
-
--   <xref:System.Net.Sockets.SocketOptionName.Expedited>
-
--   <xref:System.Net.Sockets.SocketOptionName.NoDelay>
-
- <xref:System.Net.Sockets.SocketOptionLevel.Udp?displayProperty=nameWithType> options that can be set using this overload.
-
--   <xref:System.Net.Sockets.SocketOptionName.ChecksumCoverage>
-
--   <xref:System.Net.Sockets.SocketOptionName.NoChecksum>
-
- <xref:System.Net.Sockets.SocketOptionLevel.IPv6?displayProperty=nameWithType> options that can be set using this overload.
-
--   <xref:System.Net.Sockets.SocketOptionName.HopLimit>
-
- For more information about these options, refer to the <xref:System.Net.Sockets.SocketOptionName> enumeration.
+For more information about these options, refer to the <xref:System.Net.Sockets.SocketOptionName> enumeration.
 
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example sets the <xref:System.Net.Sockets.LingerOption> and <xref:System.Net.Sockets.Socket.Send*> time-out values.
@@ -13484,7 +13551,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="T:System.Net.Sockets.SocketOptionName" />
         <altmember cref="T:System.Net.Sockets.SocketOptionLevel" />
         <altmember cref="M:System.Net.Sockets.Socket.GetSocketOption(System.Net.Sockets.SocketOptionLevel,System.Net.Sockets.SocketOptionName)" />
@@ -13557,7 +13624,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
         <exception cref="T:System.ArgumentNullException">
           <paramref name="optionValue" /> is <see langword="null" />.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="T:System.Net.Sockets.SocketOptionName" />
         <altmember cref="T:System.Net.Sockets.SocketOptionLevel" />
         <altmember cref="M:System.Net.Sockets.Socket.GetSocketOption(System.Net.Sockets.SocketOptionLevel,System.Net.Sockets.SocketOptionName)" />
@@ -13616,18 +13683,17 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
 
  The following table shows the <xref:System.Net.Sockets.SocketShutdown> enumeration values that are valid for the `how` parameter.
 
-|Value|Description|
-|-----------|-----------------|
-|Send|Disable sending on this <xref:System.Net.Sockets.Socket>.|
-|Receive|Disable receiving on this <xref:System.Net.Sockets.Socket>.|
-|Both|Disable both sending and receiving on this <xref:System.Net.Sockets.Socket>.|
+| Value   | Description                                                                  |
+|---------|------------------------------------------------------------------------------|
+| Send    | Disable sending on this <xref:System.Net.Sockets.Socket>.                    |
+| Receive | Disable receiving on this <xref:System.Net.Sockets.Socket>.                  |
+| Both    | Disable both sending and receiving on this <xref:System.Net.Sockets.Socket>. |
 
  Setting `how` to <xref:System.Net.Sockets.SocketShutdown.Send> specifies that subsequent calls to <xref:System.Net.Sockets.Socket.Send*> are not allowed. If you are using a connectionless <xref:System.Net.Sockets.Socket>, specifying <xref:System.Net.Sockets.SocketShutdown.Send> will have no effect.
 
- Setting `how` to <xref:System.Net.Sockets.SocketShutdown.Receive> specifies that subsequent calls to <xref:System.Net.Sockets.Socket.Receive*> are not allowed. This has no effect on lower protocol layers. If you are using a connection-oriented protocol, the connection is terminated if either of the following conditions exist after a call to <xref:System.Net.Sockets.Socket.Shutdown*> :
+ Setting `how` to <xref:System.Net.Sockets.SocketShutdown.Receive> specifies that subsequent calls to <xref:System.Net.Sockets.Socket.Receive*> are not allowed. This has no effect on lower protocol layers. If you are using a connection-oriented protocol, the connection is terminated if either of the following conditions exist after a call to <xref:System.Net.Sockets.Socket.Shutdown*>:
 
 - Data is in the incoming network buffer waiting to be received.
-
 - More data has arrived.
 
  If you are using a connectionless protocol, datagrams are accepted and queued. However, if no buffer space is available for additional incoming datagrams, they will be discarded and no error will be returned to the sender. Using <xref:System.Net.Sockets.Socket.Shutdown*> on a connectionless <xref:System.Net.Sockets.Socket> is not recommended.
@@ -13636,6 +13702,9 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
 
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException> when calling the <xref:System.Net.Sockets.Socket.Shutdown*> method, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example uses <xref:System.Net.Sockets.Socket.Shutdown*> to disable the <xref:System.Net.Sockets.Socket>.
@@ -13646,7 +13715,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Close" />
         <altmember cref="T:System.Net.Sockets.SocketShutdown" />
       </Docs>
@@ -13870,7 +13939,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that specifies the Time To Live (TTL) value of Internet Protocol (IP) packets sent by the <see cref="T:System.Net.Sockets.Socket" />.</summary>
-        <value>The TTL value.</value>
+        <value> The TTL value.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -13890,10 +13959,10 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentOutOfRangeException">The TTL value is a negative number.</exception>
-        <exception cref="T:System.NotSupportedException">The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
+        <exception cref="T:System.ArgumentOutOfRangeException"> The TTL value is a negative number.</exception>
+        <exception cref="T:System.NotSupportedException"> The socket is not in the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" /> families.</exception>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket. This error is also returned when an attempt was made to set TTL to a value higher than 255.</exception>
-        <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
+        <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="UseOnlyOverlappedIO">
@@ -13944,8 +14013,8 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
       <Docs>
         <summary>Gets or sets a value that specifies whether the socket should only use Overlapped I/O mode.</summary>
         <value>Always <see langword="false" />.</value>
-        <remarks>The value of this property is always `false`, and you cannot change its value.</remarks>
-        <exception cref="T:System.InvalidOperationException">The socket has been bound to a completion port.</exception>
+        <remarks> The value of this property is always `false`, and you cannot change its value.</remarks>
+        <exception cref="T:System.InvalidOperationException"> The socket has been bound to a completion port.</exception>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Net.Sockets/Socket.xml
+++ b/xml/System.Net.Sockets/Socket.xml
@@ -242,6 +242,8 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > If this constructor throws a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">The combination of  <paramref name="socketType" /> and <paramref name="protocolType" /> results in an invalid socket.</exception>
@@ -298,7 +300,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  The `addressFamily` parameter specifies the addressing scheme that the <xref:System.Net.Sockets.Socket> class uses, the `socketType` parameter specifies the type of the <xref:System.Net.Sockets.Socket> class, and the `protocolType` parameter specifies the protocol used by <xref:System.Net.Sockets.Socket>. The three parameters are not independent. Some address families restrict which protocols can be used with them, and often the <xref:System.Net.Sockets.Socket> type is implicit in the protocol. If the combination of address family, <xref:System.Net.Sockets.Socket> type, and protocol type results in an invalid <xref:System.Net.Sockets.Socket>, this constructor throws a <xref:System.Net.Sockets.SocketException>.
 
 > [!NOTE]
->  If this constructor throws a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If this constructor throws a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates how to create an instance of the <xref:System.Net.Sockets.Socket> class.
@@ -367,7 +372,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  If you call this method using a non-blocking <xref:System.Net.Sockets.Socket>, and no connection requests are queued, <xref:System.Net.Sockets.Socket.Accept*> throws a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  Before calling the <xref:System.Net.Sockets.Socket.Accept*> method, you must first call the <xref:System.Net.Sockets.Socket.Listen*> method to listen for and queue incoming connection requests.
+> Before calling the <xref:System.Net.Sockets.Socket.Accept*> method, you must first call the <xref:System.Net.Sockets.Socket.Listen*> method to listen for and queue incoming connection requests.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example accepts a simple <xref:System.Net.Sockets.Socket> connection.
@@ -755,6 +763,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  If the remote host shuts down or closes the connection, <xref:System.Net.Sockets.Socket.Available*> can throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example compares the results of calling IOControl with FIONREAD and the Available property.
 
@@ -847,13 +858,16 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  To cancel a pending call to the <xref:System.Net.Sockets.Socket.BeginAccept*> method, close the <xref:System.Net.Sockets.Socket>. When the <xref:System.Net.Sockets.Socket.Close*> method is called while an asynchronous operation is in progress, the callback provided to the <xref:System.Net.Sockets.Socket.BeginAccept*> method is called. A subsequent call to the <xref:System.Net.Sockets.Socket.EndAccept*> method will throw an <xref:System.ObjectDisposedException> (before .NET 7) or a <xref:System.Net.Sockets.SocketException> (on .NET 7+) to indicate that the operation has been cancelled.
 
 > [!NOTE]
->  You can use the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the returned <xref:System.Net.Sockets.Socket> to identify the remote host's network address and port number.
+> You can use the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the returned <xref:System.Net.Sockets.Socket> to identify the remote host's network address and port number.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> This member outputs trace information when you enable network tracing in your application.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -939,13 +953,16 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  To cancel a pending call to the <xref:System.Net.Sockets.Socket.BeginAccept*> method, close the <xref:System.Net.Sockets.Socket>. When the <xref:System.Net.Sockets.Socket.Close*> method is called while an asynchronous operation is in progress, the callback provided to the <xref:System.Net.Sockets.Socket.BeginAccept*> method is called. A subsequent call to the <xref:System.Net.Sockets.Socket.EndAccept*> method will throw an <xref:System.ObjectDisposedException> (before .NET 7) or a <xref:System.Net.Sockets.SocketException> (on .NET 7+) to indicate that the operation has been cancelled.
 
 > [!NOTE]
->  You can use the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the returned <xref:System.Net.Sockets.Socket> to identify the remote host's network address and port number.
+> You can use the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the returned <xref:System.Net.Sockets.Socket> to identify the remote host's network address and port number.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> This member outputs trace information when you enable network tracing in your application.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -1035,13 +1052,16 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  To cancel a pending call to the <xref:System.Net.Sockets.Socket.BeginAccept*> method, close the <xref:System.Net.Sockets.Socket>. When the <xref:System.Net.Sockets.Socket.Close*> method is called while an asynchronous operation is in progress, the callback provided to the <xref:System.Net.Sockets.Socket.BeginAccept*> method is called. A subsequent call to the <xref:System.Net.Sockets.Socket.EndAccept*> method will throw an <xref:System.ObjectDisposedException> (before .NET 7) or a <xref:System.Net.Sockets.SocketException> (on .NET 7+) to indicate that the operation has been cancelled.
 
 > [!NOTE]
->  You can use the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the returned <xref:System.Net.Sockets.Socket> to identify the remote host's network address and port number.
+> You can use the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the returned <xref:System.Net.Sockets.Socket> to identify the remote host's network address and port number.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> This member outputs trace information when you enable network tracing in your application.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -1148,13 +1168,16 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  To cancel a pending call to the <xref:System.Net.Sockets.Socket.BeginAccept*> method, close the <xref:System.Net.Sockets.Socket>. When the <xref:System.Net.Sockets.Socket.Close*> method is called while an asynchronous operation is in progress, the callback provided to the <xref:System.Net.Sockets.Socket.BeginAccept*> method is called. A subsequent call to the <xref:System.Net.Sockets.Socket.EndAccept*> method will throw an <xref:System.ObjectDisposedException> (before .NET 7) or a <xref:System.Net.Sockets.SocketException> (on .NET 7+) to indicate that the operation has been cancelled.
 
 > [!NOTE]
->  You can use the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the returned <xref:System.Net.Sockets.Socket> to identify the remote host's network address and port number.
+> You can use the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the returned <xref:System.Net.Sockets.Socket> to identify the remote host's network address and port number.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> This member outputs trace information when you enable network tracing in your application.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -1255,13 +1278,16 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  To cancel a pending call to the <xref:System.Net.Sockets.Socket.BeginConnect*> method, close the <xref:System.Net.Sockets.Socket>. When the <xref:System.Net.Sockets.Socket.Close*> method is called while an asynchronous operation is in progress, the callback provided to the <xref:System.Net.Sockets.Socket.BeginConnect*> method is called. A subsequent call to the <xref:System.Net.Sockets.Socket.EndConnect*> method will throw an <xref:System.ObjectDisposedException> (before .NET 7) or a <xref:System.Net.Sockets.SocketException> (on .NET 7+) to indicate that the operation has been cancelled.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  If this socket has previously been disconnected, then <xref:System.Net.Sockets.Socket.BeginConnect*> must be called on a thread that will not exit until the operation is complete. This is a limitation of the underlying provider.
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> If this socket has previously been disconnected, then <xref:System.Net.Sockets.Socket.BeginConnect*> must be called on a thread that will not exit until the operation is complete. This is a limitation of the underlying provider.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -1364,13 +1390,16 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  To cancel a pending call to the <xref:System.Net.Sockets.Socket.BeginConnect*> method, close the <xref:System.Net.Sockets.Socket>. When the <xref:System.Net.Sockets.Socket.Close*> method is called while an asynchronous operation is in progress, the callback provided to the <xref:System.Net.Sockets.Socket.BeginConnect*> method is called. A subsequent call to the <xref:System.Net.Sockets.Socket.EndConnect*> method will throw an <xref:System.ObjectDisposedException> (before .NET 7) or a <xref:System.Net.Sockets.SocketException> (on .NET 7+) to indicate that the operation has been cancelled.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  If this socket has previously been disconnected, then <xref:System.Net.Sockets.Socket.BeginConnect*> must be called on a thread that will not exit until the operation is complete. This is a limitation of the underlying provider.
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> If this socket has previously been disconnected, then <xref:System.Net.Sockets.Socket.BeginConnect*> must be called on a thread that will not exit until the operation is complete. This is a limitation of the underlying provider.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -1473,13 +1502,16 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  To cancel a pending call to the <xref:System.Net.Sockets.Socket.BeginConnect*> method, close the <xref:System.Net.Sockets.Socket>. When the <xref:System.Net.Sockets.Socket.Close*> method is called while an asynchronous operation is in progress, the callback provided to the <xref:System.Net.Sockets.Socket.BeginConnect*> method is called. A subsequent call to the <xref:System.Net.Sockets.Socket.EndConnect*> method will throw an <xref:System.ObjectDisposedException> (before .NET 7) or a <xref:System.Net.Sockets.SocketException> (on .NET 7+) to indicate that the operation has been cancelled.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  If this socket has previously been disconnected, then <xref:System.Net.Sockets.Socket.BeginConnect*> must be called on a thread that will not exit until the operation is complete. This is a limitation of the underlying provider.
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> If this socket has previously been disconnected, then <xref:System.Net.Sockets.Socket.BeginConnect*> must be called on a thread that will not exit until the operation is complete. This is a limitation of the underlying provider.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -1566,7 +1598,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  The <xref:System.Net.Sockets.Socket.BeginDisconnect*> operation must be completed by calling the <xref:System.Net.Sockets.Socket.EndDisconnect*> method. Typically, the method is invoked by the provided <xref:System.AsyncCallback> delegate. <xref:System.Net.Sockets.Socket.EndDisconnect*> will block the calling thread until the operation is completed.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
  ]]></format>
         </remarks>
@@ -1659,16 +1691,19 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  Close the <xref:System.Net.Sockets.Socket> to cancel a pending <xref:System.Net.Sockets.Socket.BeginReceive*>. When the <xref:System.Net.Sockets.Socket.Close*> method is called while an asynchronous operation is in progress, the callback provided to the <xref:System.Net.Sockets.Socket.BeginReceive*> method is called. A subsequent call to the <xref:System.Net.Sockets.Socket.EndReceive*> method will throw an <xref:System.ObjectDisposedException> (before .NET 7) or a <xref:System.Net.Sockets.SocketException> (on .NET 7+) to indicate that the operation has been cancelled.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
->  `state` is an instantiation of a user-defined class.
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> `state` is an instantiation of a user-defined class.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -1757,16 +1792,19 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  Close the <xref:System.Net.Sockets.Socket> to cancel a pending <xref:System.Net.Sockets.Socket.BeginReceive*>. When the <xref:System.Net.Sockets.Socket.Close*> method is called while an asynchronous operation is in progress, the callback provided to the <xref:System.Net.Sockets.Socket.BeginReceive*> method is called. A subsequent call to the <xref:System.Net.Sockets.Socket.EndReceive*> method will throw an <xref:System.ObjectDisposedException> (before .NET 7) or a <xref:System.Net.Sockets.SocketException> (on .NET 7+) to indicate that the operation has been cancelled.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
->  `state` is an instantiation of a user-defined class.
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> `state` is an instantiation of a user-defined class.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -1865,16 +1903,19 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  Close the <xref:System.Net.Sockets.Socket> to cancel a pending <xref:System.Net.Sockets.Socket.BeginReceive*>. When the <xref:System.Net.Sockets.Socket.Close*> method is called while an asynchronous operation is in progress, the callback provided to the <xref:System.Net.Sockets.Socket.BeginReceive*> method is called. A subsequent call to the <xref:System.Net.Sockets.Socket.EndReceive*> method will throw an <xref:System.ObjectDisposedException> (before .NET 7) or a <xref:System.Net.Sockets.SocketException> (on .NET 7+) to indicate that the operation has been cancelled.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
->  `state` is an instantiation of a user-defined class.
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> `state` is an instantiation of a user-defined class.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -1981,16 +2022,19 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  Close the <xref:System.Net.Sockets.Socket> to cancel a pending <xref:System.Net.Sockets.Socket.BeginReceive*>. When the <xref:System.Net.Sockets.Socket.Close*> method is called while an asynchronous operation is in progress, the callback provided to the <xref:System.Net.Sockets.Socket.BeginReceive*> method is called. A subsequent call to the <xref:System.Net.Sockets.Socket.EndReceive*> method will throw an <xref:System.ObjectDisposedException> (before .NET 7) or a <xref:System.Net.Sockets.SocketException> (on .NET 7+) to indicate that the operation has been cancelled.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
->  `state` is an instantiation of a user-defined class.
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> `state` is an instantiation of a user-defined class.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -2115,10 +2159,13 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  To cancel a pending <xref:System.Net.Sockets.Socket.BeginReceiveFrom*>, call the <xref:System.Net.Sockets.Socket.Close*> method.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> This member outputs trace information when you enable network tracing in your application.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -2237,10 +2284,13 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  This method reads data into the `buffer` parameter, and captures the remote host endpoint from which the data is sent, as well as information about the received packet. For information on how to retrieve this endpoint, refer to <xref:System.Net.Sockets.Socket.EndReceiveMessageFrom*>. This method is most useful if you intend to asynchronously receive connectionless datagrams from an unknown host or multiple hosts.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> This member outputs trace information when you enable network tracing in your application.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -2355,19 +2405,22 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  If you specify the <xref:System.Net.Sockets.SocketFlags.DontRoute> flag as the `socketflags` parameter, the data you are sending will not be routed.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
->  `state` is an instantiation of a user-defined class.
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> `state` is an instantiation of a user-defined class.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -2458,19 +2511,22 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  If you specify the <xref:System.Net.Sockets.SocketFlags.DontRoute> flag as the `socketflags` parameter, the data you are sending will not be routed.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
->  `state` is an instantiation of a user-defined class.
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> `state` is an instantiation of a user-defined class.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -2571,19 +2627,22 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  If you specify the <xref:System.Net.Sockets.SocketFlags.DontRoute> flag as the `socketflags` parameter, the data you are sending will not be routed.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
->  `state` is an instantiation of a user-defined class.
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> `state` is an instantiation of a user-defined class.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -2690,19 +2749,22 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  If you specify the <xref:System.Net.Sockets.SocketFlags.DontRoute> flag as the `socketflags` parameter, the data you are sending will not be routed.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
->  `state` is an instantiation of a user-defined class.
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> `state` is an instantiation of a user-defined class.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+
+> [!NOTE]
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -2811,10 +2873,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  Although intended for connection-oriented protocols, <xref:System.Net.Sockets.Socket.BeginSendFile*> also works for connectionless protocols, provided that you first call the <xref:System.Net.Sockets.Socket.Connect*> or <xref:System.Net.Sockets.Socket.BeginConnect*> method to establish a default remote host. With connectionless protocols, you must be sure that the size of your file does not exceed the maximum packet size of the underlying service provider. If it does, the datagram is not sent and <xref:System.Net.Sockets.Socket.BeginSendFile*> throws a <xref:System.Net.Sockets.SocketException> exception.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -2900,10 +2962,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  Although intended for connection-oriented protocols, <xref:System.Net.Sockets.Socket.BeginSendFile*> also works for connectionless protocols, provided that you first call the <xref:System.Net.Sockets.Socket.Connect*> or <xref:System.Net.Sockets.Socket.BeginConnect*> method to establish a default remote host. With connectionless protocols, you must be sure that the size of your file does not exceed the maximum packet size of the underlying service provider. If it does, the datagram is not sent and <xref:System.Net.Sockets.Socket.BeginSendFile*> throws a <xref:System.Net.Sockets.SocketException> exception.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -3006,10 +3068,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  If you specify the <xref:System.Net.Sockets.SocketFlags.DontRoute> flag as the `socketflags` parameter, the data you are sending will not be routed.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
+> The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
@@ -3100,13 +3162,13 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  If a UDP socket wants to receive interface information on received packets,  the <xref:System.Net.Sockets.Socket.SetSocketOption*> method should be explicitly called with the socket option set to <xref:System.Net.Sockets.SocketOptionName.PacketInformation> immediately after calling the <xref:System.Net.Sockets.Socket.Bind*> method.
 
 > [!NOTE]
->  If you intend to receive multicast datagrams, you must call the <xref:System.Net.Sockets.Socket.Bind*> method with a multicast port number.
+> If you intend to receive multicast datagrams, you must call the <xref:System.Net.Sockets.Socket.Bind*> method with a multicast port number.
 
 > [!NOTE]
->  You must call the <xref:System.Net.Sockets.Socket.Bind*> method if you intend to receive connectionless datagrams using the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method.
+> You must call the <xref:System.Net.Sockets.Socket.Bind*> method if you intend to receive connectionless datagrams using the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException> when calling the <xref:System.Net.Sockets.Socket.Bind*> method, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException> when calling the <xref:System.Net.Sockets.Socket.Bind*> method, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -3180,7 +3242,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  If you are in blocking mode, and you make a method call that does not complete immediately, your application will block execution until the requested operation completes. If you want execution to continue even though the requested operation is not complete, change the <xref:System.Net.Sockets.Socket.Blocking> property to `false`. The <xref:System.Net.Sockets.Socket.Blocking> property has no effect on asynchronous methods. If you are sending and receiving data asynchronously and want to block execution, use the <xref:System.Threading.ManualResetEvent> class.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
  ]]></format>
         </remarks>
@@ -3303,7 +3365,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  If you need to call <xref:System.Net.Sockets.Socket.Close*> without first calling <xref:System.Net.Sockets.Socket.Shutdown*>, you can ensure that data queued for outgoing transmission will be sent by setting the <xref:System.Net.Sockets.SocketOptionName.DontLinger><xref:System.Net.Sockets.Socket> option to `false` and specifying a non-zero time-out interval. <xref:System.Net.Sockets.Socket.Close*> will then block until this data is sent or until the specified time-out expires. If you set <xref:System.Net.Sockets.SocketOptionName.DontLinger> to `false` and specify a zero time-out interval, <xref:System.Net.Sockets.Socket.Close*> releases the connection and automatically discards outgoing queued data.
 
 > [!NOTE]
->  To set the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to `false`, create a <xref:System.Net.Sockets.LingerOption>, set the enabled property to `true`, and set the <xref:System.Net.Sockets.LingerOption.LingerTime> property to the desired time out period. Use this <xref:System.Net.Sockets.LingerOption> along with the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to call the <xref:System.Net.Sockets.Socket.SetSocketOption*> method.
+> To set the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to `false`, create a <xref:System.Net.Sockets.LingerOption>, set the enabled property to `true`, and set the <xref:System.Net.Sockets.LingerOption.LingerTime> property to the desired time out period. Use this <xref:System.Net.Sockets.LingerOption> along with the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to call the <xref:System.Net.Sockets.Socket.SetSocketOption*> method.
 
 
 
@@ -3371,7 +3433,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  If you need to call <xref:System.Net.Sockets.Socket.Close*> without first calling <xref:System.Net.Sockets.Socket.Shutdown*>, you can ensure that data queued for outgoing transmission will be sent by setting the <xref:System.Net.Sockets.SocketOptionName.DontLinger> option to `false` and specifying a non-zero time-out interval. <xref:System.Net.Sockets.Socket.Close*> will then block until this data is sent or until the specified time-out expires. If you set <xref:System.Net.Sockets.SocketOptionName.DontLinger> to `false` and specify a zero time-out interval, <xref:System.Net.Sockets.Socket.Close*> releases the connection and automatically discards outgoing queued data.
 
 > [!NOTE]
->  To set the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to `false`, create a <xref:System.Net.Sockets.LingerOption>, set the enabled property to `true`, and set the <xref:System.Net.Sockets.LingerOption.LingerTime> property to the desired time-out period. Use this <xref:System.Net.Sockets.LingerOption> along with the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to call the <xref:System.Net.Sockets.Socket.SetSocketOption*> method.
+> To set the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to `false`, create a <xref:System.Net.Sockets.LingerOption>, set the enabled property to `true`, and set the <xref:System.Net.Sockets.LingerOption.LingerTime> property to the desired time-out period. Use this <xref:System.Net.Sockets.LingerOption> along with the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to call the <xref:System.Net.Sockets.Socket.SetSocketOption*> method.
 
 
 
@@ -3451,10 +3513,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  The <xref:System.Net.Sockets.Socket.Connect*> method will block, unless you specifically set the <xref:System.Net.Sockets.Socket.Blocking> property to `false` prior to calling <xref:System.Net.Sockets.Socket.Connect*>. If you are using a connection-oriented protocol like TCP and you do disable blocking, <xref:System.Net.Sockets.Socket.Connect*> will throw a <xref:System.Net.Sockets.SocketException> because it needs time to make the connection. Connectionless protocols will not throw an exception because they simply establish a default remote host. You can use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error. If the error returned WSAEWOULDBLOCK, the remote host connection has been initiated by a connection-oriented <xref:System.Net.Sockets.Socket>, but has not yet completed successfully. Use the <xref:System.Net.Sockets.Socket.Poll*> method to determine when the <xref:System.Net.Sockets.Socket> is finished connecting.
 
 > [!NOTE]
->  If you are using a connection-oriented protocol and did not call <xref:System.Net.Sockets.Socket.Bind*> before calling <xref:System.Net.Sockets.Socket.Connect*>, the underlying service provider will assign the local network address and port number. If you are using a connectionless protocol, the service provider will not assign a local network address and port number until you complete a send or receive operation. If you want to change the default remote host, call <xref:System.Net.Sockets.Socket.Connect*> again with the desired endpoint.
+> If you are using a connection-oriented protocol and did not call <xref:System.Net.Sockets.Socket.Bind*> before calling <xref:System.Net.Sockets.Socket.Connect*>, the underlying service provider will assign the local network address and port number. If you are using a connectionless protocol, the service provider will not assign a local network address and port number until you complete a send or receive operation. If you want to change the default remote host, call <xref:System.Net.Sockets.Socket.Connect*> again with the desired endpoint.
 
 > [!NOTE]
->  If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
+> If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
 
 
 
@@ -3537,10 +3599,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  <xref:System.Net.Sockets.Socket.Connect*> method will block, unless you specifically set the <xref:System.Net.Sockets.Socket.Blocking> property to `false` prior to calling <xref:System.Net.Sockets.Socket.Connect*>. If you are using a connection-oriented protocol like TCP and you do disable blocking, <xref:System.Net.Sockets.Socket.Connect*> will throw a <xref:System.Net.Sockets.SocketException> because it needs time to make the connection. Connectionless protocols will not throw an exception because they simply establish a default remote host. You can use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error. If the error returned WSAEWOULDBLOCK, the remote host connection has been initiated by a connection-oriented <xref:System.Net.Sockets.Socket>, but has not yet completed successfully. Use the <xref:System.Net.Sockets.Socket.Poll*> method to determine when the <xref:System.Net.Sockets.Socket> is finished connecting.
 
 > [!NOTE]
->  If you are using a connection-oriented protocol and did not call <xref:System.Net.Sockets.Socket.Bind*> before calling <xref:System.Net.Sockets.Socket.Connect*>, the underlying service provider will assign the local network address and port number. If you are using a connectionless protocol, the service provider will not assign a local network address and port number until you complete a send or receive operation. If you want to change the default remote host, call <xref:System.Net.Sockets.Socket.Connect*> again with the desired endpoint.
+> If you are using a connection-oriented protocol and did not call <xref:System.Net.Sockets.Socket.Bind*> before calling <xref:System.Net.Sockets.Socket.Connect*>, the underlying service provider will assign the local network address and port number. If you are using a connectionless protocol, the service provider will not assign a local network address and port number until you complete a send or receive operation. If you want to change the default remote host, call <xref:System.Net.Sockets.Socket.Connect*> again with the desired endpoint.
 
 > [!NOTE]
->  If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
+> If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
 
 ## Examples
  The following code example connects to a remote endpoint and then verifies the connection.
@@ -3614,10 +3676,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  <xref:System.Net.Sockets.Socket.Connect*> method will block, unless you specifically set the <xref:System.Net.Sockets.Socket.Blocking> property to `false` prior to calling <xref:System.Net.Sockets.Socket.Connect*>. If you are using a connection-oriented protocol like TCP and you do disable blocking, <xref:System.Net.Sockets.Socket.Connect*> will throw a <xref:System.Net.Sockets.SocketException> because it needs time to make the connection. Connectionless protocols will not throw an exception because they simply establish a default remote host. You can use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error. If the error returned WSAEWOULDBLOCK, the remote host connection has been initiated by a connection-oriented <xref:System.Net.Sockets.Socket>, but has not yet completed successfully. Use the <xref:System.Net.Sockets.Socket.Poll*> method to determine when the <xref:System.Net.Sockets.Socket> is finished connecting.
 
 > [!NOTE]
->  If you are using a connection-oriented protocol and did not call <xref:System.Net.Sockets.Socket.Bind*> before calling <xref:System.Net.Sockets.Socket.Connect*>, the underlying service provider will assign the local network address and port number. If you are using a connectionless protocol, the service provider will not assign a local network address and port number until you complete a send or receive operation. If you want to change the default remote host, call <xref:System.Net.Sockets.Socket.Connect*> again with the desired endpoint.
+> If you are using a connection-oriented protocol and did not call <xref:System.Net.Sockets.Socket.Bind*> before calling <xref:System.Net.Sockets.Socket.Connect*>, the underlying service provider will assign the local network address and port number. If you are using a connectionless protocol, the service provider will not assign a local network address and port number until you complete a send or receive operation. If you want to change the default remote host, call <xref:System.Net.Sockets.Socket.Connect*> again with the desired endpoint.
 
 > [!NOTE]
->  If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
+> If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
 
 ## Examples
  The following code example connects to a remote endpoint and then verifies the connection.
@@ -3693,10 +3755,10 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  If IPv6 is enabled and the <xref:System.Net.Sockets.Socket.Connect(System.String,System.Int32)> method is called to connect to a host that resolves to both IPv6 and IPv4 addresses, the connection to the IPv6 address will be attempted first before the IPv4 address. This may have the effect of delaying the time to establish the connection if the host is not listening on the IPv6 address.
 
 > [!NOTE]
->  If you're using a connection-oriented protocol and did not call <xref:System.Net.Sockets.Socket.Bind*> before calling <xref:System.Net.Sockets.Socket.Connect*>, the underlying service provider will assign the local network address and port number. If you are using a connectionless protocol, the service provider will not assign a local network address and port number until you complete a send or receive operation. If you want to change the default remote host, call <xref:System.Net.Sockets.Socket.Connect*> again with the desired endpoint.
+> If you're using a connection-oriented protocol and did not call <xref:System.Net.Sockets.Socket.Bind*> before calling <xref:System.Net.Sockets.Socket.Connect*>, the underlying service provider will assign the local network address and port number. If you are using a connectionless protocol, the service provider will not assign a local network address and port number until you complete a send or receive operation. If you want to change the default remote host, call <xref:System.Net.Sockets.Socket.Connect*> again with the desired endpoint.
 
 > [!NOTE]
->  If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
+> If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
 
 ## Examples
  The following code example connects to a remote endpoint and then verifies the connection.
@@ -3840,7 +3902,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  The <xref:System.Net.Sockets.Socket.ConnectAsync*> method throws <xref:System.NotSupportedException> if the address family of the <xref:System.Net.Sockets.Socket> and the <xref:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint*?displayProperty=nameWithType> are not the same address family.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException> when calling this method, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException> when calling this method, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
  ]]></format>
         </remarks>
@@ -4223,7 +4285,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  The <xref:System.Net.Sockets.Socket.ConnectAsync*> method throws <xref:System.NotSupportedException> if the address family of the <xref:System.Net.Sockets.Socket> and the <xref:System.Net.Sockets.SocketAsyncEventArgs.RemoteEndPoint*?displayProperty=nameWithType> are not the same address family.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException> when calling this method, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException> when calling this method, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
  ]]></format>
         </remarks>
@@ -4442,7 +4504,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  If you need to call <xref:System.Net.Sockets.Socket.Disconnect*> without first calling <xref:System.Net.Sockets.Socket.Shutdown*>, you can set the <xref:System.Net.Sockets.SocketOptionName.DontLinger><xref:System.Net.Sockets.Socket> option to `false` and specify a nonzero time-out interval to ensure that data queued for outgoing transmission is sent. <xref:System.Net.Sockets.Socket.Disconnect*> then blocks until the data is sent or until the specified time-out expires. If you set <xref:System.Net.Sockets.SocketOptionName.DontLinger> to `false` and specify a zero time-out interval, <xref:System.Net.Sockets.Socket.Close*> releases the connection and automatically discards outgoing queued data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -4616,7 +4678,7 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  For more information, see [Cleaning Up Unmanaged Resources](/dotnet/standard/garbage-collection/unmanaged) and [Implementing a Dispose Method](/dotnet/standard/garbage-collection/implementing-dispose).
 
 > [!NOTE]
->  Always call `Dispose` before you release your last reference to the <xref:System.Net.Sockets.Socket>. Otherwise, the resources it is using will not be freed until the garbage collector calls the <xref:System.Net.Sockets.Socket> object's `Finalize` method.
+> Always call `Dispose` before you release your last reference to the <xref:System.Net.Sockets.Socket>. Otherwise, the resources it is using will not be freed until the garbage collector calls the <xref:System.Net.Sockets.Socket> object's `Finalize` method.
 
  ]]></format>
         </remarks>
@@ -4985,6 +5047,9 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5063,6 +5128,9 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5138,6 +5206,9 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5206,6 +5277,9 @@ Duplication of the socket reference failed.</exception>
 
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -5276,7 +5350,10 @@ Duplication of the socket reference failed.</exception>
  <xref:System.Net.Sockets.Socket.EndDisconnect*> completes the operation started by <xref:System.Net.Sockets.Socket.BeginDisconnect*>. You need to pass the <xref:System.IAsyncResult> created by the matching <xref:System.Net.Sockets.Socket.BeginDisconnect*> call. <xref:System.Net.Sockets.Socket.EndDisconnect*> will block the calling thread until the operation is completed.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -5359,10 +5436,13 @@ Duplication of the socket reference failed.</exception>
  The <xref:System.Net.Sockets.Socket.EndReceive*> method will block until data is available. If you are using a connectionless protocol, <xref:System.Net.Sockets.Socket.EndReceive*> will read the first enqueued datagram available in the incoming network buffer. If you are using a connection-oriented protocol, the <xref:System.Net.Sockets.Socket.EndReceive*> method will read as much data as is available up to the number of bytes you specified in the `size` parameter of the <xref:System.Net.Sockets.Socket.BeginReceive*> method. If the remote host shuts down the <xref:System.Net.Sockets.Socket> connection with the <xref:System.Net.Sockets.Socket.Shutdown*> method, and all available data has been received, the <xref:System.Net.Sockets.Socket.EndReceive*> method will complete immediately and return zero bytes.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> This member outputs trace information when you enable network tracing in your application.
+
+> [!NOTE]
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
  ]]></format>
         </remarks>
@@ -5440,10 +5520,13 @@ Duplication of the socket reference failed.</exception>
  The <xref:System.Net.Sockets.Socket.EndReceive*> method will block until data is available. If you are using a connectionless protocol, <xref:System.Net.Sockets.Socket.EndReceive*> will read the first enqueued datagram available in the incoming network buffer. If you are using a connection-oriented protocol, the <xref:System.Net.Sockets.Socket.EndReceive*> method will read as much data as is available up to the number of bytes you specified in the `size` parameter of the <xref:System.Net.Sockets.Socket.BeginReceive*> method. If the remote host shuts down the <xref:System.Net.Sockets.Socket> connection with the <xref:System.Net.Sockets.Socket.Shutdown*> method, and all available data has been received, the <xref:System.Net.Sockets.Socket.EndReceive*> method will complete immediately and return zero bytes.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> This member outputs trace information when you enable network tracing in your application.
+
+> [!NOTE]
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
  ]]></format>
         </remarks>
@@ -5522,7 +5605,10 @@ Duplication of the socket reference failed.</exception>
  The <xref:System.Net.Sockets.Socket.EndReceiveFrom*> method will block until data is available. If you are using a connectionless protocol, <xref:System.Net.Sockets.Socket.EndReceiveFrom*> will read the first enqueued datagram available in the incoming network buffer. If you are using a connection-oriented protocol, the <xref:System.Net.Sockets.Socket.EndReceiveFrom*> method will read as much data as is available up to the number of bytes you specified in the `size` parameter of the <xref:System.Net.Sockets.Socket.BeginReceiveFrom*> method. If the remote host shuts down the <xref:System.Net.Sockets.Socket> connection with the <xref:System.Net.Sockets.Socket.Shutdown*> method, and all available data has been received, the <xref:System.Net.Sockets.Socket.EndReceiveFrom*> method will complete immediately and return zero bytes. To obtain the received data, call the <xref:System.IAsyncResult.AsyncState*> method of the <xref:System.IAsyncResult> object, and extract the buffer contained in the resulting state object. To identify the originating host, extract the <xref:System.Net.EndPoint> and cast it to an <xref:System.Net.IPEndPoint>. Use the <xref:System.Net.IPEndPoint.Address*?displayProperty=nameWithType> method to obtain the IP address and the <xref:System.Net.IPEndPoint.Port*?displayProperty=nameWithType> method to obtain the port number.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -5599,7 +5685,10 @@ Duplication of the socket reference failed.</exception>
  Examine `ipPacketInformation` if you need to know if the datagram was sent using a unicast, multicast, or broadcast address.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -5687,13 +5776,16 @@ Duplication of the socket reference failed.</exception>
  There is no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.BeginSend*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+
+> [!NOTE]
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
  ]]></format>
         </remarks>
@@ -5773,13 +5865,16 @@ Duplication of the socket reference failed.</exception>
  There is no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.BeginSend*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
+> All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -5927,7 +6022,7 @@ Duplication of the socket reference failed.</exception>
  If you are using a connectionless protocol, <xref:System.Net.Sockets.Socket.EndSendTo*> will block until the datagram is sent. If you are using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.EndSendTo*> will block until the requested number of bytes are sent. There is no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.BeginSendTo*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
  ]]></format>
         </remarks>
@@ -6171,7 +6266,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
  <xref:System.Net.Sockets.Socket> options determine the behavior of the current <xref:System.Net.Sockets.Socket>. Use this overload to get the <xref:System.Net.Sockets.SocketOptionName.Linger>, <xref:System.Net.Sockets.SocketOptionName.AddMembership>, and <xref:System.Net.Sockets.SocketOptionName.DropMembership><xref:System.Net.Sockets.Socket> options. For the <xref:System.Net.Sockets.SocketOptionName.Linger> option, use <xref:System.Net.Sockets.Socket> for the `optionLevel` parameter. For <xref:System.Net.Sockets.SocketOptionName.AddMembership> and <xref:System.Net.Sockets.SocketOptionName.DropMembership>, use <xref:System.Net.Sockets.SocketOptionLevel.IP>. If you want to set the value of any of the options listed above, use the <xref:System.Net.Sockets.Socket.SetSocketOption*> method.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -6325,7 +6420,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
  The `optionLength` parameter sets the maximum size of the returned byte array. If the option value requires fewer bytes, the array will contain only that many bytes. If the option value requires more bytes, <xref:System.Net.Sockets.Socket.GetSocketOption*> will throw a <xref:System.Net.Sockets.SocketException>. Use this overload for any sockets that are represented by Boolean values or integers.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -6456,7 +6551,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
  The <xref:System.Net.Sockets.Socket.IOControl*> method provides low-level access to the operating system <xref:System.Net.Sockets.Socket> underlying the current instance of the <xref:System.Net.Sockets.Socket> class. For more information, see the [WSAIoctl](/windows/win32/api/winsock2/nf-winsock2-wsaioctl) documentation.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -6528,7 +6623,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
  This method provides low-level access to the operating system <xref:System.Net.Sockets.Socket> underlying the current instance of the <xref:System.Net.Sockets.Socket> class. For more, see the [WSAIoctl](/windows/win32/api/winsock2/nf-winsock2-wsaioctl) documentation.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -6774,10 +6869,10 @@ The maximum length of the pending connections queue is determined automatically.
  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error. Use <xref:System.Net.Sockets.Socket.Accept*> or <xref:System.Net.Sockets.Socket.BeginAccept*> to accept a connection from the queue.
 
 > [!NOTE]
->  You must call the <xref:System.Net.Sockets.Socket.Bind*> method before calling <xref:System.Net.Sockets.Socket.Listen*>, or <xref:System.Net.Sockets.Socket.Listen*> will throw a <xref:System.Net.Sockets.SocketException>.
+> You must call the <xref:System.Net.Sockets.Socket.Bind*> method before calling <xref:System.Net.Sockets.Socket.Listen*>, or <xref:System.Net.Sockets.Socket.Listen*> will throw a <xref:System.Net.Sockets.SocketException>.
 
 > [!NOTE]
->  The backlog parameter is limited to different values depending on the Operating System. You may specify a higher value, but the backlog will be limited based on the Operating System.
+> The backlog parameter is limited to different values depending on the Operating System. You may specify a higher value, but the backlog will be limited based on the Operating System.
 
 
 
@@ -6852,7 +6947,7 @@ The maximum length of the pending connections queue is determined automatically.
  The <xref:System.Net.Sockets.Socket.LocalEndPoint> property is usually set after you make a call to the <xref:System.Net.Sockets.Socket.Bind*> method. If you allow the system to assign your socket's local IP address and port number, the <xref:System.Net.Sockets.Socket.LocalEndPoint> property will be set after the first I/O operation. For connection-oriented protocols, the first I/O operation would be a call to the <xref:System.Net.Sockets.Socket.Connect*> or <xref:System.Net.Sockets.Socket.Accept*> method. For connectionless protocols, the first I/O operation would be any of the send or receive calls.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -7180,10 +7275,10 @@ The maximum length of the pending connections queue is determined automatically.
  The <xref:System.Net.Sockets.Socket.Poll*> method checks the state of the <xref:System.Net.Sockets.Socket>. Specify <xref:System.Net.Sockets.SelectMode.SelectRead?displayProperty=nameWithType> for the `selectMode` parameter to determine if the <xref:System.Net.Sockets.Socket> is readable. Specify <xref:System.Net.Sockets.SelectMode.SelectWrite?displayProperty=nameWithType> to determine if the <xref:System.Net.Sockets.Socket> is writable. Use <xref:System.Net.Sockets.SelectMode.SelectError?displayProperty=nameWithType> to detect an error condition. <xref:System.Net.Sockets.Socket.Poll*> will block execution until the specified time period, measured in `microseconds`, elapses or data becomes available. Set the `microSeconds` parameter to a negative integer if you would like to wait indefinitely for a response. If you want to check the status of multiple sockets, you might prefer to use the <xref:System.Net.Sockets.Socket.Select*> method.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  This method cannot detect certain kinds of connection problems, such as a broken network cable, or that the remote host was shut down ungracefully. You must attempt to send or receive data to detect these kinds of errors.
+> This method cannot detect certain kinds of connection problems, such as a broken network cable, or that the remote host was shut down ungracefully. You must attempt to send or receive data to detect these kinds of errors.
 
 ## Examples
  The following code example creates a socket, connects to a server, and uses <xref:System.Net.Sockets.Socket.Poll*> to check the status of the socket.
@@ -7368,7 +7463,7 @@ The maximum length of the pending connections queue is determined automatically.
  If you are using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.Net.Sockets.Socket.Receive*> will read the first queued datagram from the destination address you specify in the <xref:System.Net.Sockets.Socket.Connect*> method. If the datagram you receive is larger than the size of the `buffer` parameter, `buffer` gets filled with the first part of the message, the excess data is lost and a <xref:System.Net.Sockets.SocketException> is thrown.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -7459,7 +7554,7 @@ The maximum length of the pending connections queue is determined automatically.
  If you are using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.Net.Sockets.Socket.Receive*> will read the first enqueued datagram from the destination address you specify in the <xref:System.Net.Sockets.Socket.Connect*> method. If the datagram you receive is larger than the size of the `buffers` parameter, `buffers` gets filled with the first part of the message, the excess data is lost and a <xref:System.Net.Sockets.SocketException> is thrown.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
  ]]></format>
         </remarks>
@@ -7597,7 +7692,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  If you are using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.Net.Sockets.Socket.Receive*> will read the first enqueued datagram from the destination address you specify in the <xref:System.Net.Sockets.Socket.Connect*> method. If the datagram you receive is larger than the size of the `buffer` parameter, `buffer` gets filled with the first part of the message, the excess data is lost and a <xref:System.Net.Sockets.SocketException> is thrown.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -7690,7 +7785,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  If you are using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.Net.Sockets.Socket.Receive*> will read the first enqueued datagram from the destination address you specify in the <xref:System.Net.Sockets.Socket.Connect*> method. If the datagram you receive is larger than the size of the `buffers` parameter, `buffers` gets filled with the first part of the message, the excess data is lost and a <xref:System.Net.Sockets.SocketException> is thrown.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -7849,7 +7944,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  If you are using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.Net.Sockets.Socket.Receive*> will read the first queued datagram from the destination address you specify in the <xref:System.Net.Sockets.Socket.Connect*> method. If the datagram you receive is larger than the size of the `buffer` parameter, `buffer` gets filled with the first part of the message, the excess data is lost and a <xref:System.Net.Sockets.SocketException> is thrown.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -7946,7 +8041,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  If you are using a connectionless <xref:System.Net.Sockets.Socket>,<xref:System.Net.Sockets.Socket.Receive*> will read the first queued datagram from the destination address you specify in the <xref:System.Net.Sockets.Socket.Connect*> method. If the datagram you receive is larger than the size of the `buffers` parameter, `buffers` gets filled with the first part of the message, the excess data is lost and a <xref:System.Net.Sockets.SocketException> is thrown.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
  ]]></format>
         </remarks>
@@ -8021,7 +8116,7 @@ If you're using a connection-oriented <xref:System.Net.Sockets.Socket>, the <xre
 If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.Net.Sockets.Socket.Receive*> will read the first queued datagram from the destination address you specify in the <xref:System.Net.Sockets.Socket.Connect*> method. If the datagram you receive is larger than the size of the `buffer` parameter, `buffer` gets filled with the first part of the message, the excess data is lost and a <xref:System.Net.Sockets.SocketException> is thrown.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
  ]]></format>
         </remarks>
@@ -8100,7 +8195,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  If you are using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.Net.Sockets.Socket.Receive*> will read the first queued datagram from the destination address you specify in the <xref:System.Net.Sockets.Socket.Connect*> method. If the datagram you receive is larger than the size of the `buffer` parameter, `buffer` gets filled with the first part of the message, the excess data is lost and a <xref:System.Net.Sockets.SocketException> is thrown.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -8699,7 +8794,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  This overload only requires you to provide a receive `buffer`, and an <xref:System.Net.EndPoint> that represents the remote host. The buffer offset defaults to 0. The size defaults to the length of the `buffer` parameter and the `socketFlags` value defaults to <xref:System.Net.Sockets.SocketFlags.None>.
 
 > [!NOTE]
->  Before calling <xref:System.Net.Sockets.Socket.ReceiveFrom*>, you must explicitly bind the <xref:System.Net.Sockets.Socket> to a local endpoint using the <xref:System.Net.Sockets.Socket.Bind*> method. If you do not, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will throw a <xref:System.Net.Sockets.SocketException>.
+> Before calling <xref:System.Net.Sockets.Socket.ReceiveFrom*>, you must explicitly bind the <xref:System.Net.Sockets.Socket> to a local endpoint using the <xref:System.Net.Sockets.Socket.Bind*> method. If you do not, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will throw a <xref:System.Net.Sockets.SocketException>.
 
  With connectionless protocols, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will read the first enqueued datagram received into the local network buffer. If the datagram you receive is larger than the size of `buffer`, the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method will fill `buffer` with as much of the message as is possible, and throw a <xref:System.Net.Sockets.SocketException>. If you are using an unreliable protocol, the excess data will be lost. If you are using a reliable protocol, the excess data will be retained by the service provider and you can retrieve it by calling the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method with a large enough buffer.
 
@@ -8710,10 +8805,10 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  With connection-oriented sockets, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will read as much data as is available up to the size of `buffer`. If the remote host shuts down the <xref:System.Net.Sockets.Socket> connection with the <xref:System.Net.Sockets.Socket.Shutdown*> method, and all available data has been received, the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method will complete immediately and return zero bytes.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
+> The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
 
 
 
@@ -8844,7 +8939,7 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  This overload only requires you to provide a receive buffer, the necessary <xref:System.Net.Sockets.SocketFlags>, and an <xref:System.Net.EndPoint> that represents the remote host. The offset defaults to 0 and the size defaults to the length of the buffer parameter.
 
 > [!NOTE]
->  Before calling <xref:System.Net.Sockets.Socket.ReceiveFrom*>, you must explicitly bind the <xref:System.Net.Sockets.Socket> to a local endpoint using the <xref:System.Net.Sockets.Socket.Bind*> method. If you do not, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will throw a <xref:System.Net.Sockets.SocketException>.
+> Before calling <xref:System.Net.Sockets.Socket.ReceiveFrom*>, you must explicitly bind the <xref:System.Net.Sockets.Socket> to a local endpoint using the <xref:System.Net.Sockets.Socket.Bind*> method. If you do not, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will throw a <xref:System.Net.Sockets.SocketException>.
 
  With connectionless protocols, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will read the first enqueued datagram received into the local network buffer. If the datagram you receive is larger than the size of `buffer`, the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method will fill `buffer` with as much of the message as is possible, and throw a <xref:System.Net.Sockets.SocketException>. If you are using an unreliable protocol, the excess data will be lost. If you are using a reliable protocol, the excess data will be retained by the service provider and you can retrieve it by calling the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method with a large enough buffer.
 
@@ -8855,10 +8950,10 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  With connection-oriented sockets, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will read as much data as is available up to the size of `buffer`. If the remote host shuts down the <xref:System.Net.Sockets.Socket> connection with the <xref:System.Net.Sockets.Socket.Shutdown*> method, and all available data has been Received, the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method will complete immediately and return zero bytes.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
+> The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
 
 
 
@@ -9048,10 +9143,10 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  With connection-oriented sockets, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will read as much data as is available up to the number of bytes specified by the `size` parameter. If the remote host shuts down the <xref:System.Net.Sockets.Socket> connection with the <xref:System.Net.Sockets.Socket.Shutdown*> method, and all available data has been received, the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method will complete immediately and return zero bytes.
 
 > [!NOTE]
->  Before calling <xref:System.Net.Sockets.Socket.ReceiveFrom*>, you must explicitly bind the <xref:System.Net.Sockets.Socket> to a local endpoint using the <xref:System.Net.Sockets.Socket.Bind*> method. If you do not, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> Before calling <xref:System.Net.Sockets.Socket.ReceiveFrom*>, you must explicitly bind the <xref:System.Net.Sockets.Socket> to a local endpoint using the <xref:System.Net.Sockets.Socket.Bind*> method. If you do not, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
+> The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
 
 
 
@@ -9162,10 +9257,10 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  With connection-oriented sockets, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will read as much data as is available up to the amount of bytes specified by the `size` parameter. If the remote host shuts down the <xref:System.Net.Sockets.Socket> connection with the <xref:System.Net.Sockets.Socket.Shutdown*> method, and all available data has been Received, the <xref:System.Net.Sockets.Socket.ReceiveFrom*> method will complete immediately and return zero bytes.
 
 > [!NOTE]
->  Before calling <xref:System.Net.Sockets.Socket.ReceiveFrom*>, you must explicitly bind the <xref:System.Net.Sockets.Socket> to a local endpoint using the <xref:System.Net.Sockets.Socket.Bind*> method. If you do not, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> Before calling <xref:System.Net.Sockets.Socket.ReceiveFrom*>, you must explicitly bind the <xref:System.Net.Sockets.Socket> to a local endpoint using the <xref:System.Net.Sockets.Socket.Bind*> method. If you do not, <xref:System.Net.Sockets.Socket.ReceiveFrom*> will throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
+> The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
 
 
 
@@ -9668,7 +9763,7 @@ You must call the Bind method before performing this operation.</exception>
  An application can examine the `ipPacketInformation` parameter if it needs to know if the datagram was sent using a unicast, multicast, or broadcast address.
 
 > [!NOTE]
->  The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
+> The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
 
  ]]></format>
         </remarks>
@@ -10229,13 +10324,13 @@ You must call the Bind method before performing this operation.</exception>
  If you have made a non-blocking call to <xref:System.Net.Sockets.Socket.Connect*>, the `checkerror` parameter identifies sockets that have not connected successfully.
 
 > [!NOTE]
->  Use the <xref:System.Net.Sockets.Socket.Poll*> method if you only want to determine the status of a single <xref:System.Net.Sockets.Socket>.
+> Use the <xref:System.Net.Sockets.Socket.Poll*> method if you only want to determine the status of a single <xref:System.Net.Sockets.Socket>.
 
 > [!NOTE]
->  This method cannot detect certain kinds of connection problems, such as a broken network cable, or that the remote host was shut down ungracefully. You must attempt to send or receive data to detect these kinds of errors.
+> This method cannot detect certain kinds of connection problems, such as a broken network cable, or that the remote host was shut down ungracefully. You must attempt to send or receive data to detect these kinds of errors.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 
 
@@ -10368,12 +10463,13 @@ You must call the Bind method before performing this operation.</exception>
  If you are using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.Send*> will block until all of the bytes in the buffer are sent, unless a time-out was set by using <xref:System.Net.Sockets.Socket.SendTimeout*?displayProperty=nameWithType>. If the time-out value was exceeded, the <xref:System.Net.Sockets.Socket.Send*> call will throw a <xref:System.Net.Sockets.SocketException>. In nonblocking mode, <xref:System.Net.Sockets.Socket.Send*> may complete successfully even if it sends less than the number of bytes in the buffer. It is your application's responsibility to keep track of the number of bytes sent and to retry the operation until the application sends the bytes in the buffer. There is also no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.Send*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates sending data on a connected <xref:System.Net.Sockets.Socket>.
@@ -10458,10 +10554,13 @@ You must call the Bind method before performing this operation.</exception>
  If you are using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.Send*> will block until all of the bytes in the buffer are sent, unless a time-out was set by using <xref:System.Net.Sockets.Socket.SendTimeout*?displayProperty=nameWithType>. If the time-out value was exceeded, the <xref:System.Net.Sockets.Socket.Send*> call will throw a <xref:System.Net.Sockets.SocketException>. In nonblocking mode, <xref:System.Net.Sockets.Socket.Send*> may complete successfully even if it sends less than the number of bytes in the buffer. It is your application's responsibility to keep track of the number of bytes sent and to retry the operation until the application sends the bytes in the buffer. There is also no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.Send*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -10600,12 +10699,13 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  If you are using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.Send*> will block until all of the bytes in the buffer are sent, unless a time-out was set by using <xref:System.Net.Sockets.Socket.SendTimeout*?displayProperty=nameWithType>. If the time-out value was exceeded, the <xref:System.Net.Sockets.Socket.Send*> call will throw a <xref:System.Net.Sockets.SocketException>. In nonblocking mode, <xref:System.Net.Sockets.Socket.Send*> may complete successfully even if it sends less than the number of bytes in the buffer. It is your application's responsibility to keep track of the number of bytes sent and to retry the operation until the application sends the requested number of bytes. There is also no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.Send*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->  You must ensure that the size of your buffer does not exceed the maximum packet size of the underlying service provider. If it does, the datagram will not be sent and <xref:System.Net.Sockets.Socket.Send*> will throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> You must ensure that the size of your buffer does not exceed the maximum packet size of the underlying service provider. If it does, the datagram will not be sent and <xref:System.Net.Sockets.Socket.Send*> will throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates sending data on a connected <xref:System.Net.Sockets.Socket>.
@@ -10690,10 +10790,13 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  If you are using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.Send*> will block until all of the bytes in the buffer are sent, unless a time-out was set by using <xref:System.Net.Sockets.Socket.SendTimeout*?displayProperty=nameWithType>. If the time-out value was exceeded, the <xref:System.Net.Sockets.Socket.Send*> call will throw a <xref:System.Net.Sockets.SocketException>. In non-blocking mode, <xref:System.Net.Sockets.Socket.Send*> may complete successfully even if it sends less than the number of bytes in the buffer. It is your application's responsibility to keep track of the number of bytes sent and to retry the operation until the application sends the bytes in the buffer. There is also no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.Send*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -10918,10 +11021,13 @@ The following code example sends the data found in buffer, and specifies <xref:S
  If you are using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.Send*> will block until all of the bytes in the buffer are sent, unless a time-out was set by using <xref:System.Net.Sockets.Socket.SendTimeout*?displayProperty=nameWithType>. If the time-out value was exceeded, the <xref:System.Net.Sockets.Socket.Send*> call will throw a <xref:System.Net.Sockets.SocketException>. In non-blocking mode, <xref:System.Net.Sockets.Socket.Send*> may complete successfully even if it sends less than the number of bytes in the buffer. It is your application's responsibility to keep track of the number of bytes sent and to retry the operation until the application sends the bytes in the buffer. There is also no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.Send*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>
@@ -11069,12 +11175,13 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  If you are using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.Send*> will block until the requested number of bytes are sent, unless a time-out was set by using <xref:System.Net.Sockets.Socket.SendTimeout*?displayProperty=nameWithType>. If the time-out value was exceeded, the <xref:System.Net.Sockets.Socket.Send*> call will throw a <xref:System.Net.Sockets.SocketException>. In nonblocking mode, <xref:System.Net.Sockets.Socket.Send*> may complete successfully even if it sends less than the number of bytes you request. It is your application's responsibility to keep track of the number of bytes sent and to retry the operation until the application sends the requested number of bytes. There is also no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.Send*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example specifies the data buffer, an offset, a size, and <xref:System.Net.Sockets.SocketFlags> for sending data to a connected <xref:System.Net.Sockets.Socket>.
@@ -11181,12 +11288,13 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  If you are using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.Send*> will block until the requested number of bytes are sent, unless a time-out was set by using <xref:System.Net.Sockets.Socket.SendTimeout*?displayProperty=nameWithType>. If the time-out value was exceeded, the <xref:System.Net.Sockets.Socket.Send*> call will throw a <xref:System.Net.Sockets.SocketException>. In nonblocking mode, <xref:System.Net.Sockets.Socket.Send*> may complete successfully even if it sends less than the number of bytes you request. It is your application's responsibility to keep track of the number of bytes sent and to retry the operation until the application sends the requested number of bytes. There is also no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.Send*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
+> The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example specifies the data buffer, an offset, a size, and <xref:System.Net.Sockets.SocketFlags> for sending data to a connected <xref:System.Net.Sockets.Socket>.
@@ -11685,7 +11793,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  If you are using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.SendFile*> blocks until the file is sent. In nonblocking mode, <xref:System.Net.Sockets.Socket.SendFile*> may complete successfully before the entire file has been sent. There is no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.SendFile*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 ## Examples
  The following code example creates and connects a socket and then sends a file to the remote host. The file "test.txt" is located in the root directory of the local machine.
@@ -11766,7 +11874,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  If you are using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.SendFile*> blocks until the entire file is sent. In nonblocking mode, <xref:System.Net.Sockets.Socket.SendFile*> may complete successfully before the entire file has been sent. There is no guarantee that the data you send will appear on the network immediately. To increase network efficiency, the underlying system may delay transmission until a significant amount of outgoing data is collected. A successful completion of the <xref:System.Net.Sockets.Socket.SendFile*> method means that the underlying system has had room to buffer your data for a network send.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 ## Examples
  The following code example creates and connects a socket. The file "test.txt" is located in the root directory of the local machine. In this example, we create a prebuffer and postbuffer of data and send them to the remote host with the file. The default <xref:System.Net.Sockets.TransmitFileOptions> are used.
@@ -12145,7 +12253,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  If you are using a connectionless protocol in blocking mode, <xref:System.Net.Sockets.Socket.SendTo*> will block until the datagram is sent. If you want to send data to a broadcast address, you must first call the <xref:System.Net.Sockets.Socket.SetSocketOption*> method and set the socket option to <xref:System.Net.Sockets.SocketOptionName.Broadcast?displayProperty=nameWithType>. You must also be sure that the number of bytes sent does not exceed the maximum packet size of the underlying service provider. If it does, the datagram will not be sent and <xref:System.Net.Sockets.Socket.SendTo*> will throw a <xref:System.Net.Sockets.SocketException>.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 ## Examples
  The following code example sends a connectionless datagram to the specified remote host.
@@ -12280,7 +12388,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  If you are using a connectionless protocol in blocking mode, <xref:System.Net.Sockets.Socket.SendTo*> will block until the datagram is sent. If you want to send data to a broadcast address, you must first call the <xref:System.Net.Sockets.Socket.SetSocketOption*> method and set the socket option to <xref:System.Net.Sockets.SocketOptionName.Broadcast?displayProperty=nameWithType>. You must also be sure that the number of bytes sent does not exceed the maximum packet size of the underlying service provider. If it does, the datagram will not be sent and <xref:System.Net.Sockets.Socket.SendTo*> will throw a <xref:System.Net.Sockets.SocketException>.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 ## Examples
  The following code example sends a connectionless datagram to the specified remote host. <xref:System.Net.Sockets.SocketFlags> are passed to the <xref:System.Net.Sockets.Socket.SendTo*> method.
@@ -12465,7 +12573,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  If you are using a connectionless protocol in blocking mode, <xref:System.Net.Sockets.Socket.SendTo*> will block until the datagram is sent. If you want to send data to a broadcast address, you must first call the <xref:System.Net.Sockets.Socket.SetSocketOption*> method and set the socket option to <xref:System.Net.Sockets.SocketOptionName.Broadcast?displayProperty=nameWithType>. You must also be sure that the number of bytes sent does not exceed the maximum packet size of the underlying service provider. If it does, the datagram will not be sent and <xref:System.Net.Sockets.Socket.SendTo*> will throw a <xref:System.Net.Sockets.SocketException>.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 ## Examples
  The following code example sends a connectionless datagram to the specified remote host. The size and <xref:System.Net.Sockets.SocketFlags> are passed to the <xref:System.Net.Sockets.Socket.SendTo*> method.
@@ -12559,7 +12667,7 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
  If you are using a connectionless protocol in blocking mode, <xref:System.Net.Sockets.Socket.SendTo*> will block until the datagram is sent. If you want to send data to a broadcast address, you must first call the <xref:System.Net.Sockets.Socket.SetSocketOption*> method and set the socket option to <xref:System.Net.Sockets.SocketOptionName.Broadcast?displayProperty=nameWithType>. You must also be sure that the size does not exceed the maximum packet size of the underlying service provider. If it does, the datagram will not be sent and <xref:System.Net.Sockets.Socket.SendTo*> will throw a <xref:System.Net.Sockets.SocketException>.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 ## Examples
  The following code example sends a connectionless datagram to the specified remote host. The offset, size, and <xref:System.Net.Sockets.SocketFlags> are passed to the <xref:System.Net.Sockets.Socket.SendTo*> method.
@@ -13161,7 +13269,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
  For more information on these options, refer to the <xref:System.Net.Sockets.SocketOptionName> enumeration.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 ## Examples
  The following code example opens a socket and enables the `DontLinger` and the `OutOfBandInline` socket options.
@@ -13228,7 +13336,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
  <xref:System.Net.Sockets.Socket> options determine the behavior of the current <xref:System.Net.Sockets.Socket>. Use this overload to set those <xref:System.Net.Sockets.Socket> options that require a byte array as an option value.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 ## Examples
  The following code example sets the <xref:System.Net.Sockets.LingerOption> and <xref:System.Net.Sockets.Socket.Send*> time-out values.
@@ -13365,7 +13473,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
  For more information about these options, refer to the <xref:System.Net.Sockets.SocketOptionName> enumeration.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 ## Examples
  The following code example sets the <xref:System.Net.Sockets.LingerOption> and <xref:System.Net.Sockets.Socket.Send*> time-out values.
@@ -13436,7 +13544,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
  <xref:System.Net.Sockets.Socket> options determine the behavior of the current <xref:System.Net.Sockets.Socket>. Use this overload to set the <xref:System.Net.Sockets.SocketOptionName.Linger>, <xref:System.Net.Sockets.SocketOptionName.AddMembership>, and <xref:System.Net.Sockets.SocketOptionName.DropMembership><xref:System.Net.Sockets.Socket> options. For the <xref:System.Net.Sockets.SocketOptionName.Linger> option, use <xref:System.Net.Sockets.Socket> for the `optionLevel` parameter. For <xref:System.Net.Sockets.SocketOptionName.AddMembership> and <xref:System.Net.Sockets.SocketOptionName.DropMembership>, use <xref:System.Net.Sockets.SocketOptionLevel.IP>. If you want to get the current value of any of the options listed above, use the <xref:System.Net.Sockets.Socket.GetSocketOption*> method.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 ## Examples
  The following code example sets the <xref:System.Net.Sockets.LingerOption> and <xref:System.Net.Sockets.Socket.Send*> time out values.
@@ -13527,7 +13635,7 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
  Setting `how` to <xref:System.Net.Sockets.SocketShutdown.Both> disables both sends and receives as described above.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException> when calling the <xref:System.Net.Sockets.Socket.Shutdown*> method, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException> when calling the <xref:System.Net.Sockets.Socket.Shutdown*> method, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 ## Examples
  The following code example uses <xref:System.Net.Sockets.Socket.Shutdown*> to disable the <xref:System.Net.Sockets.Socket>.

--- a/xml/System.Net.Sockets/Socket.xml
+++ b/xml/System.Net.Sockets/Socket.xml
@@ -82,14 +82,6 @@ implementation, this may lead to unintended data interleaving for large or multi
     <altmember cref="N:System.Net.Cache" />
     <altmember cref="N:System.Net.Security" />
     <altmember cref="T:System.Net.Sockets.SocketAsyncEventArgs" />
-    <related type="Article" href="/dotnet/framework/network-programming/">Network Programming in the .NET Framework</related>
-    <related type="Article" href="/dotnet/framework/network-programming/best-practices-for-system-net-classes">Best Practices for System.Net Classes</related>
-    <related type="Article" href="/dotnet/framework/network-programming/cache-management-for-network-applications">Cache Management for Network Applications</related>
-    <related type="Article" href="/dotnet/framework/network-programming/internet-protocol-version-6">Internet Protocol Version 6</related>
-    <related type="Article" href="/dotnet/framework/network-programming/network-programming-samples">Network Programming Samples</related>
-    <related type="Article" href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</related>
-    <related type="Article" href="/dotnet/framework/network-programming/security-in-network-programming">Security in Network Programming</related>
-    <related type="Article" href="/dotnet/framework/network-programming/socket-performance-enhancements-in-version-3-5">Socket Performance Enhancements in Version 3.5</related>
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
@@ -250,9 +242,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 > If this constructor throws a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">The combination of  <paramref name="socketType" /> and <paramref name="protocolType" /> results in an invalid socket.</exception>
@@ -310,11 +299,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 >  If this constructor throws a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
 
 ## Examples
  The following code example demonstrates how to create an instance of the <xref:System.Net.Sockets.Socket> class.
@@ -384,11 +368,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 >  Before calling the <xref:System.Net.Sockets.Socket.Accept*> method, you must first call the <xref:System.Net.Sockets.Socket.Listen*> method to listen for and queue incoming connection requests.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
 
 ## Examples
  The following code example accepts a simple <xref:System.Net.Sockets.Socket> connection.
@@ -776,11 +755,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  If the remote host shuts down or closes the connection, <xref:System.Net.Sockets.Socket.Available*> can throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
 ## Examples
  The following code example compares the results of calling IOControl with FIONREAD and the Available property.
 
@@ -879,9 +853,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
@@ -892,14 +863,11 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  -or-
 
  The accepted socket is bound.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="M:System.Net.Sockets.Socket.EndAccept(System.IAsyncResult)" />
         <altmember cref="T:System.Net.Sockets.Socket" />
         <altmember cref="P:System.Net.Sockets.Socket.RemoteEndPoint" />
-        <related type="Article" href="/dotnet/framework/network-programming/asynchronous-client-socket-example">Asynchronous Client Socket Example</related>
-        <related type="Article" href="/dotnet/framework/network-programming/asynchronous-server-socket-example">Asynchronous Server Socket Example</related>
       </Docs>
     </Member>
     <Member MemberName="BeginAccept">
@@ -977,9 +945,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
@@ -992,14 +957,11 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  The accepted socket is bound.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="receiveSize" /> is less than 0.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="M:System.Net.Sockets.Socket.EndAccept(System.IAsyncResult)" />
         <altmember cref="T:System.Net.Sockets.Socket" />
         <altmember cref="P:System.Net.Sockets.Socket.RemoteEndPoint" />
-        <related type="Article" href="/dotnet/framework/network-programming/asynchronous-client-socket-example">Asynchronous Client Socket Example</related>
-        <related type="Article" href="/dotnet/framework/network-programming/asynchronous-server-socket-example">Asynchronous Server Socket Example</related>
       </Docs>
     </Member>
     <Member MemberName="BeginAccept">
@@ -1079,9 +1041,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
@@ -1094,14 +1053,11 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  The accepted socket is bound.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="receiveSize" /> is less than 0.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="M:System.Net.Sockets.Socket.EndAccept(System.IAsyncResult)" />
         <altmember cref="T:System.Net.Sockets.Socket" />
         <altmember cref="P:System.Net.Sockets.Socket.RemoteEndPoint" />
-        <related type="Article" href="/dotnet/framework/network-programming/asynchronous-client-socket-example">Asynchronous Client Socket Example</related>
-        <related type="Article" href="/dotnet/framework/network-programming/asynchronous-server-socket-example">Asynchronous Server Socket Example</related>
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginConnect">
@@ -1198,16 +1154,12 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="remoteEP" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have permission for the requested operation.</exception>
         <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Net.Sockets.Socket" /> has been placed in a listening state by calling <see cref="M:System.Net.Sockets.Socket.Listen(System.Int32)" />, or an asynchronous operation is already in progress.</exception>
@@ -1309,16 +1261,12 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  If this socket has previously been disconnected, then <xref:System.Net.Sockets.Socket.BeginConnect*> must be called on a thread that will not exit until the operation is complete. This is a limitation of the underlying provider.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="address" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.NotSupportedException">The <see cref="T:System.Net.Sockets.Socket" /> is not in the socket family.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">The port number is not valid.</exception>
@@ -1422,16 +1370,12 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  If this socket has previously been disconnected, then <xref:System.Net.Sockets.Socket.BeginConnect*> must be called on a thread that will not exit until the operation is complete. This is a limitation of the underlying provider.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="addresses" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.NotSupportedException">This method is valid for sockets that use <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> or <see cref="F:System.Net.Sockets.AddressFamily.InterNetworkV6" />.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">The port number is not valid.</exception>
@@ -1535,9 +1479,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  If this socket has previously been disconnected, then <xref:System.Net.Sockets.Socket.BeginConnect*> must be called on a thread that will not exit until the operation is complete. This is a limitation of the underlying provider.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
@@ -1627,13 +1568,9 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginReceive">
@@ -1731,16 +1668,12 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  `state` is an instantiation of a user-defined class.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffers" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException">
           <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.EndAccept(System.IAsyncResult)" />
@@ -1833,16 +1766,12 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  `state` is an instantiation of a user-defined class.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffers" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException">
           <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.EndAccept(System.IAsyncResult)" />
@@ -1945,16 +1874,12 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  `state` is an instantiation of a user-defined class.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffer" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException">
           <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
@@ -2065,16 +1990,12 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  `state` is an instantiation of a user-defined class.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffer" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException">
           <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
@@ -2197,9 +2118,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
@@ -2210,7 +2128,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  -or-
 
  <paramref name="remoteEP" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="offset" /> is less than 0.
 
@@ -2323,9 +2240,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
@@ -2336,7 +2250,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  -or-
 
  <paramref name="remoteEP" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="offset" /> is less than 0.
 
@@ -2454,9 +2367,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
@@ -2465,7 +2375,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
           <paramref name="buffers" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="buffers" /> is empty.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket. See remarks section below.</exception>
         <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="T:System.AsyncCallback" />
@@ -2561,9 +2470,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
@@ -2572,7 +2478,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
           <paramref name="buffers" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="buffers" /> is empty.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket. See remarks section below.</exception>
         <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.Connect(System.Net.EndPoint)" />
         <altmember cref="T:System.AsyncCallback" />
@@ -2678,16 +2583,12 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffer" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket. See remarks section below.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="offset" /> is less than 0.
 
@@ -2801,16 +2702,12 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="buffer" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket. See remarks section below.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="offset" /> is less than 0.
 
@@ -2917,9 +2814,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
@@ -2927,7 +2821,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
         <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
         <exception cref="T:System.NotSupportedException">The socket is not connected to a remote host.</exception>
         <exception cref="T:System.IO.FileNotFoundException">The file <paramref name="fileName" /> was not found.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket. See remarks section below.</exception>
       </Docs>
     </Member>
     <Member MemberName="BeginSendFile">
@@ -3010,15 +2903,11 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  If you receive a <xref:System.Net.Sockets.SocketException> exception, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
         </remarks>
         <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> object has been closed.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket. See remarks section below.</exception>
         <exception cref="T:System.NotSupportedException">The operating system is not Windows NT or later.
 
 -or-
@@ -3120,9 +3009,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The execution context (the security context, the impersonated user, and the calling context) is cached for the asynchronous <xref:System.Net.Sockets.Socket> methods. After the first use of a particular context (a specific asynchronous <xref:System.Net.Sockets.Socket> method, a specific <xref:System.Net.Sockets.Socket> instance, and a specific callback), subsequent uses of that context will see a performance improvement.
 
  ]]></format>
@@ -3133,7 +3019,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
  -or-
 
  <paramref name="remoteEP" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.Net.Sockets.SocketException">.NET Framework only: An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="offset" /> is less than 0.
 
@@ -3223,9 +3108,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException> when calling the <xref:System.Net.Sockets.Socket.Bind*> method, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 
 
 ## Examples
@@ -3299,9 +3181,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
  ]]></format>
         </remarks>
@@ -3426,9 +3305,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 >  To set the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to `false`, create a <xref:System.Net.Sockets.LingerOption>, set the enabled property to `true`, and set the <xref:System.Net.Sockets.LingerOption.LingerTime> property to the desired time out period. Use this <xref:System.Net.Sockets.LingerOption> along with the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to call the <xref:System.Net.Sockets.Socket.SetSocketOption*> method.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 
 
 ## Examples
@@ -3496,9 +3372,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 >  To set the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to `false`, create a <xref:System.Net.Sockets.LingerOption>, set the enabled property to `true`, and set the <xref:System.Net.Sockets.LingerOption.LingerTime> property to the desired time-out period. Use this <xref:System.Net.Sockets.LingerOption> along with the <xref:System.Net.Sockets.SocketOptionName.DontLinger> socket option to call the <xref:System.Net.Sockets.Socket.SetSocketOption*> method.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -3582,9 +3455,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 >  If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -3672,9 +3542,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 >  If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 ## Examples
  The following code example connects to a remote endpoint and then verifies the connection.
 
@@ -3751,9 +3618,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 >  If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 ## Examples
  The following code example connects to a remote endpoint and then verifies the connection.
@@ -3833,9 +3697,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
 > [!NOTE]
 >  If the socket has been previously disconnected, then you cannot use this method to restore the connection. Use one of the asynchronous <xref:System.Net.Sockets.Socket.BeginConnect*> methods to reconnect. This is a limitation of the underlying provider.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 ## Examples
  The following code example connects to a remote endpoint and then verifies the connection.
@@ -4583,9 +4444,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 
 
 ## Examples
@@ -4816,9 +4674,6 @@ This method populates the <xref:System.Net.Sockets.Socket> instance with data ga
 
  When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.Sockets.Socket> references. This method invokes the `Dispose()` method of each referenced object.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <block subset="none" type="overrides">
@@ -4989,8 +4844,6 @@ The target process should use the <xref:System.Net.Sockets.Socket.%23ctor(System
 
 Do not call the <xref:System.Net.Sockets.Socket.%23ctor(System.Net.Sockets.SocketInformation)> constructor multiple times using the same byte array in the <xref:System.Net.Sockets.SocketInformation> argument in each call. If you do, you'll have multiple managed <xref:System.Net.Sockets.Socket> instances with the same underlying socket, which is strongly discouraged.
 
-On .NET Framework, if the process creating the socket uses asynchronous methods, the process must first set the <xref:System.Net.Sockets.Socket.UseOnlyOverlappedIO> property to `true`. Otherwise, the asynchronous method will bind the socket to an [I/O completion port](/windows/win32/fileio/i-o-completion-ports) of the creating process, which may cause an <xref:System.ArgumentNullException> to be thrown in the target process.
-
 <xref:System.Net.Sockets.Socket.DuplicateAndClose(System.Int32)> has limited support on Windows. Unlike on .NET Framework, the <xref:System.Net.Sockets.Socket.UseOnlyOverlappedIO> property is a NOP, therefore the process creating the socket must never call asynchronous methods on the socket. A call to an asynchronous operation will always bind it to an [I/O completion port](/windows/win32/fileio/i-o-completion-ports) of the creating process, which may cause an <xref:System.ArgumentNullException> to be thrown in the target process.
 
  ]]></format>
@@ -5132,9 +4985,6 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5146,7 +4996,6 @@ Duplication of the socket reference failed.</exception>
 -or-
 
 .NET 7+ only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.InvalidOperationException">
           <see cref="M:System.Net.Sockets.Socket.EndAccept(System.IAsyncResult)" /> method was previously called.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.BeginAccept(System.AsyncCallback,System.Object)" />
@@ -5214,12 +5063,8 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="asyncResult" /> is empty.</exception>
         <exception cref="T:System.ArgumentException">
@@ -5293,12 +5138,8 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="asyncResult" /> is empty.</exception>
         <exception cref="T:System.ArgumentException">
@@ -5366,9 +5207,6 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5382,7 +5220,6 @@ Duplication of the socket reference failed.</exception>
 -or-
 
 .NET 7+ only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.BeginConnect(System.Net.EndPoint,System.AsyncCallback,System.Object)" />
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="P:System.IAsyncResult.AsyncState" />
@@ -5441,12 +5278,8 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="asyncResult" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
@@ -5531,9 +5364,6 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 >  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5547,7 +5377,6 @@ Duplication of the socket reference failed.</exception>
 -or-
 
 .NET 7+ only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.BeginReceive(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.AsyncCallback,System.Object)" />
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="T:System.IAsyncResult" />
@@ -5616,9 +5445,6 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 >  All I/O initiated by a given thread is canceled when that thread exits. A pending asynchronous operation can fail if the thread exits before the operation completes.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5632,7 +5458,6 @@ Duplication of the socket reference failed.</exception>
 -or-
 
 .NET 7+ only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.BeginReceive(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.AsyncCallback,System.Object)" />
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="T:System.IAsyncResult" />
@@ -5699,9 +5524,6 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5715,7 +5537,6 @@ Duplication of the socket reference failed.</exception>
 -or-
 
 .NET 7+ only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="EndReceiveMessageFrom">
@@ -5797,7 +5618,6 @@ Duplication of the socket reference failed.</exception>
 -or-
 
 .NET 7+ only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="EndSend">
@@ -5875,9 +5695,6 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5891,7 +5708,6 @@ Duplication of the socket reference failed.</exception>
 -or-
 
 .NET 7+ only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.BeginSend(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.AsyncCallback,System.Object)" />
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="P:System.IAsyncResult.AsyncState" />
@@ -5965,9 +5781,6 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5981,7 +5794,6 @@ Duplication of the socket reference failed.</exception>
 -or-
 
 .NET 7+ only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.BeginSend(System.Byte[],System.Int32,System.Int32,System.Net.Sockets.SocketFlags,System.AsyncCallback,System.Object)" />
         <altmember cref="T:System.AsyncCallback" />
         <altmember cref="P:System.IAsyncResult.AsyncState" />
@@ -6044,13 +5856,9 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.NotSupportedException">.NET 8+ only: The socket is not connected to a remote host.</exception>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="asyncResult" /> is empty.</exception>
         <exception cref="T:System.ArgumentException">
@@ -6121,9 +5929,6 @@ Duplication of the socket reference failed.</exception>
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -6137,7 +5942,6 @@ Duplication of the socket reference failed.</exception>
 -or-
 
 .NET 7+ only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
-        <exception cref="T:System.ObjectDisposedException">.NET Framework, .NET Core, and .NET 5-6 only: The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
       </Docs>
     </Member>
     <Member MemberName="ExclusiveAddressUse">
@@ -6369,9 +6173,6 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 
 
 ## Examples
@@ -6447,9 +6248,6 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
  <xref:System.Net.Sockets.Socket> options determine the behavior of the current <xref:System.Net.Sockets.Socket>. Upon successful completion of this method, the array specified by the `optionValue` parameter contains the value of the specified <xref:System.Net.Sockets.Socket> option.
 
  When the length of the `optionValue` array is smaller than the number of bytes required to store the value of the specified <xref:System.Net.Sockets.Socket> option, <xref:System.Net.Sockets.Socket.GetSocketOption*> will throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error. Use this overload for any sockets that are represented by Boolean values or integers.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -6528,9 +6326,6 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -6663,9 +6458,6 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 
 
 ## Examples
@@ -6737,9 +6529,6 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -6988,9 +6777,6 @@ The maximum length of the pending connections queue is determined automatically.
 >  You must call the <xref:System.Net.Sockets.Socket.Bind*> method before calling <xref:System.Net.Sockets.Socket.Listen*>, or <xref:System.Net.Sockets.Socket.Listen*> will throw a <xref:System.Net.Sockets.SocketException>.
 
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 >  The backlog parameter is limited to different values depending on the Operating System. You may specify a higher value, but the backlog will be limited based on the Operating System.
 
 
@@ -7067,9 +6853,6 @@ The maximum length of the pending connections queue is determined automatically.
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -7402,9 +7185,6 @@ The maximum length of the pending connections queue is determined automatically.
 > [!NOTE]
 >  This method cannot detect certain kinds of connection problems, such as a broken network cable, or that the remote host was shut down ungracefully. You must attempt to send or receive data to detect these kinds of errors.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 ## Examples
  The following code example creates a socket, connects to a server, and uses <xref:System.Net.Sockets.Socket.Poll*> to check the status of the socket.
 
@@ -7590,9 +7370,6 @@ The maximum length of the pending connections queue is determined automatically.
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 
 
 ## Examples
@@ -7684,8 +7461,6 @@ The maximum length of the pending connections queue is determined automatically.
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
- **Note** This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <altCompliant cref="M:System.Net.Sockets.Socket.Receive(System.Byte[])" />
@@ -7747,8 +7522,6 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
@@ -7825,9 +7598,6 @@ This member outputs trace information when you enable network tracing in your ap
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -7922,9 +7692,6 @@ This member outputs trace information when you enable network tracing in your ap
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 
 
 ## Examples
@@ -8005,8 +7772,6 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 > If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
@@ -8085,9 +7850,6 @@ This member outputs trace information when you enable network tracing in your ap
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -8186,9 +7948,6 @@ This member outputs trace information when you enable network tracing in your ap
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <altCompliant cref="M:System.Net.Sockets.Socket.Receive(System.Byte[],System.Net.Sockets.SocketFlags)" />
@@ -8263,9 +8022,6 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
  ]]></format>
         </remarks>
@@ -8345,9 +8101,6 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -8458,9 +8211,6 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
  If you are using a connection-oriented <xref:System.Net.Sockets.Socket>, the <xref:System.Net.Sockets.Socket.Receive*> method will read as much data as is available, up to the number of bytes specified by the size parameter. If the remote host shuts down the <xref:System.Net.Sockets.Socket> connection with the <xref:System.Net.Sockets.Socket.Shutdown*> method, and all available data has been received, the <xref:System.Net.Sockets.Socket.Receive*> method will complete immediately and return zero bytes.
 
  If you are using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.Net.Sockets.Socket.Receive*> will read the first queued datagram from the destination address you specify in the <xref:System.Net.Sockets.Socket.Connect*> method. If the datagram you receive is larger than the size of the `buffer` parameter, `buffer` gets filled with the first part of the message, the excess data is lost and a <xref:System.Net.Sockets.SocketException> is thrown.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
  ]]></format>
         </remarks>
@@ -8965,9 +8715,6 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 >  The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 
 
 ## Examples
@@ -9112,9 +8859,6 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
 > [!NOTE]
 >  The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -9309,9 +9053,6 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 > [!NOTE]
 >  The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 
 
 ## Examples
@@ -9425,9 +9166,6 @@ If you're using a connectionless <xref:System.Net.Sockets.Socket>, <xref:System.
 
 > [!NOTE]
 >  The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -9932,9 +9670,6 @@ You must call the Bind method before performing this operation.</exception>
 > [!NOTE]
 >  The <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.ReceiveFrom*> needs to match the <xref:System.Net.Sockets.AddressFamily> of the <xref:System.Net.EndPoint> used in <xref:System.Net.Sockets.Socket.SendTo*>.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -9966,7 +9701,7 @@ You must call the Bind method before performing this operation.</exception>
 
  -or-
 
- The .NET Framework is running on an AMD 64-bit processor.
+ .NET is running on an AMD 64-bit processor.
 
  -or-
 
@@ -10373,9 +10108,6 @@ You must call the Bind method before performing this operation.</exception>
 
  The <xref:System.Net.Sockets.Socket.RemoteEndPoint*> is set after a call to either <xref:System.Net.Sockets.Socket.Accept*> or <xref:System.Net.Sockets.Socket.Connect*>. If you try to access this property earlier, <xref:System.Net.Sockets.Socket.RemoteEndPoint*> will throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 
 
 ## Examples
@@ -10641,9 +10373,6 @@ You must call the Bind method before performing this operation.</exception>
 > [!NOTE]
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 
 
 ## Examples
@@ -10734,9 +10463,6 @@ You must call the Bind method before performing this operation.</exception>
 > [!NOTE]
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <altCompliant cref="M:System.Net.Sockets.Socket.Send(System.Byte[])" />
@@ -10799,8 +10525,6 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
 > [!NOTE]
 >If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 > [!IMPORTANT]
 >The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
@@ -10880,9 +10604,6 @@ This member outputs trace information when you enable network tracing in your ap
 
 > [!NOTE]
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -10973,9 +10694,6 @@ This member outputs trace information when you enable network tracing in your ap
 
 > [!NOTE]
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
  ]]></format>
         </remarks>
@@ -11104,8 +10822,6 @@ With a connection-oriented protocol, <xref:System.Net.Sockets.Socket.Send*> will
 > [!NOTE]
 > You must ensure that the size does not exceed the maximum packet size of the underlying service provider. If it does, the datagram won't be sent and <xref:System.Net.Sockets.Socket.Send*> will throw a <xref:System.Net.Sockets.SocketException>. If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 > [!IMPORTANT]
 >The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
@@ -11207,9 +10923,6 @@ The following code example sends the data found in buffer, and specifies <xref:S
 > [!NOTE]
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <altCompliant cref="M:System.Net.Sockets.Socket.Send(System.Byte[],System.Int32,System.Net.Sockets.SocketFlags)" />
@@ -11275,8 +10988,6 @@ If you're using a connection-oriented protocol, <xref:System.Net.Sockets.Socket.
 
 > [!NOTE]
 >If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you've obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 > [!IMPORTANT]
 >The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
@@ -11362,9 +11073,6 @@ This member outputs trace information when you enable network tracing in your ap
 
 > [!NOTE]
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -11477,9 +11185,6 @@ This member outputs trace information when you enable network tracing in your ap
 
 > [!NOTE]
 >  The successful completion of a send does not indicate that the data was successfully delivered. If no buffer space is available within the transport system to hold the data to be transmitted, send will block unless the socket has been placed in nonblocking mode.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
 
@@ -11982,9 +11687,6 @@ This member outputs trace information when you enable network tracing in your ap
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 ## Examples
  The following code example creates and connects a socket and then sends a file to the remote host. The file "test.txt" is located in the root directory of the local machine.
 
@@ -12065,9 +11767,6 @@ This member outputs trace information when you enable network tracing in your ap
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 ## Examples
  The following code example creates and connects a socket. The file "test.txt" is located in the root directory of the local machine. In this example, we create a prebuffer and postbuffer of data and send them to the remote host with the file. The default <xref:System.Net.Sockets.TransmitFileOptions> are used.
@@ -12448,9 +12147,6 @@ This member outputs trace information when you enable network tracing in your ap
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 ## Examples
  The following code example sends a connectionless datagram to the specified remote host.
 
@@ -12585,9 +12281,6 @@ This member outputs trace information when you enable network tracing in your ap
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 ## Examples
  The following code example sends a connectionless datagram to the specified remote host. <xref:System.Net.Sockets.SocketFlags> are passed to the <xref:System.Net.Sockets.Socket.SendTo*> method.
@@ -12774,9 +12467,6 @@ This member outputs trace information when you enable network tracing in your ap
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 ## Examples
  The following code example sends a connectionless datagram to the specified remote host. The size and <xref:System.Net.Sockets.SocketFlags> are passed to the <xref:System.Net.Sockets.Socket.SendTo*> method.
 
@@ -12870,9 +12560,6 @@ This member outputs trace information when you enable network tracing in your ap
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 ## Examples
  The following code example sends a connectionless datagram to the specified remote host. The offset, size, and <xref:System.Net.Sockets.SocketFlags> are passed to the <xref:System.Net.Sockets.Socket.SendTo*> method.
@@ -13543,9 +13230,6 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
 ## Examples
  The following code example sets the <xref:System.Net.Sockets.LingerOption> and <xref:System.Net.Sockets.Socket.Send*> time-out values.
 
@@ -13682,9 +13366,6 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 ## Examples
  The following code example sets the <xref:System.Net.Sockets.LingerOption> and <xref:System.Net.Sockets.Socket.Send*> time-out values.
@@ -13847,9 +13528,6 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException> when calling the <xref:System.Net.Sockets.Socket.Shutdown*> method, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code. After you have obtained this code, refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 ## Examples
  The following code example uses <xref:System.Net.Sockets.Socket.Shutdown*> to disable the <xref:System.Net.Sockets.Socket>.
@@ -14038,17 +13716,10 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets a value that indicates whether the Framework supports IPv6 for certain obsolete <see cref="T:System.Net.Dns" /> members.</summary>
+        <summary>Gets a value that indicates whether the framework supports IPv6 for certain obsolete <see cref="T:System.Net.Dns" /> members.</summary>
         <value>
-          <see langword="true" /> if the Framework supports IPv6 for certain obsolete <see cref="T:System.Net.Dns" /> methods; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The operating system may support both IPv4 and IPv6 protocols.
-
- ]]></format>
-        </remarks>
+          <see langword="true" /> if the framework supports IPv6 for certain obsolete <see cref="T:System.Net.Dns" /> methods; otherwise, <see langword="false" />.</value>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Net.Sockets.Socket.OSSupportsIPv6" />
         <altmember cref="P:System.Net.Sockets.Socket.SupportsIPv4" />
       </Docs>
@@ -14163,20 +13834,9 @@ The <xref:System.Net.Sockets.Socket.SetRawSocketOption(System.Int32,System.Int32
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets or sets a value that specifies whether the socket should only use Overlapped I/O mode. On .NET 5+ (including .NET Core versions), the value is always <see langword="false" />.</summary>
-        <value>
-          <see langword="true" /> on .NET Framework if the <see cref="T:System.Net.Sockets.Socket" /> uses only overlapped I/O; otherwise, <see langword="false" />. The default is <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-.NET Framework only: Set this property to `true` for a <xref:System.Net.Sockets.Socket> you intend to call <xref:System.Net.Sockets.Socket.DuplicateAndClose*> on. Otherwise, the Framework may assign a completion port to the socket, which would prohibit the use of <xref:System.Net.Sockets.Socket.DuplicateAndClose*>.
-
-On .NET 5+ (include .NET Core) versions, the value of this property is always `false`, and you cannot change its value.
-
- ]]></format>
-        </remarks>
+        <summary>Gets or sets a value that specifies whether the socket should only use Overlapped I/O mode.</summary>
+        <value>Always <see langword="false" />.</value>
+        <remarks>The value of this property is always `false`, and you cannot change its value.</remarks>
         <exception cref="T:System.InvalidOperationException">The socket has been bound to a completion port.</exception>
       </Docs>
     </Member>

--- a/xml/System.Net.Sockets/SocketAsyncEventArgs.xml
+++ b/xml/System.Net.Sockets/SocketAsyncEventArgs.xml
@@ -100,9 +100,6 @@
     <altmember cref="M:System.Net.Sockets.Socket.SendAsync(System.Net.Sockets.SocketAsyncEventArgs)" />
     <altmember cref="M:System.Net.Sockets.Socket.SendPacketsAsync(System.Net.Sockets.SocketAsyncEventArgs)" />
     <altmember cref="M:System.Net.Sockets.Socket.SendToAsync(System.Net.Sockets.SocketAsyncEventArgs)" />
-    <related type="Article" href="/dotnet/framework/network-programming/">Network Programming in the .NET Framework</related>
-    <related type="Article" href="/dotnet/framework/network-programming/network-tracing">Network Tracing in the .NET Framework</related>
-    <related type="Article" href="/dotnet/framework/network-programming/socket-performance-enhancements-in-version-3-5">Socket Performance Enhancements in Version 3.5</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -761,9 +758,6 @@
  This method is called by the public `Dispose()` method and the <xref:System.Object.Finalize> method, if it has been overridden. `Dispose()` invokes this method with the `disposing` parameter set to `true`. `Finalize` invokes this method with `disposing` set to `false`.
 
  When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.Sockets.SocketAsyncEventArgs> references. This method invokes the `Dispose()` method of each referenced object.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
  ]]></format>
         </remarks>

--- a/xml/System.Net.Sockets/SocketAsyncEventArgs.xml
+++ b/xml/System.Net.Sockets/SocketAsyncEventArgs.xml
@@ -759,6 +759,9 @@
 
  When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.Sockets.SocketAsyncEventArgs> references. This method invokes the `Dispose()` method of each referenced object.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
  ]]></format>
         </remarks>
         <block subset="none" type="overrides">

--- a/xml/System.Net.Sockets/SocketFlags.xml
+++ b/xml/System.Net.Sockets/SocketFlags.xml
@@ -56,7 +56,7 @@
 
 ## Examples
  The following example sends data and specifies `SocketFlags.None`.
-  
+
  :::code language="csharp" source="~/snippets/csharp/System.Net.Sockets/Socket/Receive/source.cs" id="Snippet3":::
  :::code language="vb" source="~/snippets/visualbasic/System.Net.Sockets/Socket/Receive/source.vb" id="Snippet3":::
 

--- a/xml/System.Net.Sockets/TcpClient.xml
+++ b/xml/System.Net.Sockets/TcpClient.xml
@@ -148,9 +148,6 @@
  This constructor creates a new <xref:System.Net.Sockets.TcpClient> and allows the underlying service provider to assign the most appropriate local IP address and port number. You must first call the <xref:System.Net.Sockets.TcpClient.Connect*> method before sending and receiving data.
 
 > [!NOTE]
-> On .NET Framework, this constructor works only with IPv4 address types.
-
-> [!NOTE]
 > This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
@@ -918,7 +915,7 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
@@ -992,7 +989,7 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
@@ -1067,7 +1064,7 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
@@ -1216,7 +1213,7 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you've obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
 > If you receive a `NotSupportedException` with the message "This protocol version is not supported" while using IPv6 address, make sure you enabled IPv6 in the constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
@@ -1283,7 +1280,7 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
@@ -1356,7 +1353,7 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
@@ -1418,7 +1415,7 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
@@ -1488,7 +1485,7 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member outputs trace information when you enable network tracing in your application.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.String,System.Int32)>.
 
@@ -1550,7 +1547,7 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
@@ -1615,7 +1612,7 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member outputs trace information when you enable network tracing in your application.
 
 > [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
@@ -1683,7 +1680,7 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member outputs trace information when you enable network tracing in your application.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.String,System.Int32)>.
 
@@ -1854,7 +1851,7 @@ The `Available` property is a way to determine whether data is queued for readin
  When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.Sockets.TcpClient> references. It does this by invoking the `Dispose()` method of each referenced object.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+> This member outputs trace information when you enable network tracing in your application.
 
  ]]></format>
         </remarks>

--- a/xml/System.Net.Sockets/TcpClient.xml
+++ b/xml/System.Net.Sockets/TcpClient.xml
@@ -69,7 +69,7 @@
 - Create a `TcpClient` using the host name and port number of the remote host. This constructor will automatically attempt a connection.
 
 > [!NOTE]
->  If you want to send connectionless datagrams in synchronous blocking mode, use the <xref:System.Net.Sockets.UdpClient> class.
+> If you want to send connectionless datagrams in synchronous blocking mode, use the <xref:System.Net.Sockets.UdpClient> class.
 
 
 
@@ -147,6 +147,12 @@
 ## Remarks
  This constructor creates a new <xref:System.Net.Sockets.TcpClient> and allows the underlying service provider to assign the most appropriate local IP address and port number. You must first call the <xref:System.Net.Sockets.TcpClient.Connect*> method before sending and receiving data.
 
+> [!NOTE]
+> On .NET Framework, this constructor works only with IPv4 address types.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example demonstrates how to use the parameterless constructor to create a new <xref:System.Net.Sockets.TcpClient>.
 
@@ -205,6 +211,9 @@
 
  You must call the <xref:System.Net.Sockets.TcpClient.Connect*> method before sending and receiving data.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example demonstrates how to create an instance of the <xref:System.Net.Sockets.TcpClient> class using a local endpoint.
 
@@ -260,6 +269,11 @@
         <summary>Initializes a new instance of the <see cref="T:System.Net.Sockets.TcpClient" /> class with the specified family.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates how to create an instance of the <xref:System.Net.Sockets.TcpClient> class.
@@ -326,7 +340,10 @@
  If IPv6 is enabled and the <xref:System.Net.Sockets.TcpClient.%23ctor(System.String,System.Int32)> method is called to connect to a host that resolves to both IPv6 and IPv4 addresses, the connection to the IPv6 address will be attempted first before the IPv4 address. This may have the effect of delaying the time to establish the connection if the host is not listening on the IPv6 address.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates how to create an instance of the <xref:System.Net.Sockets.TcpClient> class using a host name and port number.
@@ -827,6 +844,9 @@ The `Available` property is a way to determine whether data is queued for readin
 
  Calling this method will eventually result in the close of the associated `Socket` and will also close the associated <xref:System.Net.Sockets.NetworkStream> that is used to send and receive data if one was created.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example demonstrates closing a <xref:System.Net.Sockets.TcpClient> by calling the `Close` method.
 
@@ -898,6 +918,9 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+
+> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
 ## Examples
@@ -966,7 +989,12 @@ The `Available` property is a way to determine whether data is queued for readin
  Call this method to establish a synchronous remote host connection to the specified <xref:System.Net.IPAddress> and port number. The <xref:System.Net.Sockets.TcpClient.Connect*> method will block until it either connects or fails. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+
+> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
 
@@ -1036,7 +1064,12 @@ The `Available` property is a way to determine whether data is queued for readin
  This method is typically used immediately after a call to the <xref:System.Net.Dns.BeginGetHostAddresses*> method, which can return multiple IP addresses for a single host. Call the `Connect` method to establish a synchronous remote host connection to the host specified by the array of <xref:System.Net.IPAddress> elements and the port number. The `Connect` method will block until it either connects or fails. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+
+> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
 
@@ -1109,7 +1142,10 @@ The `Available` property is a way to determine whether data is queued for readin
  If IPv6 is enabled and the `Connect(String, Int32)` method is called to connect to a host that resolves to both IPv6 and IPv4 addresses, the connection to the IPv6 address will be attempted first before the IPv4 address. This may have the effect of delaying the time to establish the connection if the host is not listening on the IPv6 address.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example uses the host name and port number to connect with a remote host.
@@ -1180,6 +1216,9 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you've obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+
+> [!NOTE]
 > If you receive a `NotSupportedException` with the message "This protocol version is not supported" while using IPv6 address, make sure you enabled IPv6 in the constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.Net.IPEndPoint)>.
@@ -1241,7 +1280,12 @@ The `Available` property is a way to determine whether data is queued for readin
  Call this method to establish a synchronous remote host connection to the specified <xref:System.Net.IPAddress> and port number as an asynchronous operation. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+
+> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.Net.IPAddress,System.Int32)>.
@@ -1309,7 +1353,12 @@ The `Available` property is a way to determine whether data is queued for readin
  This method is typically used immediately after a call to the <xref:System.Net.Dns.BeginGetHostAddresses*> method, which can return multiple IP addresses for a single host. Call this method to establish a synchronous remote host connection to the host specified by the array of <xref:System.Net.IPAddress> elements and the port number as an asynchronous operation. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+
+> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.Net.IPAddress[],System.Int32)>.
@@ -1366,7 +1415,12 @@ The `Available` property is a way to determine whether data is queued for readin
  Call this method to establish a synchronous remote host connection to the specified <xref:System.Net.IPEndPoint>. Before you call `Connect`, you must create an instance of the `IPEndPoint` class using an IP address and a port number. Use this `IPEndPoint` as the `remoteEP` parameter. The `Connect` method will block until it either connects or fails. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+
+> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.Net.IPEndPoint)>.
@@ -1431,7 +1485,12 @@ The `Available` property is a way to determine whether data is queued for readin
  If IPv6 is enabled and the <xref:System.Net.Sockets.TcpClient.ConnectAsync(System.String,System.Int32)> method is called to connect to a host that resolves to both IPv6 and IPv4 addresses, the connection to the IPv6 address will be attempted first before the IPv4 address. This may have the effect of delaying the time to establish the connection if the host is not listening on the IPv6 address.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error. This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.String,System.Int32)>.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+
+ This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.String,System.Int32)>.
 
 ]]></format>
         </remarks>
@@ -1488,7 +1547,12 @@ The `Available` property is a way to determine whether data is queued for readin
  Call this method to establish a synchronous remote host connection to the specified IP address and port number as an asynchronous operation. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+
+> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.Net.IPAddress,System.Int32)>.
@@ -1548,7 +1612,12 @@ The `Available` property is a way to determine whether data is queued for readin
  This method is typically used immediately after a call to the <xref:System.Net.Dns.BeginGetHostAddresses*> method, which can return multiple IP addresses for a single host. Call this method to establish a synchronous remote host connection to the host specified by the array of IP addresses and the port number as an asynchronous operation. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+
+> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.Net.IPAddress[],System.Int32)>.
@@ -1611,7 +1680,12 @@ The `Available` property is a way to determine whether data is queued for readin
  If IPv6 is enabled and the <xref:System.Net.Sockets.TcpClient.ConnectAsync(System.String,System.Int32)> method is called to connect to a host that resolves to both IPv6 and IPv4 addresses, the connection to the IPv6 address will be attempted first before the IPv4 address. This may have the effect of delaying the time to establish the connection if the host is not listening on the IPv6 address.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error. This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.String,System.Int32)>.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+
+ This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.String,System.Int32)>.
 
 ]]></format>
         </remarks>
@@ -1777,7 +1851,12 @@ The `Available` property is a way to determine whether data is queued for readin
 ## Remarks
  This method is called by the public `Dispose()` method and the <xref:System.Object.Finalize> method, if it has been overridden. `Dispose()` invokes this method with the `disposing` parameter set to `true`. `Finalize` invokes this method with `disposing` set to `false`.
 
- When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.Sockets.TcpClient> references. It does this by invoking the `Dispose()` method of each referenced object. ]]></format>
+ When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.Sockets.TcpClient> references. It does this by invoking the `Dispose()` method of each referenced object.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
+
+ ]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>
@@ -1835,7 +1914,7 @@ The `Available` property is a way to determine whether data is queued for readin
  This method blocks until the operation is complete. To perform this operation synchronously, use a <xref:System.Net.Sockets.TcpClient.Connect*> method.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
  ]]></format>
         </remarks>
@@ -2011,7 +2090,10 @@ The `GetStream` method returns a <xref:System.Net.Sockets.NetworkStream> that yo
  You must call the <xref:System.Net.Sockets.TcpClient.Connect*> method first, or the <xref:System.Net.Sockets.TcpClient.GetStream*> method will throw an <xref:System.InvalidOperationException>. After you have obtained the `NetworkStream`, call the <xref:System.Net.Sockets.NetworkStream.Write*> method to send data to the remote host. Call the <xref:System.Net.Sockets.NetworkStream.Read*> method to receive data arriving from the remote host. Both of these methods block until the specified operation is performed. You can avoid blocking on a read operation by checking the <xref:System.Net.Sockets.NetworkStream.DataAvailable> property. A `true` value means that data has arrived from the remote host and is available for reading. In this case, <xref:System.Net.Sockets.NetworkStream.Read*> is guaranteed to complete immediately. If the remote host has shutdown its connection, <xref:System.Net.Sockets.NetworkStream.Read*> will immediately return with zero bytes.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example uses `GetStream` to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. After obtaining the <xref:System.Net.Sockets.NetworkStream>, it sends and receives using its <xref:System.Net.Sockets.NetworkStream.Write*> and <xref:System.Net.Sockets.NetworkStream.Read*> methods.

--- a/xml/System.Net.Sockets/TcpClient.xml
+++ b/xml/System.Net.Sockets/TcpClient.xml
@@ -147,14 +147,6 @@
 ## Remarks
  This constructor creates a new <xref:System.Net.Sockets.TcpClient> and allows the underlying service provider to assign the most appropriate local IP address and port number. You must first call the <xref:System.Net.Sockets.TcpClient.Connect*> method before sending and receiving data.
 
-> [!NOTE]
->  On .NET Framework, this constructor works only with IPv4 address types.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
 ## Examples
  The following code example demonstrates how to use the parameterless constructor to create a new <xref:System.Net.Sockets.TcpClient>.
 
@@ -213,11 +205,6 @@
 
  You must call the <xref:System.Net.Sockets.TcpClient.Connect*> method before sending and receiving data.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
 ## Examples
  The following code example demonstrates how to create an instance of the <xref:System.Net.Sockets.TcpClient> class using a local endpoint.
 
@@ -273,13 +260,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Net.Sockets.TcpClient" /> class with the specified family.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
 
 ## Examples
  The following code example demonstrates how to create an instance of the <xref:System.Net.Sockets.TcpClient> class.
@@ -347,11 +327,6 @@
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
 
 ## Examples
  The following code example demonstrates how to create an instance of the <xref:System.Net.Sockets.TcpClient> class using a host name and port number.
@@ -852,11 +827,6 @@ The `Available` property is a way to determine whether data is queued for readin
 
  Calling this method will eventually result in the close of the associated `Socket` and will also close the associated <xref:System.Net.Sockets.NetworkStream> that is used to send and receive data if one was created.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
 ## Examples
  The following code example demonstrates closing a <xref:System.Net.Sockets.TcpClient> by calling the `Close` method.
 
@@ -928,9 +898,6 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
 ## Examples
@@ -999,12 +966,7 @@ The `Available` property is a way to determine whether data is queued for readin
  Call this method to establish a synchronous remote host connection to the specified <xref:System.Net.IPAddress> and port number. The <xref:System.Net.Sockets.TcpClient.Connect*> method will block until it either connects or fails. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
+>  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
 
@@ -1074,12 +1036,7 @@ The `Available` property is a way to determine whether data is queued for readin
  This method is typically used immediately after a call to the <xref:System.Net.Dns.BeginGetHostAddresses*> method, which can return multiple IP addresses for a single host. Call the `Connect` method to establish a synchronous remote host connection to the host specified by the array of <xref:System.Net.IPAddress> elements and the port number. The `Connect` method will block until it either connects or fails. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
+>  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
 
@@ -1154,11 +1111,6 @@ The `Available` property is a way to determine whether data is queued for readin
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
 ## Examples
  The following code example uses the host name and port number to connect with a remote host.
 
@@ -1228,9 +1180,6 @@ The `Available` property is a way to determine whether data is queued for readin
 > If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you've obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
 > [!NOTE]
-> This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
 > If you receive a `NotSupportedException` with the message "This protocol version is not supported" while using IPv6 address, make sure you enabled IPv6 in the constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.Net.IPEndPoint)>.
@@ -1292,12 +1241,7 @@ The `Available` property is a way to determine whether data is queued for readin
  Call this method to establish a synchronous remote host connection to the specified <xref:System.Net.IPAddress> and port number as an asynchronous operation. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
+>  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.Net.IPAddress,System.Int32)>.
@@ -1365,12 +1309,7 @@ The `Available` property is a way to determine whether data is queued for readin
  This method is typically used immediately after a call to the <xref:System.Net.Dns.BeginGetHostAddresses*> method, which can return multiple IP addresses for a single host. Call this method to establish a synchronous remote host connection to the host specified by the array of <xref:System.Net.IPAddress> elements and the port number as an asynchronous operation. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
+>  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.Net.IPAddress[],System.Int32)>.
@@ -1427,12 +1366,7 @@ The `Available` property is a way to determine whether data is queued for readin
  Call this method to establish a synchronous remote host connection to the specified <xref:System.Net.IPEndPoint>. Before you call `Connect`, you must create an instance of the `IPEndPoint` class using an IP address and a port number. Use this `IPEndPoint` as the `remoteEP` parameter. The `Connect` method will block until it either connects or fails. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
+>  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.Net.IPEndPoint)>.
@@ -1497,12 +1431,7 @@ The `Available` property is a way to determine whether data is queued for readin
  If IPv6 is enabled and the <xref:System.Net.Sockets.TcpClient.ConnectAsync(System.String,System.Int32)> method is called to connect to a host that resolves to both IPv6 and IPv4 addresses, the connection to the IPv6 address will be attempted first before the IPv4 address. This may have the effect of delaying the time to establish the connection if the host is not listening on the IPv6 address.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.String,System.Int32)>.
+>  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error. This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.String,System.Int32)>.
 
 ]]></format>
         </remarks>
@@ -1559,12 +1488,7 @@ The `Available` property is a way to determine whether data is queued for readin
  Call this method to establish a synchronous remote host connection to the specified IP address and port number as an asynchronous operation. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
+>  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.Net.IPAddress,System.Int32)>.
@@ -1624,12 +1548,7 @@ The `Available` property is a way to determine whether data is queued for readin
  This method is typically used immediately after a call to the <xref:System.Net.Dns.BeginGetHostAddresses*> method, which can return multiple IP addresses for a single host. Call this method to establish a synchronous remote host connection to the host specified by the array of IP addresses and the port number as an asynchronous operation. After connecting with the remote host, use the <xref:System.Net.Sockets.TcpClient.GetStream*> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. Use this `NetworkStream` to send and receive data.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-> [!NOTE]
+>  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.> [!NOTE]
 > If you receive NotSupportedException with message `This protocol version is not supported` while using IPv6 address, then make sure you enabled IPv6 in constructor by passing <xref:System.Net.Sockets.AddressFamily.InterNetworkV6>.
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.Net.IPAddress[],System.Int32)>.
@@ -1692,12 +1611,7 @@ The `Available` property is a way to determine whether data is queued for readin
  If IPv6 is enabled and the <xref:System.Net.Sockets.TcpClient.ConnectAsync(System.String,System.Int32)> method is called to connect to a host that resolves to both IPv6 and IPv4 addresses, the connection to the IPv6 address will be attempted first before the IPv4 address. This may have the effect of delaying the time to establish the connection if the host is not listening on the IPv6 address.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.String,System.Int32)>.
+>  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error. This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpClient.Connect(System.String,System.Int32)>.
 
 ]]></format>
         </remarks>
@@ -1863,12 +1777,7 @@ The `Available` property is a way to determine whether data is queued for readin
 ## Remarks
  This method is called by the public `Dispose()` method and the <xref:System.Object.Finalize> method, if it has been overridden. `Dispose()` invokes this method with the `disposing` parameter set to `true`. `Finalize` invokes this method with `disposing` set to `false`.
 
- When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.Sockets.TcpClient> references. It does this by invoking the `Dispose()` method of each referenced object.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- ]]></format>
+ When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.Sockets.TcpClient> references. It does this by invoking the `Dispose()` method of each referenced object. ]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>
@@ -2103,11 +2012,6 @@ The `GetStream` method returns a <xref:System.Net.Sockets.NetworkStream> that yo
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use <xref:System.Net.Sockets.SocketException.ErrorCode*?displayProperty=nameWithType> to obtain the specific error code. After you have obtained this code, you can refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
 
 ## Examples
  The following code example uses `GetStream` to obtain the underlying <xref:System.Net.Sockets.NetworkStream>. After obtaining the <xref:System.Net.Sockets.NetworkStream>, it sends and receives using its <xref:System.Net.Sockets.NetworkStream.Write*> and <xref:System.Net.Sockets.NetworkStream.Read*> methods.

--- a/xml/System.Net.Sockets/TcpListener.xml
+++ b/xml/System.Net.Sockets/TcpListener.xml
@@ -72,7 +72,7 @@
  Call the <xref:System.Net.Sockets.TcpListener.Stop*> method to close the <xref:System.Net.Sockets.TcpListener>.
 
 > [!NOTE]
->  The <xref:System.Net.Sockets.TcpListener.Stop*> method does not close any accepted connections. You are responsible for closing these separately.
+> The <xref:System.Net.Sockets.TcpListener.Stop*> method does not close any accepted connections. You are responsible for closing these separately.
 
 
 
@@ -219,6 +219,9 @@
 
  Call the <xref:System.Net.Sockets.TcpListener.Start*> method to begin listening for incoming connection attempts.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example creates an instance of the <xref:System.Net.Sockets.TcpListener> class using the local endpoint.
 
@@ -282,6 +285,9 @@
  This constructor allows you to specify the local IP address and port number on which to listen for incoming connection attempts. Before calling this constructor you must first create an <xref:System.Net.IPAddress> using the desired local address. Pass this <xref:System.Net.IPAddress> to the constructor as the `localaddr` parameter. If you do not care which local address is assigned, specify <xref:System.Net.IPAddress.Any?displayProperty=nameWithType> for the `localaddr` parameter, and the underlying service provider will assign the most appropriate network address. This might help simplify your application if you have multiple network interfaces. If you do not care which local port is used, you can specify 0 for the port number. In this case, the service provider will assign an available port number between 1024 and 65535. If you use this approach, you can discover what local network address and port number has been assigned by using the <xref:System.Net.Sockets.TcpListener.LocalEndpoint> property.
 
  Call the <xref:System.Net.Sockets.TcpListener.Start*> method to begin listening for incoming connection attempts.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example creates an instance of the <xref:System.Net.Sockets.TcpListener> class using a local IP address and port number.
@@ -347,6 +353,9 @@
 
  The <xref:System.Net.Sockets.Socket> returned is initialized with the IP address and port number of the remote host. You can use any of the <xref:System.Net.Sockets.Socket.Send*> and <xref:System.Net.Sockets.Socket.Receive*> methods available in the <xref:System.Net.Sockets.Socket> class to communicate with the remote host. When you are finished using the <xref:System.Net.Sockets.Socket>, be sure to call its <xref:System.Net.Sockets.Socket.Close*> method. If your application is relatively simple, consider using the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method rather than the <xref:System.Net.Sockets.TcpListener.AcceptSocket*> method. <xref:System.Net.Sockets.TcpClient> provides you with simple methods for sending and receiving data over a network in blocking synchronous mode.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  In the following code example, the <xref:System.Net.Sockets.TcpListener.AcceptSocket*> method is used to return a <xref:System.Net.Sockets.Socket>. This <xref:System.Net.Sockets.Socket> is used to communicate with the newly connected client.
 
@@ -406,7 +415,10 @@
 ## Remarks
  This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the socket connection has been accepted.
 
- The <xref:System.Net.Sockets.Socket> returned in <xref:System.Threading.Tasks.Task`1> is initialized with the IP address and port number of the remote host. You can use any of the <xref:System.Net.Sockets.Socket.Send*> and <xref:System.Net.Sockets.Socket.Receive*> methods available in the <xref:System.Net.Sockets.Socket> class to communicate with the remote host. When you are finished using the <xref:System.Net.Sockets.Socket>, be sure to call its <xref:System.Net.Sockets.Socket.Close*> method. If your application is relatively simple, consider using the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method rather than the <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync*> method. <xref:System.Net.Sockets.TcpClient> provides you with simple methods for sending and receiving data over a network in blocking synchronous mode. This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptSocket>.
+ The <xref:System.Net.Sockets.Socket> returned in <xref:System.Threading.Tasks.Task`1> is initialized with the IP address and port number of the remote host. You can use any of the <xref:System.Net.Sockets.Socket.Send*> and <xref:System.Net.Sockets.Socket.Receive*> methods available in the <xref:System.Net.Sockets.Socket> class to communicate with the remote host. When you are finished using the <xref:System.Net.Sockets.Socket>, be sure to call its <xref:System.Net.Sockets.Socket.Close*> method. If your application is relatively simple, consider using the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method rather than the <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync*> method. <xref:System.Net.Sockets.TcpClient> provides you with simple methods for sending and receiving data over a network in blocking synchronous mode.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptSocket>.
 
 ]]></format>
         </remarks>
@@ -460,7 +472,8 @@
 
  The <xref:System.Net.Sockets.Socket> returned in <xref:System.Threading.Tasks.Task`1> is initialized with the IP address and port number of the remote host. You can use any of the <xref:System.Net.Sockets.Socket.Send*> and <xref:System.Net.Sockets.Socket.Receive*> methods available in the <xref:System.Net.Sockets.Socket> class to communicate with the remote host. When you are finished using the <xref:System.Net.Sockets.Socket>, be sure to call its <xref:System.Net.Sockets.Socket.Close*> method. If your application is relatively simple, consider using the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method rather than the <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync*> method. <xref:System.Net.Sockets.TcpClient> provides you with simple methods for sending and receiving data over a network in blocking synchronous mode.
 
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptSocket>.
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptSocket>.
 
 ]]></format>
         </remarks>
@@ -514,6 +527,9 @@
  <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> is a blocking method that returns a <xref:System.Net.Sockets.TcpClient> that you can use to send and receive data. Use the <xref:System.Net.Sockets.TcpListener.Pending*> method to determine if connection requests are available in the incoming connection queue if you want to avoid blocking.
 
  Use the <xref:System.Net.Sockets.TcpClient.GetStream*?displayProperty=nameWithType> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream> of the returned <xref:System.Net.Sockets.TcpClient>. The <xref:System.Net.Sockets.NetworkStream> will provide you with methods for sending and receiving with the remote host. When you are through with the <xref:System.Net.Sockets.TcpClient>, be sure to call its <xref:System.Net.Sockets.TcpClient.Close*> method. If you want greater flexibility than a <xref:System.Net.Sockets.TcpClient> offers, consider using <xref:System.Net.Sockets.TcpListener.AcceptSocket*>.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  In the following code example, the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method is used to return a <xref:System.Net.Sockets.TcpClient>. This <xref:System.Net.Sockets.TcpClient> is used to communicate with the newly connected client.
@@ -578,7 +594,8 @@
 
  Use the <xref:System.Net.Sockets.TcpClient.GetStream*?displayProperty=nameWithType> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream> of the returned <xref:System.Net.Sockets.TcpClient> in the <xref:System.Threading.Tasks.Task`1>. The <xref:System.Net.Sockets.NetworkStream> will provide you with methods for sending and receiving with the remote host. When you are through with the <xref:System.Net.Sockets.TcpClient>, be sure to call its <xref:System.Net.Sockets.TcpClient.Close*> method. If you want greater flexibility than a <xref:System.Net.Sockets.TcpClient> offers, consider using <xref:System.Net.Sockets.TcpListener.AcceptSocket*> or <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync*>.
 
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptTcpClient>.
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptTcpClient>.
 
 ]]></format>
         </remarks>
@@ -634,7 +651,8 @@
 
  Use the <xref:System.Net.Sockets.TcpClient.GetStream*?displayProperty=nameWithType> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream> of the returned <xref:System.Net.Sockets.TcpClient> in the <xref:System.Threading.Tasks.Task`1>. The <xref:System.Net.Sockets.NetworkStream> will provide you with methods for sending and receiving with the remote host. When you are through with the <xref:System.Net.Sockets.TcpClient>, be sure to call its <xref:System.Net.Sockets.TcpClient.Close*> method. If you want greater flexibility than a <xref:System.Net.Sockets.TcpClient> offers, consider using <xref:System.Net.Sockets.TcpListener.AcceptSocket*> or <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync*>.
 
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptTcpClient>.
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptTcpClient>.
 
 ]]></format>
         </remarks>
@@ -825,12 +843,13 @@
  For detailed information about using the asynchronous programming model, see [Calling Synchronous Methods Asynchronously](/dotnet/standard/asynchronous-programming-patterns/calling-synchronous-methods-asynchronously).
 
 > [!NOTE]
->  You can call the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the returned <xref:System.Net.Sockets.Socket> to identify the remote host's network address and port number.
+> You can call the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the returned <xref:System.Net.Sockets.Socket> to identify the remote host's network address and port number.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
- ]]></format>
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred while attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
@@ -898,9 +917,10 @@
  For detailed information about using the asynchronous programming model, see [Calling Synchronous Methods Asynchronously](/dotnet/standard/asynchronous-programming-patterns/calling-synchronous-methods-asynchronously).
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
- ]]></format>
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred while attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
@@ -1031,12 +1051,13 @@
  This method blocks until the operation is complete. To perform this operation synchronously, use the <xref:System.Net.Sockets.TcpListener.AcceptSocket*> method.
 
 > [!NOTE]
->  You can call the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the returned <xref:System.Net.Sockets.Socket> to identify the remote host's network address and port number.
+> You can call the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the returned <xref:System.Net.Sockets.Socket> to identify the remote host's network address and port number.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
- ]]></format>
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application. ]]></format>
         </remarks>
         <exception cref="T:System.ObjectDisposedException">The underlying <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <exception cref="T:System.ArgumentNullException">The <paramref name="asyncResult" /> parameter is <see langword="null" />.</exception>
@@ -1096,12 +1117,13 @@
  This method blocks until the operation is complete. To perform this operation synchronously, use the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method.
 
 > [!NOTE]
->  You can call the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the underlying socket (<xref:System.Net.Sockets.TcpClient.Client*>) to identify the remote host's network address and port number.
+> You can call the <xref:System.Net.Sockets.Socket.RemoteEndPoint> property of the underlying socket (<xref:System.Net.Sockets.TcpClient.Client*>) to identify the remote host's network address and port number.
 
 > [!NOTE]
->  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
  ]]></format>
         </remarks>
       </Docs>
@@ -1340,7 +1362,7 @@
  <xref:System.Net.Sockets.TcpListener> creates a <xref:System.Net.Sockets.Socket> to listen for incoming client connection requests. Classes deriving from <xref:System.Net.Sockets.TcpListener> can use this property to get this <xref:System.Net.Sockets.Socket>. Use the underlying <xref:System.Net.Sockets.Socket> returned by the <xref:System.Net.Sockets.TcpListener.Server> property if you require access beyond that which <xref:System.Net.Sockets.TcpListener> provides.
 
 > [!NOTE]
->  The <xref:System.Net.Sockets.TcpListener.Server> property only returns the <xref:System.Net.Sockets.Socket> used to listen for incoming client connection requests. Use the <xref:System.Net.Sockets.TcpListener.AcceptSocket*> method to accept a pending connection request and obtain a <xref:System.Net.Sockets.Socket> for sending and receiving data. You can also use the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method to accept a pending connection request and obtain a <xref:System.Net.Sockets.TcpClient> for sending and receiving data.
+> The <xref:System.Net.Sockets.TcpListener.Server> property only returns the <xref:System.Net.Sockets.Socket> used to listen for incoming client connection requests. Use the <xref:System.Net.Sockets.TcpListener.AcceptSocket*> method to accept a pending connection request and obtain a <xref:System.Net.Sockets.Socket> for sending and receiving data. You can also use the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method to accept a pending connection request and obtain a <xref:System.Net.Sockets.TcpClient> for sending and receiving data.
 
 
 
@@ -1417,6 +1439,9 @@
 
  Use the <xref:System.Net.Sockets.TcpListener.Stop*> method to close the <xref:System.Net.Sockets.TcpListener> and stop listening. You are responsible for closing your accepted connections separately.
 
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
+
 ## Examples
  The following code example demonstrates how <xref:System.Net.Sockets.TcpListener.Start*> is used to listen for incoming client connection attempts.
 
@@ -1485,7 +1510,10 @@
  Use the <xref:System.Net.Sockets.TcpListener.Stop*> method to close the <xref:System.Net.Sockets.TcpListener> and stop listening. You are responsible for closing your accepted connections separately.
 
 > [!NOTE]
->  Use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+> Use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates how <xref:System.Net.Sockets.TcpListener.Start*> is used to listen for incoming client connection attempts.
@@ -1550,6 +1578,9 @@
 
 ## Remarks
  <xref:System.Net.Sockets.TcpListener.Stop*> closes the listener. Any unaccepted connection requests in the queue will be lost. Remote hosts waiting for a connection to be accepted will throw a <xref:System.Net.Sockets.SocketException>. You are responsible for closing your accepted connections separately.
+
+> [!NOTE]
+> This member outputs trace information when you enable network tracing in your application.
 
 ## Examples
  The following code example demonstrates using the <xref:System.Net.Sockets.TcpListener.Stop*> method to close the underlying <xref:System.Net.Sockets.Socket>.

--- a/xml/System.Net.Sockets/TcpListener.xml
+++ b/xml/System.Net.Sockets/TcpListener.xml
@@ -219,11 +219,6 @@
 
  Call the <xref:System.Net.Sockets.TcpListener.Start*> method to begin listening for incoming connection attempts.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
 ## Examples
  The following code example creates an instance of the <xref:System.Net.Sockets.TcpListener> class using the local endpoint.
 
@@ -287,11 +282,6 @@
  This constructor allows you to specify the local IP address and port number on which to listen for incoming connection attempts. Before calling this constructor you must first create an <xref:System.Net.IPAddress> using the desired local address. Pass this <xref:System.Net.IPAddress> to the constructor as the `localaddr` parameter. If you do not care which local address is assigned, specify <xref:System.Net.IPAddress.Any?displayProperty=nameWithType> for the `localaddr` parameter, and the underlying service provider will assign the most appropriate network address. This might help simplify your application if you have multiple network interfaces. If you do not care which local port is used, you can specify 0 for the port number. In this case, the service provider will assign an available port number between 1024 and 65535. If you use this approach, you can discover what local network address and port number has been assigned by using the <xref:System.Net.Sockets.TcpListener.LocalEndpoint> property.
 
  Call the <xref:System.Net.Sockets.TcpListener.Start*> method to begin listening for incoming connection attempts.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
 
 ## Examples
  The following code example creates an instance of the <xref:System.Net.Sockets.TcpListener> class using a local IP address and port number.
@@ -357,11 +347,6 @@
 
  The <xref:System.Net.Sockets.Socket> returned is initialized with the IP address and port number of the remote host. You can use any of the <xref:System.Net.Sockets.Socket.Send*> and <xref:System.Net.Sockets.Socket.Receive*> methods available in the <xref:System.Net.Sockets.Socket> class to communicate with the remote host. When you are finished using the <xref:System.Net.Sockets.Socket>, be sure to call its <xref:System.Net.Sockets.Socket.Close*> method. If your application is relatively simple, consider using the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method rather than the <xref:System.Net.Sockets.TcpListener.AcceptSocket*> method. <xref:System.Net.Sockets.TcpClient> provides you with simple methods for sending and receiving data over a network in blocking synchronous mode.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
 ## Examples
  In the following code example, the <xref:System.Net.Sockets.TcpListener.AcceptSocket*> method is used to return a <xref:System.Net.Sockets.Socket>. This <xref:System.Net.Sockets.Socket> is used to communicate with the newly connected client.
 
@@ -421,12 +406,7 @@
 ## Remarks
  This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the socket connection has been accepted.
 
- The <xref:System.Net.Sockets.Socket> returned in <xref:System.Threading.Tasks.Task`1> is initialized with the IP address and port number of the remote host. You can use any of the <xref:System.Net.Sockets.Socket.Send*> and <xref:System.Net.Sockets.Socket.Receive*> methods available in the <xref:System.Net.Sockets.Socket> class to communicate with the remote host. When you are finished using the <xref:System.Net.Sockets.Socket>, be sure to call its <xref:System.Net.Sockets.Socket.Close*> method. If your application is relatively simple, consider using the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method rather than the <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync*> method. <xref:System.Net.Sockets.TcpClient> provides you with simple methods for sending and receiving data over a network in blocking synchronous mode.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
- This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptSocket>.
+ The <xref:System.Net.Sockets.Socket> returned in <xref:System.Threading.Tasks.Task`1> is initialized with the IP address and port number of the remote host. You can use any of the <xref:System.Net.Sockets.Socket.Send*> and <xref:System.Net.Sockets.Socket.Receive*> methods available in the <xref:System.Net.Sockets.Socket> class to communicate with the remote host. When you are finished using the <xref:System.Net.Sockets.Socket>, be sure to call its <xref:System.Net.Sockets.Socket.Close*> method. If your application is relatively simple, consider using the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method rather than the <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync*> method. <xref:System.Net.Sockets.TcpClient> provides you with simple methods for sending and receiving data over a network in blocking synchronous mode. This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptSocket>.
 
 ]]></format>
         </remarks>
@@ -479,9 +459,6 @@
  This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the socket connection has been accepted.
 
  The <xref:System.Net.Sockets.Socket> returned in <xref:System.Threading.Tasks.Task`1> is initialized with the IP address and port number of the remote host. You can use any of the <xref:System.Net.Sockets.Socket.Send*> and <xref:System.Net.Sockets.Socket.Receive*> methods available in the <xref:System.Net.Sockets.Socket> class to communicate with the remote host. When you are finished using the <xref:System.Net.Sockets.Socket>, be sure to call its <xref:System.Net.Sockets.Socket.Close*> method. If your application is relatively simple, consider using the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method rather than the <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync*> method. <xref:System.Net.Sockets.TcpClient> provides you with simple methods for sending and receiving data over a network in blocking synchronous mode.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptSocket>.
 
@@ -537,11 +514,6 @@
  <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> is a blocking method that returns a <xref:System.Net.Sockets.TcpClient> that you can use to send and receive data. Use the <xref:System.Net.Sockets.TcpListener.Pending*> method to determine if connection requests are available in the incoming connection queue if you want to avoid blocking.
 
  Use the <xref:System.Net.Sockets.TcpClient.GetStream*?displayProperty=nameWithType> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream> of the returned <xref:System.Net.Sockets.TcpClient>. The <xref:System.Net.Sockets.NetworkStream> will provide you with methods for sending and receiving with the remote host. When you are through with the <xref:System.Net.Sockets.TcpClient>, be sure to call its <xref:System.Net.Sockets.TcpClient.Close*> method. If you want greater flexibility than a <xref:System.Net.Sockets.TcpClient> offers, consider using <xref:System.Net.Sockets.TcpListener.AcceptSocket*>.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
 
 ## Examples
  In the following code example, the <xref:System.Net.Sockets.TcpListener.AcceptTcpClient*> method is used to return a <xref:System.Net.Sockets.TcpClient>. This <xref:System.Net.Sockets.TcpClient> is used to communicate with the newly connected client.
@@ -606,9 +578,6 @@
 
  Use the <xref:System.Net.Sockets.TcpClient.GetStream*?displayProperty=nameWithType> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream> of the returned <xref:System.Net.Sockets.TcpClient> in the <xref:System.Threading.Tasks.Task`1>. The <xref:System.Net.Sockets.NetworkStream> will provide you with methods for sending and receiving with the remote host. When you are through with the <xref:System.Net.Sockets.TcpClient>, be sure to call its <xref:System.Net.Sockets.TcpClient.Close*> method. If you want greater flexibility than a <xref:System.Net.Sockets.TcpClient> offers, consider using <xref:System.Net.Sockets.TcpListener.AcceptSocket*> or <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync*>.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptTcpClient>.
 
 ]]></format>
@@ -664,9 +633,6 @@
  This operation will not block. The returned <xref:System.Threading.Tasks.Task`1> object will complete after the TCP connection has been accepted.
 
  Use the <xref:System.Net.Sockets.TcpClient.GetStream*?displayProperty=nameWithType> method to obtain the underlying <xref:System.Net.Sockets.NetworkStream> of the returned <xref:System.Net.Sockets.TcpClient> in the <xref:System.Threading.Tasks.Task`1>. The <xref:System.Net.Sockets.NetworkStream> will provide you with methods for sending and receiving with the remote host. When you are through with the <xref:System.Net.Sockets.TcpClient>, be sure to call its <xref:System.Net.Sockets.TcpClient.Close*> method. If you want greater flexibility than a <xref:System.Net.Sockets.TcpClient> offers, consider using <xref:System.Net.Sockets.TcpListener.AcceptSocket*> or <xref:System.Net.Sockets.TcpListener.AcceptSocketAsync*>.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
  This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <xref:System.ArgumentException>, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <xref:System.Net.Sockets.TcpListener.AcceptTcpClient>.
 
@@ -864,9 +830,6 @@
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.Net.Sockets.SocketException">An error occurred while attempting to access the socket.</exception>
@@ -936,9 +899,6 @@
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
  ]]></format>
         </remarks>
@@ -1076,9 +1036,6 @@
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ObjectDisposedException">The underlying <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
@@ -1143,9 +1100,6 @@
 
 > [!NOTE]
 >  If you receive a <xref:System.Net.Sockets.SocketException>, use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
 
 
  ]]></format>
@@ -1463,11 +1417,6 @@
 
  Use the <xref:System.Net.Sockets.TcpListener.Stop*> method to close the <xref:System.Net.Sockets.TcpListener> and stop listening. You are responsible for closing your accepted connections separately.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
 ## Examples
  The following code example demonstrates how <xref:System.Net.Sockets.TcpListener.Start*> is used to listen for incoming client connection attempts.
 
@@ -1538,11 +1487,6 @@
 > [!NOTE]
 >  Use the <xref:System.Net.Sockets.SocketException.ErrorCode?displayProperty=nameWithType> property to obtain the specific error code and refer to the [Windows Sockets version 2 API error code](/windows/desktop/winsock/windows-sockets-error-codes-2) documentation for a detailed description of the error.
 
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
-
 ## Examples
  The following code example demonstrates how <xref:System.Net.Sockets.TcpListener.Start*> is used to listen for incoming client connection attempts.
 
@@ -1606,11 +1550,6 @@
 
 ## Remarks
  <xref:System.Net.Sockets.TcpListener.Stop*> closes the listener. Any unaccepted connection requests in the queue will be lost. Remote hosts waiting for a connection to be accepted will throw a <xref:System.Net.Sockets.SocketException>. You are responsible for closing your accepted connections separately.
-
-> [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](/dotnet/framework/network-programming/network-tracing).
-
-
 
 ## Examples
  The following code example demonstrates using the <xref:System.Net.Sockets.TcpListener.Stop*> method to close the underlying <xref:System.Net.Sockets.Socket>.

--- a/xml/System.Net.WebSockets/WebSocket.xml
+++ b/xml/System.Net.WebSockets/WebSocket.xml
@@ -940,8 +940,8 @@ Exactly one send and one receive is supported on each <xref:System.Net.WebSocket
           <AttributeName Language="F#">[&lt;System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)&gt;]</AttributeName>
         </Attribute>
         <Attribute FrameworkAlternate="net-10.0;net-11.0;net-6.0;net-7.0;net-8.0;net-9.0">
-          <AttributeName Language="C#">[System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.")]</AttributeName>
-          <AttributeName Language="F#">[&lt;System.Obsolete("This API supports the .NET Framework infrastructure and is not intended to be used directly from your code.")&gt;]</AttributeName>
+          <AttributeName Language="C#">[System.Obsolete("This API supports the .NET infrastructure and is not intended to be used directly from your code.")]</AttributeName>
+          <AttributeName Language="F#">[&lt;System.Obsolete("This API supports the .NET infrastructure and is not intended to be used directly from your code.")&gt;]</AttributeName>
         </Attribute>
       </Attributes>
       <ReturnValue>

--- a/xml/System.Net.WebSockets/WebSocket.xml
+++ b/xml/System.Net.WebSockets/WebSocket.xml
@@ -749,9 +749,9 @@ Exactly one send and one receive is supported on each <xref:System.Net.WebSocket
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Returns a value that indicates if the WebSocket instance is targeting .NET Framework 4.5.</summary>
+        <summary>Returns a value that indicates if the WebSocket instance targets .NET Framework 4.5.</summary>
         <returns>
-          <see langword="true" /> if the <see cref="T:System.Net.WebSockets.WebSocket" /> is targeting .NET Framework 4.5; otherwise, <see langword="false" />.</returns>
+          <see langword="true" /> if the <see cref="T:System.Net.WebSockets.WebSocket" /> targets .NET Framework 4.5; otherwise, <see langword="false" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
.NET Framework API ref has moved to its own repo (https://github.com/dotnet/dotnetfw-api-docs), so we can clean up .NET Framework remarks, exceptions, and code examples out of this repo. Contributes to #12513.

Removes remarks and examples related to:

- .NET Framework versions
- Code-access security
- Configuring apps via app.config file
- App domains

Also remarks *all* remarks from obsolete APIs.

*Hide whitespace changes*