### PR TITLE
Remove .NET Framework remarks (System.Management)

### DIFF
--- a/xml/System.Management/CompletedEventArgs.xml
+++ b/xml/System.Management/CompletedEventArgs.xml
@@ -26,14 +26,14 @@
   <Docs>
     <summary>Holds event data for the <see cref="E:System.Management.ManagementOperationObserver.Completed" /> event.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Examples  
- The following example calls a method asynchronously. The **Win32_Process.Create** method is called to create a new process for Calc.exe.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example calls a method asynchronously. The **Win32_Process.Create** method is called to create a new process for Calc.exe.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_CompletedEventArgs/cs/CompletedEventArgs.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/CompletedEventArgs/Overview/CompletedEventArgs.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/CompletedEventArgs/Overview/CompletedEventArgs.vb" id="Snippet1":::
+
  ]]></format>
     </remarks>
   </Docs>
@@ -57,19 +57,7 @@
       <Docs>
         <summary>Gets the completion status of the operation.</summary>
         <value>One of the enumeration values that indicates the completion status of the operation.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A <xref:System.Management.ManagementStatus> value indicating the status of the operation.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="StatusObject">
@@ -89,21 +77,9 @@
         <ReturnType>System.Management.ManagementBaseObject</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets additional status information within a WMI object. This may be <see langword="null" />.</summary>
-        <value>Additional status information about the completion of an operation.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `null` if an error did not occur. Otherwise, may be non-null if the provider supports extended error information.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <summary>Gets additional status information within a WMI object.</summary>
+        <value>Additional status information about the completion of an operation, or <see langword="null" /> if no extended error information is available or no error occurred.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/ConnectionOptions.xml
+++ b/xml/System.Management/ConnectionOptions.xml
@@ -65,13 +65,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example connects to a remote computer and displays information about the operating system on the remote computer. A <xref:System.Management.ConnectionOptions> is created to connect to the remote computer with default connection options.
 
@@ -159,13 +152,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example connects to a remote computer and displays information about the operating system on the remote computer. A <xref:System.Management.ConnectionOptions> is created to connect to the remote computer with the desired connection options.
 
@@ -194,23 +180,17 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the COM authentication level to be used for operations in this connection.</summary>
-        <value>Returns an <see cref="T:System.Management.AuthenticationLevel" /> enumeration value indicating the COM authentication level used for a connection to the local or a remote computer.</value>
+        <value>The COM authentication level used for connections to the local or a remote computer. The default value is <see cref="System.Management.AuthenticationLevel.Unchanged" />, which indicates that the client will use the authentication level requested by the server, according to the standard DCOM negotiation process.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- On Windows 2000 and below, the WMI service will request Connect level authentication, while on Windows XP and higher it will request Packet level authentication. If the client requires a specific authentication setting, this property can be used to control the authentication level on this particular connection. For example, the property can be set to <xref:System.Management.AuthenticationLevel.PacketPrivacy?displayProperty=nameWithType> if the client requires all communication to be encrypted.
 
-## Property Value
- The COM authentication level to be used for operations in this connection. The default value is <xref:System.Management.AuthenticationLevel.Unchanged?displayProperty=nameWithType>, which indicates that the client will use the authentication level requested by the server, according to the standard DCOM negotiation process.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
+The WMI service requests Packet level authentication. If the client requires a specific authentication setting, this property can be used to control the authentication level on this particular connection. For example, the property can be set to <xref:System.Management.AuthenticationLevel.PacketPrivacy?displayProperty=nameWithType> if the client requires all communication to be encrypted.
 
 ## Examples
- The following example connects to a remote computer and displays information about the operating system on the remote computer. A <xref:System.Management.ConnectionOptions> is created to connect to the remote computer with the desired connection options.
+
+The following example connects to a remote computer and displays information about the operating system on the remote computer. A <xref:System.Management.ConnectionOptions> is created to connect to the remote computer with the desired connection options.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ConnectionOptions_Authentication/cs/ConnectionOptions_Authentication.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Management/ConnectionOptions/Authentication/ConnectionOptions_Authentication.vb" id="Snippet1":::
@@ -238,32 +218,17 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the authority to be used to authenticate the specified user.</summary>
-        <value>Returns a <see cref="T:System.String" /> that defines the authority used to authenticate the specified user.</value>
+        <value>The authority used to authenticate the specified user.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The property must be passed as follows: If it begins with the string "Kerberos:", Kerberos authentication will be used and this property should contain a Kerberos principal name. For example,
 
-```
-Kerberos:<principal name>
-```
+The property must be passed as follows: If it begins with the string "Kerberos:", Kerberos authentication is used and this property should contain a Kerberos principal name. For example, `Kerberos:<principal name>`.
 
- If the property value begins with the string "NTLMDOMAIN:", NTLM authentication will be used and the property should contain a NTLM domain name. For example,
+If the property value begins with the string "NTLMDOMAIN:", NTLM authentication is used and the property should contain a NTLM domain name. For example, `NTLMDOMAIN:<domain name>`.
 
-```
-NTLMDOMAIN:<domain name>
-```
-
- If the property is null, NTLM authentication will be used and the NTLM domain of the current user will be used.
-
-## Property Value
- If not `null`, this property can contain the name of the Windows NT/Windows 2000 domain in which to obtain the user to authenticate.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
+If the property is null, NTLM authentication is used with the NTLM domain of the current user.
 
 ## Examples
  The following example connects to a remote computer and displays information about the operating system on the remote computer. A <xref:System.Management.ConnectionOptions> is created to connect to the remote computer with the desired connection options.
@@ -295,16 +260,7 @@ NTLMDOMAIN:<domain name>
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>The cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>
@@ -326,20 +282,8 @@ NTLMDOMAIN:<domain name>
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating whether user privileges need to be enabled for the connection operation. This property should only be used when the operation performed requires a certain user privilege to be enabled (for example, a machine restart).</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether user privileges need to be enabled for the connection operation.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- `true` if user privileges need to be enabled for the connection operation; otherwise, `false`. The default value is `false`.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value><see langword="true"/> if user privileges need to be enabled for the connection operation; otherwise, <see langword="false"/>. The default value is <see langword="false"/>.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Impersonation">
@@ -360,20 +304,12 @@ NTLMDOMAIN:<domain name>
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the COM impersonation level to be used for operations in this connection.</summary>
-        <value>Returns an <see cref="T:System.Management.ImpersonationLevel" /> enumeration value indicating the impersonation level used to connect to WMI.</value>
+        <value>The impersonation level used to connect to WMI. The default value is <xref:System.Management.ImpersonationLevel.Impersonate?displayProperty=nameWithType>, which indicates that the WMI provider can impersonate the client when performing the requested operations in this connection.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The <xref:System.Management.ImpersonationLevel.Impersonate?displayProperty=nameWithType> setting is advantageous when the provider is a trusted application or service. It eliminates the need for the provider to perform client identity and access checks for the requested operations. However, if for some reason the provider cannot be trusted, allowing it to impersonate the client may constitute a security threat. In such cases, we recommend that this property be set by the client to a lower value, such as <xref:System.Management.ImpersonationLevel.Identify?displayProperty=nameWithType>. Note that this may cause failure of the provider to perform the requested operations, for lack of sufficient permissions or inability to perform access checks.
-
-## Property Value
- The COM impersonation level to be used for operations in this connection. The default value is <xref:System.Management.ImpersonationLevel.Impersonate?displayProperty=nameWithType>, which indicates that the WMI provider can impersonate the client when performing the requested operations in this connection.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
+ The <xref:System.Management.ImpersonationLevel.Impersonate?displayProperty=nameWithType> setting is advantageous when the provider is a trusted application or service. It eliminates the need for the provider to perform client identity and access checks for the requested operations. However, if for some reason the provider cannot be trusted, allowing it to impersonate the client may constitute a security threat. In such cases, we recommend that this property be set by the client to a lower value, such as <xref:System.Management.ImpersonationLevel.Identify?displayProperty=nameWithType>. This might cause failure of the provider to perform the requested operations, for lack of sufficient permissions or inability to perform access checks.
 
 ## Examples
  The following example connects to a remote computer and displays information about the operating system on the remote computer. A <xref:System.Management.ConnectionOptions> is created to connect to the remote computer with the desired connection options.
@@ -403,20 +339,12 @@ NTLMDOMAIN:<domain name>
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the locale to be used for the connection operation.</summary>
-        <value>Returns a <see cref="T:System.String" /> value used for the locale in a connection to WMI.</value>
+        <value>The locale in a connection to WMI. The default value is DEFAULTLOCALE.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  For Microsoft locale identifiers, the format of the string is "MS_*xxx*", where *xxx* is a string in hexadecimal form that indicates the Locale Identification (LCID); for example, American English would appear as "MS_409".
-
-## Property Value
- The default value is DEFAULTLOCALE.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example connects to a remote computer and displays information about the operating system on the remote computer. A <xref:System.Management.ConnectionOptions> is created to connect to the remote computer with the desired connection options.
@@ -446,20 +374,14 @@ NTLMDOMAIN:<domain name>
       </ReturnValue>
       <Docs>
         <summary>Sets the password for the specified user.</summary>
-        <value>Returns a <see cref="T:System.String" /> value used for the password in a connection to WMI.</value>
+        <value>The password in a connection to WMI. The default value is <see langword="null" />. If the user name is also <see langword="null" />, the credentials used will be thoseof the currently logged-on user are used.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  A blank string ("") specifies a valid zero-length password.
 
- Hard-coding a password is a security threat.  Use security precautions such as encrypting a password, or prompting the user for a password when you set the <xref:System.Management.ConnectionOptions.Password> property.
-
-## Property Value
- The default value is `null`. If the user name is also `null`, the credentials used will be those of the currently logged-on user.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
+ Hard-coding a password is a security threat. Use security precautions such as encrypting the password or prompting the user for a password when you set the <xref:System.Management.ConnectionOptions.Password> property.
 
  ]]></format>
         </remarks>
@@ -511,20 +433,12 @@ A blank <xref:System.Security.SecureString> ("") specifies a valid zero-length p
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the user name to be used for the connection operation.</summary>
-        <value>Returns a <see cref="T:System.String" /> value used as the user name in a connection to WMI.</value>
+        <value>The user name in a connection to WMI. The default value is <see langword="null" />. If <see langword="null" />, the credentials used will be those of the currently logged-on user are used.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  If the user name is from a domain other than the current domain, the string may contain the domain name and user name, separated by a backslash: string 'username' = "EnterDomainHere\\\EnterUsernameHere". The `strUser` parameter cannot be an empty string.
-
-## Property Value
- `null` if the connection will use the currently logged-on user; otherwise, a string representing the user name. The default value is `null`.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example connects to a remote computer and displays information about the operating system on the remote computer. A <xref:System.Management.ConnectionOptions> is created to connect to the remote computer with the desired connection options.

--- a/xml/System.Management/ConnectionOptions.xml
+++ b/xml/System.Management/ConnectionOptions.xml
@@ -304,7 +304,7 @@ If the property is null, NTLM authentication is used with the NTLM domain of the
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the COM impersonation level to be used for operations in this connection.</summary>
-        <value>The impersonation level used to connect to WMI. The default value is <xref:System.Management.ImpersonationLevel.Impersonate?displayProperty=nameWithType>, which indicates that the WMI provider can impersonate the client when performing the requested operations in this connection.</value>
+        <value>The impersonation level used to connect to WMI. The default value is <see cref="F:System.Management.ImpersonationLevel.Impersonate" />, which indicates that the WMI provider can impersonate the client when performing the requested operations in this connection.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 

--- a/xml/System.Management/ConnectionOptions.xml
+++ b/xml/System.Management/ConnectionOptions.xml
@@ -374,7 +374,7 @@ If the property is null, NTLM authentication is used with the NTLM domain of the
       </ReturnValue>
       <Docs>
         <summary>Sets the password for the specified user.</summary>
-        <value>The password in a connection to WMI. The default value is <see langword="null" />. If the user name is also <see langword="null" />, the credentials used will be thoseof the currently logged-on user are used.</value>
+        <value>The password in a connection to WMI. The default value is <see langword="null" />. If the user name is also <see langword="null" />, the credentials used will be those of the currently logged-on user are used.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -433,7 +433,7 @@ A blank <xref:System.Security.SecureString> ("") specifies a valid zero-length p
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the user name to be used for the connection operation.</summary>
-        <value>The user name in a connection to WMI. The default value is <see langword="null" />. If <see langword="null" />, the credentials used will be those of the currently logged-on user are used.</value>
+        <value>The user name in a connection to WMI. The default value is <see langword="null" />. If <see langword="null" />, the credentials of the currently logged-on user are used.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 

--- a/xml/System.Management/DeleteOptions.xml
+++ b/xml/System.Management/DeleteOptions.xml
@@ -52,16 +52,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.DeleteOptions" /> class for the delete operation, using default values. This is the parameterless constructor.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -85,16 +76,7 @@
         <param name="context">A provider-specific, named-value pairs object to be passed through to the provider.</param>
         <param name="timeout">The length of time to let the operation perform before it times out. The default value is <see cref="F:System.TimeSpan.MaxValue">TimeSpan.MaxValue</see>. Setting this parameter will invoke the operation semisynchronously.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.DeleteOptions" /> class for a delete operation, using the specified values.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clone">
@@ -117,16 +99,7 @@
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>A cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>

--- a/xml/System.Management/EnumerationOptions.xml
+++ b/xml/System.Management/EnumerationOptions.xml
@@ -26,14 +26,14 @@
   <Docs>
     <summary>Provides a base class for query and enumeration-related options objects.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Examples  
- The following example initializes an <xref:System.Management.EnumerationOptions> variable with an <xref:System.Management.EnumerationOptions> constructor and then gets all the instances of a WMI class and its subclasses.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example initializes an <xref:System.Management.EnumerationOptions> variable with an <xref:System.Management.EnumerationOptions> constructor and then gets all the instances of a WMI class and its subclasses.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_EnumerationOptions/cs/EnumerationOptions.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/EnumerationOptions/Overview/EnumerationOptions.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/EnumerationOptions/Overview/EnumerationOptions.vb" id="Snippet1":::
+
  ]]></format>
     </remarks>
   </Docs>
@@ -63,21 +63,14 @@
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.EnumerationOptions" /> class with default values (see the individual property descriptions for what the default values are). This is the parameterless constructor.</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example initializes an <xref:System.Management.EnumerationOptions> variable with an <xref:System.Management.EnumerationOptions> constructor and then gets all the instances of a WMI class and its subclasses.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example initializes an <xref:System.Management.EnumerationOptions> variable with an <xref:System.Management.EnumerationOptions> constructor and then gets all the instances of a WMI class and its subclasses.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_EnumerationOptions/cs/EnumerationOptions.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/EnumerationOptions/Overview/EnumerationOptions.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/EnumerationOptions/Overview/EnumerationOptions.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -127,21 +120,14 @@
           <see langword="true" /> to use recursive enumeration in subclasses; otherwise, <see langword="false" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.EnumerationOptions" /> class to be used for queries or enumerations, allowing the user to specify values for the different options.</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example initializes an <xref:System.Management.EnumerationOptions> variable with an <xref:System.Management.EnumerationOptions> constructor and then gets all the instances of a WMI class and its subclasses.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example initializes an <xref:System.Management.EnumerationOptions> variable with an <xref:System.Management.EnumerationOptions> constructor and then gets all the instances of a WMI class and its subclasses.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_EnumerationOptions-10/cs/EnumerationOptions-10.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/EnumerationOptions/.ctor/EnumerationOptions-10.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/EnumerationOptions/.ctor/EnumerationOptions-10.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -164,26 +150,16 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the block size for block operations. When enumerating through a collection, WMI will return results in groups of the specified size.</summary>
-        <value>The block size in block operations.</value>
+        <value>The block size in block operations. The default value is 1.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- The default value is 1.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example initializes an <xref:System.Management.EnumerationOptions> variable with an <xref:System.Management.EnumerationOptions> constructor and then gets all the instances of a WMI class and its subclasses.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example initializes an <xref:System.Management.EnumerationOptions> variable with an <xref:System.Management.EnumerationOptions> constructor and then gets all the instances of a WMI class and its subclasses.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_EnumerationOptions_BlockSize/cs/EnumerationOptions_BlockSize.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/EnumerationOptions/BlockSize/EnumerationOptions_BlockSize.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/EnumerationOptions/BlockSize/EnumerationOptions_BlockSize.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -208,16 +184,7 @@
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>The cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>
@@ -240,26 +207,16 @@
       <Docs>
         <summary>Gets or sets a value indicating whether *direct access* to the WMI provider is requested for the specified class, without any regard to its super class or derived classes.</summary>
         <value>
-          <see langword="true" /> if *direct access* to the WMI provider is requested for the specified class; otherwise, <see langword="false" />.</value>
+          <see langword="true" /> if only objects of the specified class should be received, without regard to derivation or inheritance; otherwise, <see langword="false" />. The default value is <see langword="false" />.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if only objects of the specified class should be received, without regard to derivation or inheritance; otherwise, `false`. The default value is `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example initializes an <xref:System.Management.EnumerationOptions> variable with an <xref:System.Management.EnumerationOptions> constructor and then gets all the instances of a WMI class and its subclasses.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example initializes an <xref:System.Management.EnumerationOptions> variable with an <xref:System.Management.EnumerationOptions> constructor and then gets all the instances of a WMI class and its subclasses.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_EnumerationOptions_DirectRead/cs/EnumerationOptions_DirectRead.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/EnumerationOptions/DirectRead/EnumerationOptions_DirectRead.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/EnumerationOptions/DirectRead/EnumerationOptions_DirectRead.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -283,20 +240,8 @@
       <Docs>
         <summary>Gets or sets a value indicating whether to the objects returned should have locatable information in them. This ensures that the system properties, such as **__PATH**, **__RELPATH**, and **__SERVER**, are non-NULL. This flag can only be used in queries, and is ignored in enumerations.</summary>
         <value>
-          <see langword="true" /> if the objects returned should have locatable information in them; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if WMI should ensure all returned objects have valid paths; otherwise, `false`. The default value is `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+          <see langword="true" /> if the returned objects have valid paths; otherwise, <see langword="false" />. The default value is <see langword="false" />.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EnumerateDeep">
@@ -318,26 +263,16 @@
       <Docs>
         <summary>Gets or sets a value indicating whether recursive enumeration is requested into all classes derived from the specified superclass. If <see langword="false" />, only immediate derived class members are returned.</summary>
         <value>
-          <see langword="true" /> if recursive enumeration is requested into all classes derived from the specified superclass; otherwise, <see langword="false" />.</value>
+          <see langword="true" /> if recursive enumeration is requested into all classes derived from the specified superclass; otherwise, <see langword="false" />. The default value is <see langword="false" />.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if recursive enumeration is requested into all classes derived from the specified superclass; otherwise, `false`. The default value is `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example initializes an <xref:System.Management.EnumerationOptions> variable with an <xref:System.Management.EnumerationOptions> constructor and then gets all the instances of a WMI class and its subclasses.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example initializes an <xref:System.Management.EnumerationOptions> variable with an <xref:System.Management.EnumerationOptions> constructor and then gets all the instances of a WMI class and its subclasses.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_EnumerationOptions_EnumerateDeep/cs/EnumerationOptions_EnumerateDeep.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/EnumerationOptions/EnumerateDeep/EnumerationOptions_EnumerateDeep.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/EnumerationOptions/EnumerateDeep/EnumerationOptions_EnumerateDeep.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -361,20 +296,8 @@
       <Docs>
         <summary>Gets or sets a value indicating whether the query should return a prototype of the result set instead of the actual results. This flag is used for prototyping.</summary>
         <value>
-          <see langword="true" /> if the query should return a prototype of the result set instead of the actual results; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if the query should return a prototype of the result set instead of the actual results; otherwise, `false`. The default value is `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+          <see langword="true" /> if the query should return a prototype of the result set instead of the actual results; otherwise, <see langword="false" />. The default value is <see langword="false" />.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ReturnImmediately">
@@ -396,20 +319,8 @@
       <Docs>
         <summary>Gets or sets a value indicating whether the invoked operation should be performed in a synchronous or semisynchronous fashion. If this property is set to <see langword="true" />, the enumeration is invoked and the call returns immediately. The actual retrieval of the results will occur when the resulting collection is walked.</summary>
         <value>
-          <see langword="true" /> if the invoked operation should be performed in a synchronous or semisynchronous fashion; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if the invoked operation should be performed in a synchronous or semisynchronous fashion; otherwise, `false`. The default value is `true`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+          <see langword="true" /> if the invoked operation should be performed in a synchronous or semisynchronous fashion; otherwise, <see langword="false" />. The default value is <see langword="true" />.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Rewindable">
@@ -431,20 +342,8 @@
       <Docs>
         <summary>Gets or sets a value indicating whether the collection is assumed to be rewindable. If <see langword="true" />, the objects in the collection will be kept available for multiple enumerations. If <see langword="false" />, the collection can only be enumerated one time.</summary>
         <value>
-          <see langword="true" /> if the collection is assumed to be rewindable; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if the collection is assumed to be rewindable; otherwise, `false`. The default value is `true`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+          <see langword="true" /> if the collection is assumed to be rewindable; otherwise, <see langword="false" />. The default value is <see langword="true" />.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UseAmendedQualifiers">
@@ -466,21 +365,8 @@
       <Docs>
         <summary>Gets or sets a value indicating whether the objects returned from WMI should contain amended information. Typically, amended information is localizable information attached to the WMI object, such as object and property descriptions.</summary>
         <value>
-          <see langword="true" /> if the objects returned from WMI should contain amended information; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- If descriptions and other amended information are not of interest, setting this property value to `false` is more efficient.  
-  
-## Property Value  
- `true` if the objects returned from WMI should contain amended information; otherwise, `false`. The default value is `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+          <see langword="true" /> if the objects returned from WMI should contain amended information; otherwise, <see langword="false" />. The default value is <see langword="false" />.</value>
+        <remarks>If descriptions and other amended information are not of interest, setting this property value to `false` is more efficient.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/EventArrivedEventArgs.xml
+++ b/xml/System.Management/EventArrivedEventArgs.xml
@@ -26,14 +26,14 @@
   <Docs>
     <summary>Holds event data for the <see cref="E:System.Management.ManagementEventWatcher.EventArrived" /> event.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The following asynchronous example sets up a WMI timer to raise an event every second, and removes it when no longer needed. The <xref:System.Management.ManagementEventWatcher> defines several .NET Framework events which are raised when WMI events are delivered. Delegates are attached to these events for handling the incoming data.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Remarks
+ The following asynchronous example sets up a WMI timer to raise an event every second, and removes it when no longer needed. The <xref:System.Management.ManagementEventWatcher> defines several .NET events that are raised when WMI events are delivered. Delegates are attached to these events for handling the incoming data.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_EventArrivedEventArgs/cs/EventArrivedEventArgs.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/EventArrivedEventArgs/Overview/EventArrivedEventArgs.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/EventArrivedEventArgs/Overview/EventArrivedEventArgs.vb" id="Snippet1":::
+
  ]]></format>
     </remarks>
   </Docs>
@@ -57,19 +57,7 @@
       <Docs>
         <summary>Gets the WMI event that was delivered.</summary>
         <value>The delivered WMI event.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- The object representing the WMI event.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/EventArrivedEventHandler.xml
+++ b/xml/System.Management/EventArrivedEventHandler.xml
@@ -34,14 +34,14 @@
     <param name="e">The <see cref="T:System.Management.EventArrivedEventArgs" /> that specifies the reason the event was invoked.</param>
     <summary>Represents the method that will handle the <see cref="E:System.Management.ManagementEventWatcher.EventArrived" /> event.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Examples  
- The following asynchronous example sets up a WMI timer to raise an event every second, and removes it when no longer needed. The <xref:System.Management.ManagementEventWatcher> defines several .NET Framework events which are raised when WMI events are delivered. Delegates are attached to these events for handling the incoming data.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following asynchronous example sets up a WMI timer to raise an event every second, and removes it when no longer needed. The <xref:System.Management.ManagementEventWatcher> defines several .NET events which are raised when WMI events are delivered. Delegates are attached to these events for handling the incoming data.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_EventArrivedEventHandler/cs/EventArrivedEventHandler.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/EventArrivedEventHandler/Overview/EventArrivedEventHandler.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/EventArrivedEventHandler/Overview/EventArrivedEventHandler.vb" id="Snippet1":::
+
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Management/EventQuery.xml
+++ b/xml/System.Management/EventQuery.xml
@@ -65,13 +65,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
@@ -103,13 +96,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.EventQuery" /> class for the specified query.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
@@ -145,13 +131,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
@@ -182,16 +161,7 @@
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>The cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>

--- a/xml/System.Management/EventWatcherOptions.xml
+++ b/xml/System.Management/EventWatcherOptions.xml
@@ -65,13 +65,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
@@ -108,13 +101,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
@@ -143,19 +129,9 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the block size for block operations. When waiting for events, this value specifies how many events to wait for before returning.</summary>
-        <value>An integer value indicating the block size for a block of operations.</value>
+        <value>An integer value indicating the block size for a block of operations. The default value is 1.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The default value is 1.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
@@ -187,16 +163,7 @@
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>The cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>

--- a/xml/System.Management/InvokeMethodOptions.xml
+++ b/xml/System.Management/InvokeMethodOptions.xml
@@ -26,14 +26,14 @@
   <Docs>
     <summary>Specifies options for invoking a management method.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Examples  
- The following example invokes the **Win32_Process::Create** method to start a new process of Calc.exe. The <xref:System.Management.InvokeMethodOptions> class is used to invoke the method.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example invokes the **Win32_Process::Create** method to start a new process of Calc.exe. The <xref:System.Management.InvokeMethodOptions> class is used to invoke the method.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_InvokeMethodOptions/cs/InvokeMethodOptions.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/InvokeMethodOptions/Overview/InvokeMethodOptions.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/InvokeMethodOptions/Overview/InvokeMethodOptions.vb" id="Snippet1":::
+
  ]]></format>
     </remarks>
   </Docs>
@@ -63,21 +63,14 @@
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.InvokeMethodOptions" /> class for the <see cref="M:System.Management.ManagementObject.InvokeMethod(System.String,System.Object[])" /> operation, using default values. This is the parameterless constructor.</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example invokes the **Win32_Process::Create** method to start a new process of Calc.exe. The parameterless constructor of the <xref:System.Management.InvokeMethodOptions> class is used.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example invokes the **Win32_Process::Create** method to start a new process of Calc.exe. The parameterless constructor of the <xref:System.Management.InvokeMethodOptions> class is used.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_InvokeMethodOptions-1/cs/InvokeMethodOptions-1.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/InvokeMethodOptions/.ctor/InvokeMethodOptions-1.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/InvokeMethodOptions/.ctor/InvokeMethodOptions-1.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -104,21 +97,14 @@
         <param name="timeout">The length of time to let the operation perform before it times out. The default value is <see cref="F:System.TimeSpan.MaxValue">TimeSpan.MaxValue</see>. Setting this parameter will invoke the operation semisynchronously.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.InvokeMethodOptions" /> class for an invoke operation using the specified values.</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example invokes the **Win32_Process::Create** method to start a new process of Calc.exe. The <xref:System.Management.InvokeMethodOptions> class is used to invoke the method.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example invokes the **Win32_Process::Create** method to start a new process of Calc.exe. The <xref:System.Management.InvokeMethodOptions> class is used to invoke the method.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_InvokeMethodOptions-2/cs/InvokeMethodOptions-2.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/InvokeMethodOptions/.ctor/InvokeMethodOptions-2.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/InvokeMethodOptions/.ctor/InvokeMethodOptions-2.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -143,16 +129,7 @@
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>The cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>

--- a/xml/System.Management/ManagementBaseObject.xml
+++ b/xml/System.Management/ManagementBaseObject.xml
@@ -72,16 +72,7 @@
         <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> to populate with data.</param>
         <param name="context">The destination (see <see cref="T:System.Runtime.Serialization.StreamingContext" /> ) for this serialization.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementBaseObject" /> class that is serializable.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClassPath">
@@ -105,16 +96,6 @@
         <value>The class path to the management object's class.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- A <xref:System.Management.ManagementPath> that represents the path to the management object's class.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example code lists all the classes with their class paths in the root\CIMV2 namespace.
@@ -151,16 +132,7 @@
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>The new cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>
@@ -190,16 +162,7 @@
         <summary>Compares this object to another, based on specified options.</summary>
         <returns>
           <see langword="true" /> if the objects compared are equal according to the given options; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Dispose">
@@ -248,16 +211,7 @@
         <summary>Compares two management objects.</summary>
         <returns>
           <see langword="true" /> if this is an instance of <see cref="T:System.Management.ManagementBaseObject" /> and represents the same object as this instance; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -280,16 +234,7 @@
       <Docs>
         <summary>Serves as a hash function for a particular type, suitable for use in hashing algorithms and data structures like a hash table.</summary>
         <returns>A hash code for the current object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetObjectData">
@@ -316,16 +261,7 @@
         <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> to populate with data.</param>
         <param name="context">The destination (see <see cref="T:System.Runtime.Serialization.StreamingContext" /> ) for this serialization.</param>
         <summary>Populates a <see cref="T:System.Runtime.Serialization.SerializationInfo" /> with the data necessary to deserialize the field represented by this instance.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetPropertyQualifierValue">
@@ -355,13 +291,6 @@
         <returns>The value of the specified qualifier.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example uses the <xref:System.Management.ManagementBaseObject.GetPropertyQualifierValue*> method to display the value of the **Description** qualifier for each of the properties in the **Win32_Process** class. For more information on the **Win32_Process** class, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
@@ -399,13 +328,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example lists all the names of the processes running on the local computer. The code uses the <xref:System.Management.ManagementBaseObject.GetPropertyValue*> method to get the process names.
 
@@ -441,13 +363,6 @@
         <returns>The value of the specified qualifier.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example displays the **Win32_Process** class description by using the <xref:System.Management.ManagementBaseObject.GetQualifierValue*> method. For more information on the **Win32_Process** class, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
@@ -486,12 +401,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Currently, the only format that WMI supports is *Managed Object Format* (MOF). In the future, other formats will be supported, such as Extensible Markup Language (XML).
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
+ Currently, the only format that WMI supports is *Managed Object Format* (MOF)
 
 ## Examples
  The following example displays the MOF code for the **Win32_Process** class by using the <xref:System.Management.ManagementBaseObject.GetText*> method. For more information about the **Win32_Process** class, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
@@ -524,20 +434,14 @@
       </Parameters>
       <Docs>
         <param name="propertyName">The name of the property of interest.</param>
-        <summary>Gets access to property values through [] notation. This property is the indexer for the <see cref="T:System.Management.ManagementBaseObject" /> class. You can use the default indexed properties defined by a type, but you cannot explicitly define your own. However, specifying the **expando** attribute on a class automatically provides a default indexed property whose type is Object and whose index type is String.</summary>
-        <value>The management object for a specific class property.</value>
+        <summary>Gets or sets the value of the specified property of the WMI class represented by this <see cref="T:System.Management.ManagementBaseObject" /> instance.</summary>
+        <value>The value of the specified class property.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
 
-## Property Value
- An object instance that contains the value of the requested property.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
+This property provides access to property values through [] notation. This property is the indexer for the <see cref="T:System.Management.ManagementBaseObject" /> class. You can use the default indexed properties defined by a type, but you cannot explicitly define your own. However, specifying the **expando** attribute on a class automatically provides a default indexed property whose type is Object and whose index type is String.
 
 ## Examples
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor and then get all the instances of a WMI class.
@@ -578,9 +482,6 @@
 ## Remarks
  This operator is used internally by instrumentation code. It is not intended for direct use by regular client or instrumented applications.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -606,16 +507,6 @@
         <value>A collection that holds the properties for the management object.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- A <xref:System.Management.PropertyDataCollection> that represents the properties of the management object.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example uses the <xref:System.Management.ManagementBaseObject.Properties> property to display the value of the **Description** qualifier for each of the properties in the **Win32_Process** class.  For more information on the **Win32_Process** class, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
@@ -649,16 +540,6 @@
         <value>A collection that holds the qualifiers for the management object.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- A <xref:System.Management.QualifierDataCollection> that represents the qualifiers defined on the management object.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example uses the <xref:System.Management.ManagementBaseObject.Qualifiers> property to display the value of the **Description** qualifier for each of the properties in the **Win32_Process** class.  For more information on the **Win32_Process** class, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
@@ -697,16 +578,7 @@
         <param name="qualifierName">The name of the property qualifier of interest.</param>
         <param name="qualifierValue">The new value for the qualifier.</param>
         <summary>Sets the value of the specified property qualifier.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetPropertyValue">
@@ -733,16 +605,7 @@
         <param name="propertyName">The name of the property to be changed.</param>
         <param name="propertyValue">The new value for this property.</param>
         <summary>Sets the value of the named property.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetQualifierValue">
@@ -769,16 +632,7 @@
         <param name="qualifierName">The name of the qualifier to set. This parameter cannot be null.</param>
         <param name="qualifierValue">The value to set.</param>
         <summary>Sets the value of the named qualifier.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Runtime.Serialization.ISerializable.GetObjectData">
@@ -835,18 +689,9 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## Property Value
- A <xref:System.Management.PropertyDataCollection> that represents the system properties of the management object.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
- The following example uses the <xref:System.Management.ManagementBaseObject.SystemProperties> property to display the name and value of the system properties for the **Win32_Process** class. For more information on the **Win32_Process** class, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
+
+The following example uses the <xref:System.Management.ManagementBaseObject.SystemProperties> property to display the name and value of the system properties for the **Win32_Process** class. For more information on the **Win32_Process** class, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementBaseObject_SystemProperties/cs/ManagementBaseObject_SystemProperties.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementBaseObject/SystemProperties/ManagementBaseObject_SystemProperties.vb" id="Snippet1":::

--- a/xml/System.Management/ManagementBaseObject.xml
+++ b/xml/System.Management/ManagementBaseObject.xml
@@ -401,7 +401,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Currently, the only format that WMI supports is *Managed Object Format* (MOF)
+ Currently, the only format that WMI supports is *Managed Object Format* (MOF).
 
 ## Examples
  The following example displays the MOF code for the **Win32_Process** class by using the <xref:System.Management.ManagementBaseObject.GetText*> method. For more information about the **Win32_Process** class, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.

--- a/xml/System.Management/ManagementClass.xml
+++ b/xml/System.Management/ManagementClass.xml
@@ -35,16 +35,7 @@
       </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementClass" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </MemberGroup>
     <Member MemberName=".ctor">
@@ -64,13 +55,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementClass" /> class. This is the parameterless constructor.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example is an example of how to initialize a <xref:System.Management.ManagementClass> variable with the <xref:System.Management.ManagementClass> parameterless constructor. The example lists the methods, properties, and qualifiers for the created class.
@@ -99,18 +83,14 @@
         <Parameter Name="path" Type="System.Management.ManagementPath" />
       </Parameters>
       <Docs>
-        <param name="path">A <see cref="T:System.Management.ManagementPath" /> specifying the WMI class to which to bind. The parameter must specify a WMI class path. The class represents a CIM management class from WMI. CIM classes represent management information including hardware, software, processes, and so on. For more information about the CIM classes available in Windows, see <see href="https://learn.microsoft.com/windows/win32/wmisdk/cimclas">CIM Classes</see>.</param>
+        <param name="path">The WMI class to which to bind. The parameter must specify a WMI class path. </param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementClass" /> class. The class represents a Common Information Model (CIM) management class from WMI such as **Win32_LogicalDisk**, which can represent a disk drive, and **Win32_Process**, which represents a process such as Notepad.exe.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The `path` parameter must specify a WMI class path.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
+The class represents a CIM management class from WMI. CIM classes represent management information including hardware, software, processes, and so on. For more information about the CIM classes available in Windows, see [CIM Classes](https://learn.microsoft.com/windows/win32/wmisdk/cimclas").
 
 ## Examples
  The following example is an example of how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor. The example lists the methods, properties, and qualifiers for the created class.
@@ -143,13 +123,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementClass" /> class initialized to the given path. The class represents a Common Information Model (CIM) management class from WMI such as **Win32_LogicalDisk**, which can represent a disk drive, and **Win32_Process**, which represents a process such as Notepad.exe.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor. The example lists the methods, properties, and qualifiers for the created class.
@@ -184,13 +157,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementClass" /> class initialized to the given WMI class path using the specified options. The class represents a Common Information Model (CIM) management class from WMI such as **Win32_LogicalDisk**, which can represent a disk drive, and **Win32_Process**, which represents a process such as Notepad.exe.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example is an example of how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor. The example lists the methods, properties, and qualifiers (including the amended qualifiers) for the created class.
@@ -233,16 +199,7 @@
         <param name="info">An instance of the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> class containing the information required to serialize the new <see cref="T:System.Management.ManagementClass" />.</param>
         <param name="context">An instance of the <see cref="T:System.Runtime.Serialization.StreamingContext" /> class containing the source of the serialized stream associated with the new <see cref="T:System.Management.ManagementClass" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementClass" /> class from the specified instances of the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> and <see cref="T:System.Runtime.Serialization.StreamingContext" /> classes.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -268,13 +225,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementClass" /> class initialized to the given WMI class path using the specified options. The class represents a Common Information Model (CIM) management class from WMI such as **Win32_LogicalDisk**, which can represent a disk drive, and **Win32_Process**, which represents a process such as Notepad.exe.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor. The example lists the methods, properties, and qualifiers (including the amended qualifiers) for the created class.
@@ -315,11 +265,6 @@
 ## Remarks
  The path can be specified as a full path (including server and namespace). However, if a scope is specified, it will override the first portion of the full path.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example is an example of how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor. The example lists the methods, properties, and qualifiers (including the amended qualifiers) for the created class. You must change the scope (namespace) in the code for the example to run correctly on your computer.
 
@@ -359,11 +304,6 @@
 ## Remarks
  The path can be specified as a full path (including server and namespace). However, if a scope is specified, it will override the first portion of the full path.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor. The example lists the methods, properties, and qualifiers (including the amended qualifiers) for the created class. You must change the scope (namespace) in the code for the example to run correctly on your computer.
 
@@ -398,10 +338,8 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Note that this does not create a copy of the WMI class; only an additional representation is created.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
+This method doesn't create a copy of the WMI class; only an additional representation is created.
 
  ]]></format>
         </remarks>
@@ -431,12 +369,8 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Note that the new instance is not committed until the <xref:System.Management.ManagementObject.Put*>() method is called. Before committing it, the key properties must be specified.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
+The new instance is not committed until the <xref:System.Management.ManagementObject.Put*>() method is called. Before committing it, the key properties must be specified.
 
 ## Examples
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor and then create a new instance of a WMI class.
@@ -469,14 +403,6 @@
         <value>A string collection containing the names of all WMI classes in the inheritance hierarchy of this class.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property is read-only.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor and then get all the classes in the inheritance hierarchy from the WMI class passed into the constructor, to the top of the hierarchy.
@@ -515,12 +441,8 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Note that the newly returned class has not been committed until the <xref:System.Management.ManagementObject.Put*>() method is explicitly called.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
+The newly returned class has not been committed until the <xref:System.Management.ManagementObject.Put*>() method is explicitly called.
 
 ## Examples
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor and then create a derived instance of a WMI class.
@@ -539,16 +461,7 @@
       </AssemblyInfo>
       <Docs>
         <summary>Returns the collection of all instances of the class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </MemberGroup>
     <Member MemberName="GetInstances">
@@ -574,14 +487,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor and then get all the instances of a WMI class.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementClass_GetInstances/cs/ManagementClass_GetInstances.cs" id="Snippet1":::
@@ -617,14 +524,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor and then get all the instances of a WMI class and its subclasses.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementClass_GetInstances-E/cs/ManagementClass_GetInstances-E.cs" id="Snippet1":::
@@ -659,14 +560,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor and then get all the instances of a WMI class asynchronously.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementClass_GetInstances-M/cs/ManagementClass_GetInstances-M.cs" id="Snippet1":::
@@ -700,16 +595,7 @@
         <param name="watcher">The object to handle the asynchronous operation's progress.</param>
         <param name="options">The specified additional options for getting the instances.</param>
         <summary>Returns the collection of all instances of the class, asynchronously, using the specified options.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetObjectData">
@@ -736,16 +622,7 @@
         <param name="info">The object to be populated with serialization information.</param>
         <param name="context">The location where serialized data will be stored and retrieved.</param>
         <summary>Populates a <see cref="T:System.Runtime.Serialization.SerializationInfo" /> with the data necessary to deserialize the field represented by this instance.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <MemberGroup MemberName="GetRelatedClasses">
@@ -755,16 +632,7 @@
       </AssemblyInfo>
       <Docs>
         <summary>Retrieves classes related to the WMI class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </MemberGroup>
     <Member MemberName="GetRelatedClasses">
@@ -791,12 +659,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The method queries the WMI schema for all possible associations that the WMI class may have with other classes, or in rare cases, to instances. For more information about related classes, see [ASSOCIATORS OF Statement](/windows/win32/wmisdk/associators-of-statement).
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
+ The method queries the WMI schema for all possible associations that the WMI class might have with other classes, or in rare cases, to instances. For more information about related classes, see [ASSOCIATORS OF Statement](/windows/win32/wmisdk/associators-of-statement).
 
 ## Examples
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor and then list all the classes related to the WMI class passed into the constructor.
@@ -830,16 +693,7 @@
       <Docs>
         <param name="watcher">The object to handle the asynchronous operation's progress.</param>
         <summary>Retrieves classes related to the WMI class, asynchronously.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetRelatedClasses">
@@ -865,16 +719,7 @@
         <param name="relatedClass">The class from which resulting classes have to be derived.</param>
         <summary>Retrieves classes related to the WMI class.</summary>
         <returns>A collection of classes related to this class.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetRelatedClasses">
@@ -901,16 +746,7 @@
         <param name="watcher">The object to handle the asynchronous operation's progress.</param>
         <param name="relatedClass">The name of the related class.</param>
         <summary>Retrieves classes related to the WMI class, asynchronously, given the related class name.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetRelatedClasses">
@@ -951,14 +787,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example uses the <xref:System.Management.ManagementClass.GetRelatedClasses*> method to list the related classes to the **CIM_LogicalDisk** class. For more information, see [CIM_LogicalDisk](/windows/win32/cimwin32prov/cim-logicaldisk).
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementClass_GetRelatedClasses-7/cs/ManagementClass_GetRelatedClasses-7.cs" id="Snippet1":::
@@ -1004,16 +834,7 @@
         <param name="thisRole">The source class must have this role in the relationship.</param>
         <param name="options">The options for retrieving the resulting classes.</param>
         <summary>Retrieves classes related to the WMI class, asynchronously, using the specified options.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <MemberGroup MemberName="GetRelationshipClasses">
@@ -1023,16 +844,7 @@
       </AssemblyInfo>
       <Docs>
         <summary>Retrieves relationship classes that relate the class to others.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </MemberGroup>
     <Member MemberName="GetRelationshipClasses">
@@ -1058,14 +870,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example uses the <xref:System.Management.ManagementClass.GetRelationshipClasses*> method to list the relationship classes to the **CIM_LogicalDisk** class. For more information, see [CIM_LogicalDisk](/windows/win32/cimwin32prov/cim-logicaldisk).
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementClass_GetRelationshipClasses/cs/ManagementClass_GetRelationshipClasses.cs" id="Snippet1":::
@@ -1097,16 +903,7 @@
       <Docs>
         <param name="watcher">The object to handle the asynchronous operation's progress.</param>
         <summary>Retrieves relationship classes that relate the class to others, asynchronously.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetRelationshipClasses">
@@ -1132,16 +929,7 @@
         <param name="relationshipClass">The endpoint class for all relationship classes returned.</param>
         <summary>Retrieves relationship classes that relate the class to others, where the endpoint class is the specified class.</summary>
         <returns>A collection of *association classes* that relate the class to the specified class. For more information about relationship classes, <see href="https://learn.microsoft.com/windows/win32/wmisdk/associators-of-statement">ASSOCIATORS OF Statement</see>.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetRelationshipClasses">
@@ -1173,9 +961,6 @@
 
 ## Remarks
  For more information about relationship classes, see [ASSOCIATORS OF Statement](/windows/win32/wmisdk/associators-of-statement).
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
 
  ]]></format>
         </remarks>
@@ -1210,16 +995,7 @@
         <param name="options">Specifies options for retrieving the results.</param>
         <summary>Retrieves relationship classes that relate this class to others, according to specified options.</summary>
         <returns>A collection of *association classes* that relate this class to others, according to the specified options. For more information about relationship classes, <see href="https://learn.microsoft.com/windows/win32/wmisdk/associators-of-statement">ASSOCIATORS OF Statement</see>.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetRelationshipClasses">
@@ -1252,16 +1028,7 @@
         <param name="thisRole">The role that the source class must have in the resulting relationship classes.</param>
         <param name="options">The options for retrieving the results.</param>
         <summary>Retrieves relationship classes that relate the class according to the specified options, asynchronously.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <MemberGroup MemberName="GetStronglyTypedClassCode">
@@ -1271,16 +1038,7 @@
       </AssemblyInfo>
       <Docs>
         <summary>Generates a strongly-typed class for a given WMI class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </MemberGroup>
     <Member MemberName="GetStronglyTypedClassCode">
@@ -1313,14 +1071,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example generates a strongly-typed class for the **Win32_LogicalDisk** class. The generated code is produced in C# or Visual Basic .NET.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementClass_GetStronglyTypedClassCode-2/cs/ManagementClass_GetStronglyTypedClassCode-2.cs" id="Snippet1":::
@@ -1361,14 +1113,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example generates a strongly-typed class for the **Win32_LogicalDisk** class. The generated code is in C# for the C# example and Visual Basic .NET for the Visual Basic .NET example.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementClass_GetStronglyTypedClassCode-3/cs/ManagementClass_GetStronglyTypedClassCode-3.cs" id="Snippet1":::
@@ -1385,16 +1131,7 @@
       </AssemblyInfo>
       <Docs>
         <summary>Returns the collection of all derived classes for the class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </MemberGroup>
     <Member MemberName="GetSubclasses">
@@ -1420,14 +1157,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example uses the <xref:System.Management.ManagementClass.GetSubclasses*> method to list the subclasses to the **CIM_LogicalDisk** class. For more information, see [CIM_LogicalDisk](/windows/win32/cimwin32prov/cim-logicaldisk).
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementClass_GetSubClasses/cs/ManagementClass_GetSubclasses.cs" id="Snippet1":::
@@ -1463,14 +1194,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor and then receive the subclasses of the WMI class passed into the constructor.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementClass_GetSubClasses-E/cs/ManagementClass_GetSubclasses-E.cs" id="Snippet1":::
@@ -1502,16 +1227,7 @@
       <Docs>
         <param name="watcher">The object to handle the asynchronous operation's progress.</param>
         <summary>Returns the collection of all classes derived from this class, asynchronously.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetSubclasses">
@@ -1538,16 +1254,7 @@
         <param name="watcher">The object to handle the asynchronous operation's progress.</param>
         <param name="options">The specified additional options to use in the derived class retrieval.</param>
         <summary>Retrieves all classes derived from this class, asynchronously, using the specified options.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Methods">
@@ -1572,14 +1279,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor and then get all the methods in the WMI class passed into the constructor.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementClass_Methods/cs/ManagementClass_Methods.cs" id="Snippet1":::
@@ -1612,12 +1313,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- When the property is set to a new value, the <xref:System.Management.ManagementClass> will be disconnected from any previously-bound WMI class. Reconnect to the new WMI class path.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
+ When the property is set to a new value, the <xref:System.Management.ManagementClass> will be disconnected from any previously bound WMI class. Reconnect to the new WMI class path.
 
 ## Examples
  The following example shows how to initialize a <xref:System.Management.ManagementClass> variable with a <xref:System.Management.ManagementClass> constructor and then get all the methods in the WMI class passed into the constructor.

--- a/xml/System.Management/ManagementDateTimeConverter.xml
+++ b/xml/System.Management/ManagementDateTimeConverter.xml
@@ -136,7 +136,7 @@ The resulting DMTF datetime string is based on the UTC offset of the current tim
 
 ## Remarks
 
-The lowest precision in DMTF is microseconds; in <xref:System.TimeSpan>, the lowest precision is <xref:System.TimeSpan.Ticks*>, which is equivalent to 100 nanoseconds. During conversion, <xref:System.TimeSpan.Ticks*> are converted to microseconds and rounded off to the nearest microsecond
+The lowest precision in DMTF is microseconds; in <xref:System.TimeSpan>, the lowest precision is <xref:System.TimeSpan.Ticks*>, which is equivalent to 100 nanoseconds. During conversion, <xref:System.TimeSpan.Ticks*> are converted to microseconds and rounded off to the nearest microsecond.
 
 ## Examples
  The following example converts a given <xref:System.TimeSpan> to DMTF time interval.

--- a/xml/System.Management/ManagementDateTimeConverter.xml
+++ b/xml/System.Management/ManagementDateTimeConverter.xml
@@ -96,7 +96,7 @@ A DMTF datetime string has an UTC offset, which this datetime string represents.
 
 ## Remarks
 
-The resulting DMTF datetime string is based on the UTC offset of the current time zone. The lowest precision in DMTF is microseconds; in <xref:System.DateTime>, the lowest precision is <xref:System.DateTime.Ticks*>, which are equivalent to 100 nanoseconds. During conversion, <xref:System.DateTime.Ticks*> are converted to microseconds and rounded off to the nearest microsecond
+The resulting DMTF datetime string is based on the UTC offset of the current time zone. The lowest precision in DMTF is microseconds; in <xref:System.DateTime>, the lowest precision is <xref:System.DateTime.Ticks*>, which are equivalent to 100 nanoseconds. During conversion, <xref:System.DateTime.Ticks*> are converted to microseconds and rounded off to the nearest microsecond.
 
 ## Examples
  The following example converts a given <xref:System.DateTime> to DMTF datetime format.

--- a/xml/System.Management/ManagementDateTimeConverter.xml
+++ b/xml/System.Management/ManagementDateTimeConverter.xml
@@ -58,9 +58,6 @@
 
 A DMTF datetime string has an UTC offset, which this datetime string represents. During conversion to <xref:System.DateTime>, the UTC offset is used to convert the date to the current time zone. According to DMTF format, a particular field can be represented by the character '*'. This will be converted to the minimum value of this field that can be represented in <xref:System.DateTime>.
 
-## .NET Framework security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
 ## Examples
  The following example converts a DMTF datetime string into a <xref:System.DateTime>.
 
@@ -99,10 +96,7 @@ A DMTF datetime string has an UTC offset, which this datetime string represents.
 
 ## Remarks
 
-The resulting DMTF datetime string is based on the UTC offset of the current time zone. The lowest precision in DMTF is microseconds; in <xref:System.DateTime>, the lowest precision is <xref:System.DateTime.Ticks*>, which are equivalent to 100 nanoseconds. During conversion, <xref:System.DateTime.Ticks*> are converted to microseconds and rounded off to the nearest microsecond.
-
-## .NET Framework security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
+The resulting DMTF datetime string is based on the UTC offset of the current time zone. The lowest precision in DMTF is microseconds; in <xref:System.DateTime>, the lowest precision is <xref:System.DateTime.Ticks*>, which are equivalent to 100 nanoseconds. During conversion, <xref:System.DateTime.Ticks*> are converted to microseconds and rounded off to the nearest microsecond
 
 ## Examples
  The following example converts a given <xref:System.DateTime> to DMTF datetime format.
@@ -142,10 +136,7 @@ The resulting DMTF datetime string is based on the UTC offset of the current tim
 
 ## Remarks
 
-The lowest precision in DMTF is microseconds; in <xref:System.TimeSpan>, the lowest precision is <xref:System.TimeSpan.Ticks*>, which is equivalent to 100 nanoseconds. During conversion, <xref:System.TimeSpan.Ticks*> are converted to microseconds and rounded off to the nearest microsecond.
-
-## .NET Framework security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
+The lowest precision in DMTF is microseconds; in <xref:System.TimeSpan>, the lowest precision is <xref:System.TimeSpan.Ticks*>, which is equivalent to 100 nanoseconds. During conversion, <xref:System.TimeSpan.Ticks*> are converted to microseconds and rounded off to the nearest microsecond
 
 ## Examples
  The following example converts a given <xref:System.TimeSpan> to DMTF time interval.
@@ -182,9 +173,6 @@ The lowest precision in DMTF is microseconds; in <xref:System.TimeSpan>, the low
         <returns>A <see cref="T:System.TimeSpan" /> that represents the given DMTF time interval.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## .NET Framework security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
 
 ## Examples
  The following example converts a given DMTF time interval to <xref:System.TimeSpan>.

--- a/xml/System.Management/ManagementEventArgs.xml
+++ b/xml/System.Management/ManagementEventArgs.xml
@@ -46,20 +46,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the operation context echoed back from the operation that triggered the event.</summary>
-        <value>The operation context.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- WMI context object containing context information provided by the operation that triggered the event.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value>The operation context information.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/ManagementEventWatcher.xml
+++ b/xml/System.Management/ManagementEventWatcher.xml
@@ -71,14 +71,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementEventWatcher/cs/ManagementEventWatcher.cs" id="Snippet1":::
@@ -112,11 +106,6 @@
 
 ## Remarks
  The namespace in which the watcher will be listening for events is the default namespace that is currently set.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  In this code example, the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
@@ -153,11 +142,6 @@
 ## Remarks
  The namespace in which the watcher will be listening for events is the default namespace that is currently set.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
@@ -192,14 +176,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  In this code example, the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementEventWatcher-M_E/cs/ManagementEventWatcher-M_E.cs" id="Snippet1":::
@@ -233,14 +211,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementEventWatcher-S_S/cs/ManagementEventWatcher-S_S.cs" id="Snippet1":::
@@ -276,14 +248,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementEventWatcher-M_E_E/cs/ManagementEventWatcher-M_E_E.cs" id="Snippet1":::
@@ -319,14 +285,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementEventWatcher-S_S_E/cs/ManagementEventWatcher-S_S_E.cs" id="Snippet1":::
@@ -367,9 +327,6 @@
 |<xref:System.Management.ManagementEventArgs.Context*> (inherited from <xref:System.Management.ManagementEventArgs>)|Gets the operation context echoed back from the operation that triggered the event.|
 |<xref:System.Management.EventArrivedEventArgs.NewEvent*>|Gets the WMI event that was delivered.|
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -393,16 +350,7 @@
       <Parameters />
       <Docs>
         <summary>Ensures that outstanding calls are cleared. This is the destructor for the object. In C#, finalizers are expressed using destructor syntax.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Options">
@@ -426,16 +374,6 @@
         <value>The event options used to watch for events.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The options used to watch for events.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
@@ -469,16 +407,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## Property Value
- The criteria to apply to the events, which is equal to the *event query*.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
@@ -511,16 +439,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## Property Value
- The scope in which to watch for events (namespace or scope).
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
@@ -550,16 +468,7 @@
       <Parameters />
       <Docs>
         <summary>Subscribes to events with the given query and delivers them, asynchronously, through the <see cref="E:System.Management.ManagementEventWatcher.EventArrived" /> event.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Stop">
@@ -584,14 +493,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementEventWatcher_Stop/cs/ManagementEventWatcher_Stop.cs" id="Snippet1":::
@@ -632,9 +535,6 @@
 |<xref:System.Management.ManagementEventArgs.Context*> (inherited from <xref:System.Management.ManagementEventArgs>)|Gets the operation context echoed back from the operation that triggered the event.|
 |<xref:System.Management.StoppedEventArgs.Status*>|Gets the completion status of the operation.|
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -664,11 +564,6 @@
 
 ## Remarks
  If the event watcher object contains options with a specified time-out, the API will wait for the next event only for the specified amount of time; otherwise, the API will be blocked until the next event occurs.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example shows how the client receives notification when an instance of **Win32_Process** is created because the event class is **__InstanceCreationEvent**. For more information, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation. The client receives events synchronously by calling the <xref:System.Management.ManagementEventWatcher.WaitForNextEvent*> method. This example can be tested by starting a process, such as Notepad, while the example code is running.

--- a/xml/System.Management/ManagementException.xml
+++ b/xml/System.Management/ManagementException.xml
@@ -52,16 +52,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementException" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -117,16 +108,7 @@
         <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> to populate with data.</param>
         <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> destination for this serialization.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementException" /> class that is serializable.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -150,16 +132,7 @@
         <param name="message">The message that describes the error.</param>
         <param name="innerException">The exception that is the cause of the current exception.</param>
         <summary>Initializes an empty new instance of the <see cref="T:System.Management.ManagementException" /> class. If the <paramref name="innerException" /> parameter is not <see langword="null" />, the current exception is raised in a catch block that handles the inner exception.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ErrorCode">
@@ -181,19 +154,7 @@
       <Docs>
         <summary>Gets the error code reported by WMI, which caused this exception.</summary>
         <value>One of the enumeration values that indicates the error code.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A <xref:System.Management.ManagementStatus> value representing the error code returned by the WMI operation.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ErrorInformation">
@@ -214,20 +175,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the extended error object provided by WMI.</summary>
-        <value>The extended error information.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A <xref:System.Management.ManagementBaseObject> representing the extended error object provided by WMI, if available; `null` otherwise.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value>The extended error information, if available; otherwise, <c>null</c>.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetObjectData">
@@ -264,16 +213,7 @@
         <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> to populate with data.</param>
         <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> destination for this serialization.</param>
         <summary>Populates the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> with the data needed to serialize the <see cref="T:System.Management.ManagementException" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially-trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
       </Docs>
     </Member>

--- a/xml/System.Management/ManagementException.xml
+++ b/xml/System.Management/ManagementException.xml
@@ -175,7 +175,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the extended error object provided by WMI.</summary>
-        <value>The extended error information, if available; otherwise, <c>null</c>.</value>
+        <value>The extended error information, if available; otherwise, <see langword="null" />.</value>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/xml/System.Management/ManagementNamedValueCollection.xml
+++ b/xml/System.Management/ManagementNamedValueCollection.xml
@@ -52,16 +52,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementNamedValueCollection" /> class, which is empty. This is the parameterless constructor.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -95,16 +86,7 @@
         <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> to populate with data.</param>
         <param name="context">The destination (see <see cref="T:System.Runtime.Serialization.StreamingContext" /> ) for this serialization.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementNamedValueCollection" /> class that is serializable and uses the specified <see cref="T:System.Runtime.Serialization.SerializationInfo" /> and <see cref="T:System.Runtime.Serialization.StreamingContext" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -131,16 +113,7 @@
         <param name="name">The name of the new value.</param>
         <param name="value">The value to be associated with the name.</param>
         <summary>Adds a single-named value to the collection.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clone">
@@ -163,16 +136,7 @@
       <Docs>
         <summary>Creates a clone of the collection. Individual values are cloned. If a value does not support cloning, then a <see cref="T:System.NotSupportedException" /> is thrown.</summary>
         <returns>The new copy of the collection.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>
@@ -199,19 +163,7 @@
         <param name="name">The name of the value to be returned.</param>
         <summary>Gets the value associated with the specified name from this collection. In C#, this property is the indexer for the <see cref="T:System.Management.ManagementNamedValueCollection" /> class.</summary>
         <value>An object that is associated with the specified name from this collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- An object containing the value of the specified item in this collection.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Remove">
@@ -236,16 +188,7 @@
       <Docs>
         <param name="name">The name of the value to be removed.</param>
         <summary>Removes a single-named value from the collection. If the collection does not contain an element with the specified name, the collection remains unchanged and no exception is thrown.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemoveAll">
@@ -267,16 +210,7 @@
       <Parameters />
       <Docs>
         <summary>Removes all entries from the collection.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/ManagementObject.xml
+++ b/xml/System.Management/ManagementObject.xml
@@ -59,14 +59,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example initializes a new instance of the <xref:System.Management.ManagementObject> class with the parameterless constructor.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementObject/cs/ManagementObject.cs" id="Snippet1":::
@@ -98,14 +92,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example initializes a new instance of the <xref:System.Management.ManagementObject> class with a specified WMI object path.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementObject-M/cs/ManagementObject-M.cs" id="Snippet1":::
@@ -139,11 +127,6 @@
 
 ## Remarks
  If the specified path is a relative path only (a server or namespace is not specified), the default path is the local machine, and the default namespace is the <xref:System.Management.ManagementPath.DefaultPath*> path (by default, root\cimv2). If the user specifies a full path, the default settings are overridden.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new instance of the <xref:System.Management.ManagementObject> class.
@@ -179,14 +162,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example initializes a new instance of the <xref:System.Management.ManagementObject> class that is bound to a specific WMI path.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementObject-M_O/cs/ManagementObject-M_O.cs" id="Snippet1":::
@@ -227,16 +204,7 @@
         <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> to populate with data.</param>
         <param name="context">The destination (see <see cref="T:System.Runtime.Serialization.StreamingContext" />) for this serialization.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementObject" /> class that is serializable.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -263,14 +231,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example initializes a new instance of the <xref:System.Management.ManagementObject> class.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementObject-S_O/cs/ManagementObject-S_O.cs" id="Snippet1":::
@@ -315,11 +277,6 @@
 
  If a scope is specified and a full WMI path is specified, then the scope will override the scope portion of the full path. For example, if the following scope was specified: \\\MyMachine\root\MyScope, and the following full path was specified: \\\MyMachine\root\MyNamespace:MyClass.Name='abc', then look for the following `object: \\MyMachine\root\MyScope:MyClass.Name= 'abc'` (the scope part of the full path is ignored).
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example initializes a new instance of the <xref:System.Management.ManagementObject> class that is bound to a specific WMI path.
 
@@ -359,11 +316,6 @@
 ## Remarks
  See the equivalent overload for details.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example initializes a new instance of the <xref:System.Management.ManagementObject> class with a specific WMI path and options.
 
@@ -399,11 +351,6 @@
 ## Remarks
  This property is read-only.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example initializes a new instance of the <xref:System.Management.ManagementObject> class and then retrieves the class path for the <xref:System.Management.ManagementObject>.
 
@@ -437,16 +384,7 @@
       <Docs>
         <summary>Creates a copy of the object.</summary>
         <returns>The copied object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyTo">
@@ -481,16 +419,7 @@
         <param name="path">The <see cref="T:System.Management.ManagementPath" /> to which the object should be copied.</param>
         <summary>Copies the object to a different location.</summary>
         <returns>The new path of the copied object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -516,16 +445,7 @@
         <param name="path">The path to which the object should be copied.</param>
         <summary>Copies the object to a different location.</summary>
         <returns>The new path of the copied object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -552,16 +472,7 @@
         <param name="watcher">The object that will receive the results of the operation.</param>
         <param name="path">A <see cref="T:System.Management.ManagementPath" /> specifying the path to which the object should be copied.</param>
         <summary>Copies the object to a different location, asynchronously.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -588,16 +499,7 @@
         <param name="watcher">The object that will receive the results of the operation.</param>
         <param name="path">The path to which the object should be copied.</param>
         <summary>Copies the object to a different location, asynchronously.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -625,16 +527,7 @@
         <param name="options">The options for how the object should be put.</param>
         <summary>Copies the object to a different location.</summary>
         <returns>The new path of the copied object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -662,16 +555,7 @@
         <param name="options">The options for how the object should be put.</param>
         <summary>Copies the object to a different location.</summary>
         <returns>The new path of the copied object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -700,16 +584,7 @@
         <param name="path">The path to which the object should be copied.</param>
         <param name="options">The options for how the object should be put.</param>
         <summary>Copies the object to a different location, asynchronously.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -738,16 +613,7 @@
         <param name="path">The path to which the object should be copied.</param>
         <param name="options">The options for how the object should be put.</param>
         <summary>Copies the object to a different location, asynchronously.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <MemberGroup MemberName="Delete">
@@ -778,16 +644,7 @@
       <Parameters />
       <Docs>
         <summary>Deletes the object.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Delete">
@@ -812,16 +669,7 @@
       <Docs>
         <param name="options">The options for how to delete the object.</param>
         <summary>Deletes the object.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Delete">
@@ -846,16 +694,7 @@
       <Docs>
         <param name="watcher">The object that will receive the results of the operation.</param>
         <summary>Deletes the object.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Delete">
@@ -882,16 +721,7 @@
         <param name="watcher">The object that will receive the results of the operation.</param>
         <param name="options">The options for how to delete the object.</param>
         <summary>Deletes the object.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Dispose">
@@ -923,16 +753,7 @@
       </AssemblyInfo>
       <Docs>
         <summary>Binds to the management object.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </MemberGroup>
     <Member MemberName="Get">
@@ -959,11 +780,6 @@
 
 ## Remarks
  The method is implicitly invoked at the first attempt to get or set information to the WMI object. It can also be explicitly invoked at the user's discretion, to better control the timing and manner of retrieval.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example calls the <xref:System.Management.ManagementObject.Get*> method to get an instance of the <xref:System.Management.ManagementObject> class.
@@ -1003,11 +819,6 @@
 ## Remarks
  The method will issue the request to get the object and then will immediately return. The results of the operation will then be delivered through events being fired on the watcher object provided.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example calls the <xref:System.Management.ManagementObject.Get*> method to asynchronously get an instance of the <xref:System.Management.ManagementObject> class.
 
@@ -1045,12 +856,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Gets the object containing the input parameters to a method, and then fills in the values and passes the object to the <xref:System.Management.ManagementObject.InvokeMethod*> call.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
+ Gets the object containing the input parameters to a method, and then fills in the values and passes the object to the <xref:System.Management.ManagementObject.InvokeMethod*> call. ]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1078,16 +884,7 @@
         <param name="info">The object to be populated with serialization information.</param>
         <param name="context">The location where serialized data will be stored and retrieved.</param>
         <summary>Populates a <see cref="T:System.Runtime.Serialization.SerializationInfo" /> with the data necessary to deserialize the field represented by this instance.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <MemberGroup MemberName="GetRelated">
@@ -1125,11 +922,6 @@
 ## Remarks
  The operation is equivalent to an *ASSOCIATORS OF* query where ResultClass = relatedClass.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example calls the <xref:System.Management.ManagementObject.GetRelated*> method to get a collection of objects related to an instance of the <xref:System.Management.ManagementObject> class.
 
@@ -1162,16 +954,7 @@
       <Docs>
         <param name="watcher">The object to use to return results.</param>
         <summary>Gets a collection of objects related to the object (associators) asynchronously. This call returns immediately, and a delegate is called when the results are available.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetRelated">
@@ -1200,14 +983,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example calls the <xref:System.Management.ManagementObject.GetRelated*> method to get a collection of objects related to an instance of the <xref:System.Management.ManagementObject> class.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementObject_GetRelated-S/cs/ManagementObject_GetRelated-S.cs" id="Snippet1":::
@@ -1245,12 +1022,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This operation is equivalent to an *ASSOCIATORS OF* query where ResultClass = relatedClass.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
+ This operation is equivalent to an *ASSOCIATORS OF* query where ResultClass = relatedClass. ]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1295,12 +1067,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This operation is equivalent to an *ASSOCIATORS OF* query where ResultClass = relatedClass.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
+ This operation is equivalent to an *ASSOCIATORS OF* query where ResultClass = relatedClass. ]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1346,12 +1113,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This operation is equivalent to an *ASSOCIATORS OF* query where ResultClass = relatedClass.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
+ This operation is equivalent to an *ASSOCIATORS OF* query where ResultClass = relatedClass. ]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1388,12 +1150,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The operation is equivalent to a *REFERENCES OF* query.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
+ The operation is equivalent to a *REFERENCES OF* query. ]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1423,12 +1180,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This operation is equivalent to a *REFERENCES OF* query.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
+ This operation is equivalent to a *REFERENCES OF* query. ]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1459,12 +1211,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This operation is equivalent to a *REFERENCES OF* query where the AssocClass = relationshipClass.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
+ This operation is equivalent to a *REFERENCES OF* query where the AssocClass = relationshipClass. ]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1496,12 +1243,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This operation is equivalent to a *REFERENCES OF* query where the AssocClass = relationshipClass.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
+ This operation is equivalent to a *REFERENCES OF* query where the AssocClass = relationshipClass. ]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1540,12 +1282,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This operation is equivalent to a *REFERENCES OF* query with possibly all the extensions.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
+ This operation is equivalent to a *REFERENCES OF* query with possibly all the extensions. ]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1585,12 +1322,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This operation is equivalent to a *REFERENCES OF* query with possibly all the extensions.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
+ This operation is equivalent to a *REFERENCES OF* query with possibly all the extensions. ]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1634,11 +1366,6 @@
 ## Remarks
  If the method is static, the execution should still succeed.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example invokes the **Win32_Process::Create** method to start a new process of Notepad.exe.
 
@@ -1679,12 +1406,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- If the method is static, the execution should still succeed.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
+ If the method is static, the execution should still succeed. ]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1718,14 +1440,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example invokes the **Win32_Process::Create** method to start a new process of Calc.exe.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementObject_InvokeMethod-S_M_I/cs/ManagementObject_InvokeMethod-S_M_I.cs" id="Snippet1":::
@@ -1767,12 +1483,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The method invokes the specified method execution and then returns. Progress and results are reported through events on the <xref:System.Management.ManagementOperationObserver>.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
+ The method invokes the specified method execution and then returns. Progress and results are reported through events on the <xref:System.Management.ManagementOperationObserver>. ]]></format>
         </remarks>
       </Docs>
     </Member>
@@ -1800,11 +1511,6 @@
 
 ## Remarks
  When the property is changed after the management object has been bound to a WMI object, the management object is disconnected from the original WMI object and later rebound using the new options.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new instance of the <xref:System.Management.ManagementObject> class and then change the default options for the <xref:System.Management.ManagementObject>.
@@ -1842,11 +1548,6 @@
  Changing the property after the management object has been bound to a WMI object in a particular namespace results in releasing the original WMI object. This causes the management object to be rebound to the new object specified by the new path properties and scope values.
 
  The rebinding is performed in a "lazy" manner, that is, only when a requested value requires the management object to be bound to the WMI object. Changes can be made to more than just the property before attempting to rebind (for example, modifying the scope and path properties simultaneously).
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new instance of the <xref:System.Management.ManagementObject> class with the default namespace, and then changes the WMI path of the <xref:System.Management.ManagementObject>.
@@ -1887,16 +1588,7 @@
       <Docs>
         <summary>Commits the changes to the object.</summary>
         <returns>A <see cref="T:System.Management.ManagementPath" /> containing the path to the committed object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Put">
@@ -1921,16 +1613,7 @@
       <Docs>
         <param name="watcher">A <see cref="T:System.Management.ManagementOperationObserver" /> used to handle the progress and results of the asynchronous operation.</param>
         <summary>Commits the changes to the object, asynchronously.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Put">
@@ -1956,16 +1639,7 @@
         <param name="options">The options for how to commit the changes.</param>
         <summary>Commits the changes to the object.</summary>
         <returns>A <see cref="T:System.Management.ManagementPath" /> containing the path to the committed object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Put">
@@ -1992,16 +1666,7 @@
         <param name="watcher">A <see cref="T:System.Management.ManagementOperationObserver" /> used to handle the progress and results of the asynchronous operation.</param>
         <param name="options">A <see cref="T:System.Management.PutOptions" /> used to specify additional options for the commit operation.</param>
         <summary>Commits the changes to the object asynchronously and using the specified options.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Scope">
@@ -2030,11 +1695,6 @@
  Changing this property after the management object has been bound to a WMI object in a particular namespace results in releasing the original WMI object. This causes the management object to be rebound to the new object specified by the new path properties and scope values.
 
  The rebinding is performed in a "lazy" manner, that is, only when a requested value requires the management object to be bound to the WMI object. Changes can be made to more than just this property before attempting to rebind (for example, modifying the scope and path properties simultaneously).
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new instance of the <xref:System.Management.ManagementObject> class with the default namespace, and then changes the scope of the <xref:System.Management.ManagementObject>.
@@ -2066,16 +1726,7 @@
       <Docs>
         <summary>Returns the full path of the object. This is an override of the default object implementation.</summary>
         <returns>The full path of the object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/ManagementObjectCollection+ManagementObjectEnumerator.xml
+++ b/xml/System.Management/ManagementObjectCollection+ManagementObjectEnumerator.xml
@@ -64,16 +64,7 @@
       <Docs>
         <summary>Gets the current <see cref="T:System.Management.ManagementBaseObject" /> that this enumerator points to.</summary>
         <value>The current object in the enumeration.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Dispose">
@@ -98,16 +89,7 @@
       <Parameters />
       <Docs>
         <summary>Releases resources associated with this object. After this method has been called, an attempt to use this object will result in an <see cref="T:System.ObjectDisposedException" /> exception being thrown.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Finalize">
@@ -129,16 +111,7 @@
       <Parameters />
       <Docs>
         <summary>Disposes of resources the object is holding. This is the destructor for the object. Finalizers are expressed using destructor syntax.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MoveNext">
@@ -165,16 +138,7 @@
         <summary>Indicates whether the enumerator has moved to the next object in the enumeration.</summary>
         <returns>
           <see langword="true" />, if the enumerator was successfully advanced to the next element; <see langword="false" /> if the enumerator has passed the end of the collection.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Reset">
@@ -199,16 +163,7 @@
       <Parameters />
       <Docs>
         <summary>Resets the enumerator to the beginning of the collection.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerator.Current">

--- a/xml/System.Management/ManagementObjectCollection.xml
+++ b/xml/System.Management/ManagementObjectCollection.xml
@@ -262,7 +262,7 @@
       <Docs>
         <summary>Gets the object to be used for synchronization.</summary>
         <value>An object that can be used for synchronization.</value>
-        <remarks>To be added.</remarks></remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.SyncRoot" />
       </Docs>
     </Member>

--- a/xml/System.Management/ManagementObjectCollection.xml
+++ b/xml/System.Management/ManagementObjectCollection.xml
@@ -74,16 +74,7 @@
         <param name="array">An array to copy to.</param>
         <param name="index">The index to start from.</param>
         <summary>Copies the collection to an array.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Collections.ICollection.CopyTo(System.Array,System.Int32)" />
       </Docs>
     </Member>
@@ -111,16 +102,7 @@
         <param name="objectCollection">The target array.</param>
         <param name="index">The index to start from.</param>
         <summary>Copies the items in the collection to a <see cref="T:System.Management.ManagementBaseObject" /> array.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -145,20 +127,7 @@
       <Docs>
         <summary>Gets a value indicating the number of objects in the collection.</summary>
         <value>The number of objects in the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property is very expensive - it requires that all members of the collection be enumerated.
-
-## Property Value
- The number of objects in the collection.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>This property is expensive - it requires that all members of the collection be enumerated.</remarks>
         <altmember cref="P:System.Collections.ICollection.Count" />
       </Docs>
     </Member>
@@ -184,16 +153,7 @@
       <Parameters />
       <Docs>
         <summary>Releases resources associated with this object. After this method has been called, an attempt to use this object will result in an <see cref="T:System.ObjectDisposedException" /> being thrown.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.IDisposable.Dispose" />
       </Docs>
     </Member>
@@ -216,16 +176,7 @@
       <Parameters />
       <Docs>
         <summary>Disposes of resources the object is holding. This is the destructor for the object. Finalizers are expressed using destructor syntax.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEnumerator">
@@ -258,9 +209,6 @@
 
  If an enumerator is rewindable, the objects in the collection will be kept available for multiple enumerations.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -288,19 +236,7 @@
         <summary>Gets a value that indicates whether the object is synchronized (thread-safe).</summary>
         <value>
           <see langword="true" /> if the object is synchronized; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- `true`, if the object is synchronized, otherwise `false`.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.IsSynchronized" />
       </Docs>
     </Member>
@@ -326,19 +262,7 @@
       <Docs>
         <summary>Gets the object to be used for synchronization.</summary>
         <value>An object that can be used for synchronization.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The object to be used for synchronization.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks></remarks>
         <altmember cref="P:System.Collections.ICollection.SyncRoot" />
       </Docs>
     </Member>

--- a/xml/System.Management/ManagementObjectSearcher.xml
+++ b/xml/System.Management/ManagementObjectSearcher.xml
@@ -58,16 +58,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementObjectSearcher" /> class. After some properties on this object are set, the object can be used to invoke a query for management information. This is the parameterless constructor.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -91,13 +82,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementObjectSearcher" /> class used to invoke the specified query for management information.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new instance of the <xref:System.Management.ManagementObjectSearcher> class with a specific query.
@@ -131,14 +115,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example initializes a new instance of the <xref:System.Management.ManagementObjectSearcher> class with a specific query.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementObjectSearcher-S/cs/ManagementObjectSearcher-S.cs" id="Snippet1":::
@@ -174,11 +152,6 @@
 
 ## Remarks
  If no scope is specified, the default scope (<xref:System.Management.ManagementPath.DefaultPath*>) is used.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new instance of the <xref:System.Management.ManagementObjectSearcher> class with a specific query and scope.
@@ -217,11 +190,6 @@
 ## Remarks
  If no scope is specified, the default scope (<xref:System.Management.ManagementPath.DefaultPath*>) is used.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example initializes a new instance of the <xref:System.Management.ManagementObjectSearcher> class with a specific query and scope.
 
@@ -258,14 +226,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example initializes a new instance of the <xref:System.Management.ManagementObjectSearcher> class with a specific query, scope, and enumeration options.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementObjectSearcher-M_O_E/cs/ManagementObjectSearcher-M_O_E.cs" id="Snippet1":::
@@ -301,14 +263,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example initializes a new instance of the <xref:System.Management.ManagementObjectSearcher> class with a specific query, scope, and enumeration options.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementObjectSearcher-S_S_E/cs/ManagementObjectSearcher-S_S_E.cs" id="Snippet1":::
@@ -350,14 +306,8 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
+
  The following example initializes a new instance of the <xref:System.Management.ManagementObjectSearcher> class with a specific query, scope, and enumeration options.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementObjectSearcher_Get/cs/ManagementObjectSearcher_Get.cs" id="Snippet1":::
@@ -389,16 +339,7 @@
       <Docs>
         <param name="watcher">The watcher that raises events triggered by the operation.</param>
         <summary>Invokes the WMI query asynchronously, and binds to a watcher to deliver the results.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Options">
@@ -420,19 +361,7 @@
       <Docs>
         <summary>Gets or sets the options for how to search for objects.</summary>
         <value>The options for searching for WMI objects.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The options for how to search for objects.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Query">
@@ -459,12 +388,6 @@
 
 ## Remarks
  When the value of this property is changed, the <xref:System.Management.ManagementObjectSearcher> is reset to use the new query.
-
-## Property Value
- The criteria to apply to the query.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
 
  ]]></format>
         </remarks>
@@ -494,14 +417,6 @@
 
 ## Remarks
  When the value of this property is changed, the <xref:System.Management.ManagementObjectSearcher> is re-bound to the new scope.
-
-## Property Value
- The scope (namespace) in which to look for objects.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new instance of the <xref:System.Management.ManagementObjectSearcher> class with a specific query and then changes the scope of the instance.

--- a/xml/System.Management/ManagementOperationObserver.xml
+++ b/xml/System.Management/ManagementOperationObserver.xml
@@ -56,13 +56,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example demonstrates how to perform an asynchronous instance enumeration. The example uses the <xref:System.Management.ManagementOperationObserver> class to handle management information and events asynchronously.
 
@@ -92,16 +85,7 @@
       <Parameters />
       <Docs>
         <summary>Cancels all outstanding operations.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Completed">
@@ -135,11 +119,6 @@
 |<xref:System.Management.ManagementEventArgs.Context*> (inherited from <xref:System.Management.ManagementEventArgs>)|Gets the operation context echoed back from the operation that triggered the event.|
 |<xref:System.Management.CompletedEventArgs.Status*>|Gets the completion status of the operation.|
 |<xref:System.Management.CompletedEventArgs.StatusObject*>|Gets or sets additional status information within a WMI object. This may be null.|
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example demonstrates how to perform an asynchronous instance enumeration. The example uses the <xref:System.Management.ManagementOperationObserver> class to handle management information and events asynchronously.
@@ -182,9 +161,6 @@
 |<xref:System.Management.ManagementEventArgs.Context*> (inherited from <xref:System.Management.ManagementEventArgs>)|Gets the operation context echoed back from the operation that triggered the event.|
 |<xref:System.Management.ObjectPutEventArgs.Path*>|Gets the identity of the object that has been put.|
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -213,17 +189,12 @@
 ## Remarks
 
 ## Event Data
- The event handler receives an argument of type <xref:System.Management.ObjectReadyEventArgs> containing data related to this event. The following <xref:System.Management.ObjectReadyEventArgs> properties provide   information specific to this event.
+ The event handler receives an argument of type <xref:System.Management.ObjectReadyEventArgs> containing data related to this event. The following <xref:System.Management.ObjectReadyEventArgs> properties provide information specific to this event.
 
 |Property|Description|
 |--------------|-----------------|
 |<xref:System.Management.ManagementEventArgs.Context*> (inherited from <xref:System.Management.ManagementEventArgs>)|Gets the operation context echoed back from the operation that triggered the event.|
 |<xref:System.Management.ObjectReadyEventArgs.NewObject*>|Gets the newly-returned object.|
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example demonstrates how to perform an asynchronous instance enumeration. The example uses the <xref:System.Management.ManagementOperationObserver> class to handle management information and events asynchronously.
@@ -267,9 +238,6 @@
 |<xref:System.Management.ProgressEventArgs.Current*>|Gets the current amount of work done by the operation. This is always less than or equal to <xref:System.Management.ProgressEventArgs.UpperBound*>.|
 |<xref:System.Management.ProgressEventArgs.Message*>|Gets or sets optional additional information regarding the operation's progress.|
 |<xref:System.Management.ProgressEventArgs.UpperBound*>|Gets the total amount of work required to be done by the operation.|
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
 
  ]]></format>
         </remarks>

--- a/xml/System.Management/ManagementOptions.xml
+++ b/xml/System.Management/ManagementOptions.xml
@@ -133,7 +133,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the time-out to apply to the operation. Note that for operations that return collections, this time-out applies to the enumeration through the resulting collection, not the operation itself (the <see cref="P:System.Management.EnumerationOptions.ReturnImmediately" /> property is used for the latter). This property is used to indicate that the operation should be performed semi-synchronously.</summary>
-        <value>The time-out time to apply to the operation. The default value is <xref:System.TimeSpan.MaxValue />, which indicates that the operation will block until it completes.</value>
+        <value>The time-out time to apply to the operation. The default value is <see cref="F:System.TimeSpan.MaxValue" />, which indicates that the operation will block until it completes.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 

--- a/xml/System.Management/ManagementOptions.xml
+++ b/xml/System.Management/ManagementOptions.xml
@@ -61,16 +61,7 @@
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>The cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>
@@ -92,20 +83,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a WMI context object. This is a name-value pairs list to be passed through to a WMI provider that supports context information for customized operation.</summary>
-        <value>Returns a <see cref="T:System.Management.ManagementNamedValueCollection" /> that contains WMI context information.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- A name-value pairs list to be passed through to a WMI provider that supports context information for customized operation.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value>A name-value pairs list that contains WMI context information.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InfiniteTimeout">
@@ -154,7 +133,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the time-out to apply to the operation. Note that for operations that return collections, this time-out applies to the enumeration through the resulting collection, not the operation itself (the <see cref="P:System.Management.EnumerationOptions.ReturnImmediately" /> property is used for the latter). This property is used to indicate that the operation should be performed semi-synchronously.</summary>
-        <value>Returns a <see cref="T:System.TimeSpan" /> that defines the time-out time to apply to the operation.</value>
+        <value>The time-out time to apply to the operation. The default value is <xref:System.TimeSpan.MaxValue />, which indicates that the operation will block until it completes.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -162,12 +141,6 @@
  The <xref:System.Management.ManagementOptions.Timeout> property is used in the corresponding semi-synchronous operation for the following classes: <xref:System.Management.ObjectGetOptions>, <xref:System.Management.PutOptions>, <xref:System.Management.DeleteOptions>, <xref:System.Management.InvokeMethodOptions>, <xref:System.Management.EnumerationOptions>, and <xref:System.Management.EventWatcherOptions>.
 
  This property has no effect on the <xref:System.Management.ManagementScope.Connect> method.
-
-## Property Value
- The default value for this property is <xref:System.TimeSpan.MaxValue>, which means the operation will block. The value specified must be positive.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
 
  ]]></format>
         </remarks>

--- a/xml/System.Management/ManagementPath.xml
+++ b/xml/System.Management/ManagementPath.xml
@@ -36,14 +36,14 @@
   <Docs>
     <summary>Provides a wrapper for parsing and building paths to WMI objects.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Examples  
- The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object.  The path that is parsed in the example is a path to an instance of a class.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object.  The path that is parsed in the example is a path to an instance of a class.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementPath/cs/ManagementPath.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/Overview/ManagementPath.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/Overview/ManagementPath.vb" id="Snippet1":::
+
  ]]></format>
     </remarks>
   </Docs>
@@ -72,16 +72,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementPath" /> class that is empty. This is the parameterless constructor.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -104,21 +95,15 @@
         <param name="path">The object path.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementPath" /> class for the given path.</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object.  The path that is parsed in the example is a path to an instance of a class.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+
+ The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object.  The path that is parsed in the example is a path to an instance of a class.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementPath-S/cs/ManagementPath-S.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/.ctor/ManagementPath-S.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/.ctor/ManagementPath-S.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -147,26 +132,16 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the class portion of the path.</summary>
-        <value>Returns a <see cref="T:System.String" /> value that holds the class portion of the path.</value>
+        <value>The class portion of the path.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A string containing the name of the class.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object. The path that is parsed in the example is a path to an instance of a class.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object. The path that is parsed in the example is a path to an instance of a class.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementPath_ClassName/cs/ManagementPath_ClassName.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/ClassName/ManagementPath_ClassName.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/ClassName/ManagementPath_ClassName.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -191,16 +166,7 @@
       <Docs>
         <summary>Returns a copy of the <see cref="T:System.Management.ManagementPath" />.</summary>
         <returns>The cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DefaultPath">
@@ -220,21 +186,9 @@
         <ReturnType>System.Management.ManagementPath</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets or sets the default scope path used when no scope is specified. The default scope is \\\\.\root\cimv2, and can be changed by setting this property.</summary>
-        <value>Returns a <see cref="T:System.Management.ManagementPath" /> that contains the default scope (namespace) path used when no scope is specified.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- By default the scope value is \\\\.\root\cimv2, or a different scope path if the default was changed.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <summary>Gets or sets the default scope path used when no scope is specified.</summary>
+        <value>The default scope (namespace) path used when no scope is specified. The default value is \\\\.\root\cimv2.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsClass">
@@ -255,26 +209,16 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating whether this is a class path.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether this is a class path.</value>
+        <value><see langword="true"/> if this is a class path; otherwise, <see langword="false"/>.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if this is a class path; otherwise, `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object. The path that is parsed in the example is a path to an instance of a class.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object. The path that is parsed in the example is a path to an instance of a class.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementPath_IsClass/cs/ManagementPath_IsClass.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/IsClass/ManagementPath_IsClass.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/IsClass/ManagementPath_IsClass.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -297,26 +241,16 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating whether this is an instance path.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether this is an instance path.</value>
+        <value><see langword="true"/> if this is an instance path; otherwise, <see langword="false"/>.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if this is an instance path; otherwise, `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object. The path that is parsed in the example is a path to an instance of a class.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object. The path that is parsed in the example is a path to an instance of a class.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementPath_IsInstance/cs/ManagementPath_IsInstance.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/IsInstance/ManagementPath_IsInstance.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/IsInstance/ManagementPath_IsInstance.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -339,20 +273,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating whether this is a *singleton* instance path.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether this is a singleton instance path.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if this is a singleton instance path; otherwise, `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value><see langword="true"/> if this is a singleton instance path; otherwise, <see langword="false"/>.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NamespacePath">
@@ -379,26 +301,16 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the namespace part of the path. Note that this does not include the server name, which can be retrieved separately.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the namespace part of the path.</value>
+        <value>The namespace part of the path.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A string containing the namespace portion of the path represented in this object.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object.  The path that is parsed in the example is a path to an instance of a class.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object.  The path that is parsed in the example is a path to an instance of a class.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementPath_NamespacePath/cs/ManagementPath_NamespacePath.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/NamespacePath/ManagementPath_NamespacePath.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/NamespacePath/ManagementPath_NamespacePath.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -427,26 +339,16 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the string representation of the full path in the object.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the full path.</value>
+        <value>The full path represented by this object.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A string containing the full path represented in this object.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object.  The path that is parsed in the example is a path to an instance of a class.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object.  The path that is parsed in the example is a path to an instance of a class.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementPath_Path/cs/ManagementPath_Path.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/Path/ManagementPath_Path.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/Path/ManagementPath_Path.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -475,26 +377,16 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the relative path: class name and keys only.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the relative path.</value>
+        <value>The relative path (not including the server and namespace portions) represented by this object.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A string containing the relative path (not including the server and namespace portions) represented in this object.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object.  The path that is parsed in the example is a path to an instance of a class.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object.  The path that is parsed in the example is a path to an instance of a class.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementPath_RelativePath/cs/ManagementPath_RelativePath.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/RelativePath/ManagementPath_RelativePath.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/RelativePath/ManagementPath_RelativePath.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -523,26 +415,16 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the server part of the path.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the server name.</value>
+        <value>The server name.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A string containing the server name from the path represented in this object.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object.  The path that is parsed in the example is a path to an instance of a class.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example demonstrates how the <xref:System.Management.ManagementPath> class parses a path to a WMI object.  The path that is parsed in the example is a path to an instance of a class.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementPath_Server/cs/ManagementPath_Server.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/Server/ManagementPath_Server.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementPath/Server/ManagementPath_Server.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -566,16 +448,7 @@
       <Parameters />
       <Docs>
         <summary>Sets the path as a new class path. This means that the path must have a class name but not key values.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetAsSingleton">
@@ -597,16 +470,7 @@
       <Parameters />
       <Docs>
         <summary>Sets the path as a new *singleton* object path. This means that it is a path to an instance but there are no key values.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.ICloneable.Clone">
@@ -632,16 +496,7 @@
       <Docs>
         <summary>Creates a new object that is a copy of the current instance.</summary>
         <returns>A new object that is a copy of this instance.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -664,16 +519,7 @@
       <Docs>
         <summary>Returns the full object path as the string representation.</summary>
         <returns>A string containing the full object path represented by this object. This value is equivalent to the value of the <see cref="P:System.Management.ManagementPath.Path" /> property.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/ManagementQuery.xml
+++ b/xml/System.Management/ManagementQuery.xml
@@ -37,7 +37,7 @@
     <summary>Provides an abstract base class for all management query objects.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[
-      
+
 This class is abstract; only derivatives of it are actually used in the API.
 
       ]]></format>
@@ -67,16 +67,7 @@ This class is abstract; only derivatives of it are actually used in the API.
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>The cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>
@@ -103,21 +94,15 @@ This class is abstract; only derivatives of it are actually used in the API.
         <param name="query">The query string to be parsed.</param>
         <summary>Parses the query string and sets the property values accordingly. If the query is valid, the class name property and condition property of the query will be parsed.</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example parses a query into class name and condition properties.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+
+ The following example parses a query into class name and condition properties.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_ManagementQuery_ParseQuery/cs/ManagementQuery_ParseQuery.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementQuery/ParseQuery/ManagementQuery.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/ManagementQuery/ParseQuery/ManagementQuery.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -140,18 +125,14 @@ This class is abstract; only derivatives of it are actually used in the API.
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the query language used in the query string, defining the format of the query string.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the format of the query string.</value>
+        <value>The format of the query string.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- Can be set to any supported query language. "WQL" is the only value supported intrinsically by WMI.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+This property can be set to any supported query language. "WQL" is the only value supported intrinsically by WMI.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -174,18 +155,14 @@ This class is abstract; only derivatives of it are actually used in the API.
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the query in text format.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the query.</value>
+        <value>The query string in text format.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- If the query object is constructed with no parameters, the property is null until specifically set. If the object was constructed with a specified query, the property returns the specified query string.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+If the query object is constructed with no parameters, the property is null until specifically set. If the object was constructed with a specified query, the property returns the specified query string.
+
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Management/ManagementScope.xml
+++ b/xml/System.Management/ManagementScope.xml
@@ -78,9 +78,6 @@
 ## Remarks
  If the object does not have any properties set before connection, it is initialized with default values (for example, the local machine and the root\cimv2 namespace).
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -104,16 +101,7 @@
       <Docs>
         <param name="path">A <see cref="T:System.Management.ManagementPath" /> containing the path to a server and namespace for the <see cref="T:System.Management.ManagementScope" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementScope" /> class representing the specified scope path.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -137,13 +125,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementScope" /> class representing the specified scope path.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new <xref:System.Management.ManagementScope> with a specific path and then connects the scope object to a WMI namespace. The example connects to a namespace on a remote computer.
@@ -176,16 +157,7 @@
         <param name="path">A <see cref="T:System.Management.ManagementPath" /> containing the path to the server and namespace for the <see cref="T:System.Management.ManagementScope" />.</param>
         <param name="options">The <see cref="T:System.Management.ConnectionOptions" /> containing options for the connection.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementScope" /> class representing the specified scope path, with the specified options.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -211,13 +183,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.ManagementScope" /> class representing the specified scope path, with the specified options.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new <xref:System.Management.ManagementScope> with a specific path and then connects the scope object to a WMI namespace. The example connects to a namespace on a remote computer.
@@ -249,16 +214,7 @@
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>A new copy of the <see cref="T:System.Management.ManagementScope" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Connect">
@@ -285,11 +241,6 @@
 
 ## Remarks
  This method is called implicitly when the scope is used in an operation that requires it to be connected. Calling it explicitly allows the user to control the time of connection. This method will return within two minutes.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new <xref:System.Management.ManagementScope> with a specific path and then connects the scope object to a WMI namespace. The example connects to a namespace on a remote computer.
@@ -319,18 +270,12 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value indicating whether the <see cref="T:System.Management.ManagementScope" /> is currently bound to a WMI server and namespace.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether the scope is currently bound to a WMI server and namespace.</value>
+        <value><see langword="true"/> if the scope is currently bound to a WMI server and namespace; otherwise, <see langword="false"/>.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  A scope is disconnected after creation until someone explicitly calls <xref:System.Management.ManagementScope.Connect*>, or uses the scope for any operation that requires a live connection. Also, the scope is disconnected from the previous connection whenever the identifying properties of the scope are changed.
-
-## Property Value
- `true` if a connection is alive (bound to a server and namespace); otherwise, `false`.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
 
  ]]></format>
         </remarks>
@@ -354,20 +299,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets options for making the WMI connection.</summary>
-        <value>Returns a <see cref="T:System.Management.ConnectionOptions" /> that contains the options for making a WMI connection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The valid <xref:System.Management.ConnectionOptions> containing options for the WMI connection.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value>The options for making a WMI connection.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Path">
@@ -388,20 +321,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the path for the <see cref="T:System.Management.ManagementScope" />.</summary>
-        <value>Returns a <see cref="T:System.Management.ManagementPath" /> containing the path to the scope (namespace).</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- A <xref:System.Management.ManagementPath> containing the path to a server and namespace.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value>The path to the scope (namespace).</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.ICloneable.Clone">
@@ -427,16 +348,7 @@
       <Docs>
         <summary>Creates a new object that is a copy of the current instance.</summary>
         <returns>A new object that is a copy of this instance.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/MethodData.xml
+++ b/xml/System.Management/MethodData.xml
@@ -56,20 +56,12 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the input parameters to the method. Each parameter is described as a property in the object. If a parameter is both in and out, it appears in both the <see cref="P:System.Management.MethodData.InParameters" /> and <see cref="P:System.Management.MethodData.OutParameters" /> properties.</summary>
-        <value>Returns a <see cref="T:System.Management.ManagementBaseObject" /> containing the input parameters to the method.</value>
+        <value>The input parameters to the method.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  Each parameter in the object should have an ID qualifier, identifying the order of the parameters in the method call.
-
-## Property Value
- A <xref:System.Management.ManagementBaseObject> containing all the input parameters to the method.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example lists information about the **Win32_Process.Create** method using the <xref:System.Management.MethodData> class. For more information about the **Win32_Process** class, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
@@ -99,19 +91,9 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the name of the method.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the name of the method.</value>
+        <value>The name of the method.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The name of the method.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example lists information about the **Win32_Process.Create** method using the <xref:System.Management.MethodData> class. For more information about the **Win32_Process** class, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
@@ -141,20 +123,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the name of the management class in which the method was first introduced in the class inheritance hierarchy.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the name of the class in which the method was first introduced in the class inheritance hierarchy.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- A string representing the originating management class name.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value>The name of the class in which the method was first introduced in the class inheritance hierarchy.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OutParameters">
@@ -175,7 +145,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the output parameters to the method. Each parameter is described as a property in the object. If a parameter is both in and out, it will appear in both the <see cref="P:System.Management.MethodData.InParameters" /> and <see cref="P:System.Management.MethodData.OutParameters" /> properties.</summary>
-        <value>Returns a <see cref="T:System.Management.ManagementBaseObject" /> containing the output parameters for the method.</value>
+        <value>The output parameters for the method.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -183,14 +153,6 @@
  Each parameter in this object should have an ID qualifier to identify the order of the parameters in the method call.
 
  The **ReturnValue** property is a special property of the <xref:System.Management.ManagementBaseObject> returned by the <xref:System.Management.MethodData.OutParameters> property and holds the return value of the method.
-
-## Property Value
- A <xref:System.Management.ManagementBaseObject> containing all the output parameters to the method.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example lists information about the **Win32_Process.Create** method using the <xref:System.Management.MethodData> class. For more information on the **Win32_Process** class, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
@@ -220,19 +182,9 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a collection of qualifiers defined in the method. Each element is of type <see cref="T:System.Management.QualifierData" /> and contains information such as the *qualifier* name, value, and *flavor*.</summary>
-        <value>Returns a <see cref="T:System.Management.QualifierDataCollection" /> containing the qualifiers for the method.</value>
+        <value>The qualifiers for the method.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- A <xref:System.Management.QualifierDataCollection> containing the qualifiers for this method.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example lists information about the **Win32_Process.Create** method using the <xref:System.Management.MethodData> class. For more information about the **Win32_Process** class, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.

--- a/xml/System.Management/MethodDataCollection+MethodDataEnumerator.xml
+++ b/xml/System.Management/MethodDataCollection+MethodDataEnumerator.xml
@@ -30,14 +30,14 @@
   <Docs>
     <summary>Represents the enumerator for <see cref="T:System.Management.MethodData" /> objects in the <see cref="T:System.Management.MethodDataCollection" />.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Examples  
- The following example enumerates through the methods in the **Win32_LogicalDisk** class and displays them.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example enumerates through the methods in the **Win32_LogicalDisk** class and displays them.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_MethodDataEnumerator/cs/MethodDataEnumerator.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/MethodDataCollection+MethodDataEnumerator/Overview/MethodDataEnumerator.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/MethodDataCollection+MethodDataEnumerator/Overview/MethodDataEnumerator.vb" id="Snippet1":::
+
  ]]></format>
     </remarks>
   </Docs>
@@ -61,16 +61,7 @@
       <Docs>
         <summary>Returns the current <see cref="T:System.Management.MethodData" /> in the <see cref="T:System.Management.MethodDataCollection" /> enumeration.</summary>
         <value>The current <see cref="T:System.Management.MethodData" /> item in the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MoveNext">
@@ -97,16 +88,7 @@
         <summary>Moves to the next element in the <see cref="T:System.Management.MethodDataCollection" /> enumeration.</summary>
         <returns>
           <see langword="true" /> if the enumerator was successfully advanced to the next method; <see langword="false" /> if the enumerator has passed the end of the collection.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Reset">
@@ -131,16 +113,7 @@
       <Parameters />
       <Docs>
         <summary>Resets the enumerator to the beginning of the <see cref="T:System.Management.MethodDataCollection" /> enumeration.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerator.Current">

--- a/xml/System.Management/MethodDataCollection.xml
+++ b/xml/System.Management/MethodDataCollection.xml
@@ -82,9 +82,6 @@
 ## Remarks
  Adding <xref:System.Management.MethodData> objects to the <xref:System.Management.MethodDataCollection> can only be done when the class has no instances. Any other case will result in an exception.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -120,9 +117,6 @@
 
 ## Remarks
  Adding <xref:System.Management.MethodData> objects to the <xref:System.Management.MethodDataCollection> can only be done when the class has no instances. Any other case will result in an exception.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
 
  ]]></format>
         </remarks>
@@ -164,16 +158,7 @@
         <param name="array">The array to which to copy the collection.</param>
         <param name="index">The index from which to start.</param>
         <summary>Copies the <see cref="T:System.Management.MethodDataCollection" /> into an array.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Collections.ICollection.CopyTo(System.Array,System.Int32)" />
       </Docs>
     </Member>
@@ -201,16 +186,7 @@
         <param name="methodArray">The destination array to which to copy the <see cref="T:System.Management.MethodData" /> objects.</param>
         <param name="index">The index in the destination array from which to start the copy.</param>
         <summary>Copies the <see cref="T:System.Management.MethodDataCollection" /> to a specialized <see cref="T:System.Management.MethodData" /> array.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -234,20 +210,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the number of objects in the <see cref="T:System.Management.MethodDataCollection" /> collection.</summary>
-        <value>Returns an <see cref="T:System.Int32" /> value representing the number of objects in the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The number of objects in the <xref:System.Management.MethodDataCollection>.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value>The number of objects in the collection.</value>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.Count" />
       </Docs>
     </Member>
@@ -283,9 +247,6 @@
 
  If an enumerator is rewindable, the objects in the collection will be kept available for multiple enumerations.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -311,20 +272,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value that indicates whether the object is synchronized.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether the object is synchronized.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- `true` if the object is synchronized; otherwise, `false`.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value><see langword="true"/> if the object is synchronized; otherwise, <see langword="false"/>.</value>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.IsSynchronized" />
       </Docs>
     </Member>
@@ -350,20 +299,8 @@
       <Docs>
         <param name="methodName">The name of the method requested.</param>
         <summary>Gets the specified <see cref="T:System.Management.MethodData" /> from the <see cref="T:System.Management.MethodDataCollection" />.</summary>
-        <value>Returns a <see cref="T:System.Management.MethodData" /> containing the method data for a specified method from the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- A <xref:System.Management.MethodData> containing all information about the specified method.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value>The method data for a specified method from the collection.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Remove">
@@ -394,9 +331,6 @@
 ## Remarks
  Removing <xref:System.Management.MethodData> objects from the <xref:System.Management.MethodDataCollection> can only be done when the class has no instances. Any other case will result in an exception.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -422,20 +356,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the object to be used for synchronization.</summary>
-        <value>Returns an <see cref="T:System.Object" /> value representing the object to be used for synchronization.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The object to be used for synchronization.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value>The object to be used for synchronization.</value>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.SyncRoot" />
       </Docs>
     </Member>

--- a/xml/System.Management/ObjectGetOptions.xml
+++ b/xml/System.Management/ObjectGetOptions.xml
@@ -52,16 +52,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ObjectGetOptions" /> class for getting a WMI object, using default values. This is the parameterless constructor.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -83,16 +74,7 @@
       <Docs>
         <param name="context">A provider-specific, named-value pairs context object to be passed through to the provider.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ObjectGetOptions" /> class for getting a WMI object, using the specified provider-specific context.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -119,16 +101,7 @@
         <param name="useAmendedQualifiers">
           <see langword="true" /> if the returned objects should contain amended (locale-aware) qualifiers; otherwise, <see langword="false" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ObjectGetOptions" /> class for getting a WMI object, using the given options values.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clone">
@@ -151,16 +124,7 @@
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>The cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>
@@ -182,20 +146,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating whether the objects returned from WMI should contain amended information. Typically, amended information is localizable information attached to the WMI object, such as object and property descriptions.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether the objects returned from WMI should contain amended information.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if the objects returned from WMI should contain amended information; otherwise, `false`. The default value is `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value><see langword="true" /> if the objects returned from WMI should contain amended information; otherwise, <see langword="false" />. The default value is <see langword="false" />.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/ObjectPutEventArgs.xml
+++ b/xml/System.Management/ObjectPutEventArgs.xml
@@ -46,20 +46,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the identity of the object that has been put.</summary>
-        <value>Returns a <see cref="T:System.Management.ManagementPath" /> containing the path of the object that has been put.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A <xref:System.Management.ManagementPath> containing the path of the object that has been put.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value>The path of the object that has been put.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/ObjectQuery.xml
+++ b/xml/System.Management/ObjectQuery.xml
@@ -27,7 +27,7 @@
     <summary>Represents a management query that returns instances or classes.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[
-      
+
 This class or its derivatives are used to specify a query in the <xref:System.Management.ManagementObjectSearcher>. Use a more specific query class whenever possible.
 
       ]]></format>
@@ -58,16 +58,7 @@ This class or its derivatives are used to specify a query in the <xref:System.Ma
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ObjectQuery" /> class with no initialized values. This is the parameterless constructor.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -89,16 +80,7 @@ This class or its derivatives are used to specify a query in the <xref:System.Ma
       <Docs>
         <param name="query">The string representation of the query.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ObjectQuery" /> class for a specific query string.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -122,16 +104,7 @@ This class or its derivatives are used to specify a query in the <xref:System.Ma
         <param name="language">The query language in which this query is specified.</param>
         <param name="query">The string representation of the query.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.ObjectQuery" /> class for a specific query string and language.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clone">
@@ -154,16 +127,7 @@ This class or its derivatives are used to specify a query in the <xref:System.Ma
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>The cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>

--- a/xml/System.Management/ObjectReadyEventArgs.xml
+++ b/xml/System.Management/ObjectReadyEventArgs.xml
@@ -45,21 +45,9 @@
         <ReturnType>System.Management.ManagementBaseObject</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the newly-returned object.</summary>
-        <value>Returns a <see cref="T:System.Management.ManagementBaseObject" /> containing the newly-returned object.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A <xref:System.Management.ManagementBaseObject> representing the newly-returned object.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <summary>Gets the newly returned object.</summary>
+        <value>The newly returned object.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/ProgressEventArgs.xml
+++ b/xml/System.Management/ProgressEventArgs.xml
@@ -46,20 +46,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the current amount of work done by the operation. This is always less than or equal to <see cref="P:System.Management.ProgressEventArgs.UpperBound" />.</summary>
-        <value>Returns an <see cref="T:System.Int32" /> value representing the current amount of work already completed by the operation.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- An integer representing the current amount of work already completed by the operation.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value>The current amount of work already completed by the operation.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Message">
@@ -80,20 +68,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets optional additional information regarding the operation's progress.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing information regarding the operation's progress.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A string containing additional information regarding the operation's progress.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value>Information regarding the operation's progress.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UpperBound">
@@ -114,20 +90,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the total amount of work required to be done by the operation.</summary>
-        <value>Returns an <see cref="T:System.Int32" /> value representing the total amount of work to be done by the operation.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- An integer representing the total amount of work for the operation.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value>The total amount of work to be done by the operation.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/PropertyData.xml
+++ b/xml/System.Management/PropertyData.xml
@@ -26,14 +26,14 @@
   <Docs>
     <summary>Represents information about a WMI property.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Examples  
- The following example lists information about the **Win32_OperatingSystem** class using the <xref:System.Management.PropertyData> class. For more information about **Win32_OperatingSystem**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example lists information about the **Win32_OperatingSystem** class using the <xref:System.Management.PropertyData> class. For more information about **Win32_OperatingSystem**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_PropertyData/cs/PropertyData.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyData/Overview/PropertyData.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyData/Overview/PropertyData.vb" id="Snippet1":::
+
  ]]></format>
     </remarks>
   </Docs>
@@ -56,20 +56,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value indicating whether the property is an array.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether the property is an array.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if the property is an array; otherwise, `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value><see langword="true"/> if the property is an array; otherwise, <see langword="false"/>.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsLocal">
@@ -90,20 +78,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value indicating whether the property has been defined in the current WMI class.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether the property has been defined in the current WMI class.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if the property has been defined in the current WMI class; otherwise, `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value><see langword="true"/> if the property has been defined in the current WMI class; otherwise, <see langword="false"/>.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -124,26 +100,16 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the name of the property.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the property name.</value>
+        <value>The property name.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A string containing the name of the property.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example lists information about the **Win32_OperatingSystem** class using the <xref:System.Management.PropertyData> class. For more information about **Win32_OperatingSystem**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example lists information about the **Win32_OperatingSystem** class using the <xref:System.Management.PropertyData> class. For more information about **Win32_OperatingSystem**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_PropertyData_Name/cs/PropertyData_Name.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyData/Name/PropertyData_Name.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyData/Name/PropertyData_Name.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -166,20 +132,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the name of the WMI class in the hierarchy in which the property was introduced.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the name of the WMI class in the hierarchy in which the property was introduced.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A string containing the name of the originating WMI class.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value>The name of the WMI class in the hierarchy in which the property was introduced.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Qualifiers">
@@ -200,26 +154,16 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the set of qualifiers defined on the property.</summary>
-        <value>Returns a <see cref="T:System.Management.QualifierDataCollection" /> containing the set of qualifiers defined on the property.</value>
+        <value>The set of qualifiers defined on the property.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A <xref:System.Management.QualifierDataCollection> that represents the set of qualifiers defined on the property.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example lists information about the **Win32_OperatingSystem** class using the <xref:System.Management.PropertyData> class. For more information about **Win32_OperatingSystem**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example lists information about the **Win32_OperatingSystem** class using the <xref:System.Management.PropertyData> class. For more information about **Win32_OperatingSystem**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_PropertyData_Qualifiers/cs/PropertyData_Qualifiers.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyData/Qualifiers/PropertyData_Qualifiers.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyData/Qualifiers/PropertyData_Qualifiers.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -242,26 +186,16 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the CIM type of the property.</summary>
-        <value>Returns a <see cref="T:System.Management.CimType" /> enumeration value representing the CIM type of the property.</value>
+        <value>The CIM type of the property.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A <xref:System.Management.CimType> value representing the CIM type of the property.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example lists information about the **Win32_OperatingSystem** class using the <xref:System.Management.PropertyData> class. For more information about **Win32_OperatingSystem**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example lists information about the **Win32_OperatingSystem** class using the <xref:System.Management.PropertyData> class. For more information about **Win32_OperatingSystem**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_PropertyData_Type/cs/PropertyData_Type.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyData/Type/PropertyData_Type.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyData/Type/PropertyData_Type.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -284,26 +218,16 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the current value of the property.</summary>
-        <value>Returns an <see cref="T:System.Object" /> value representing the value of the property.</value>
+        <value>The value of the property.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- An object containing the value of the property.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example lists information about the **Win32_OperatingSystem** class using the <xref:System.Management.PropertyData> class. For more information about **Win32_OperatingSystem**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example lists information about the **Win32_OperatingSystem** class using the <xref:System.Management.PropertyData> class. For more information about **Win32_OperatingSystem**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_PropertyData_Value/cs/PropertyData_Value.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyData/Value/PropertyData_Value.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyData/Value/PropertyData_Value.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Management/PropertyDataCollection+PropertyDataEnumerator.xml
+++ b/xml/System.Management/PropertyDataCollection+PropertyDataEnumerator.xml
@@ -30,14 +30,14 @@
   <Docs>
     <summary>Represents the enumerator for <see cref="T:System.Management.PropertyData" /> objects in the <see cref="T:System.Management.PropertyDataCollection" />.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Examples  
- The following example enumerates through the properties of the **Win32_LogicalDisk** class.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example enumerates through the properties of the **Win32_LogicalDisk** class.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_PropertyDataEnumerator/cs/PropertyDataEnumerator.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyDataCollection+PropertyDataEnumerator/Overview/PropertyDataEnumerator.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyDataCollection+PropertyDataEnumerator/Overview/PropertyDataEnumerator.vb" id="Snippet1":::
+
  ]]></format>
     </remarks>
   </Docs>
@@ -61,16 +61,7 @@
       <Docs>
         <summary>Gets the current <see cref="T:System.Management.PropertyData" /> in the <see cref="T:System.Management.PropertyDataCollection" /> enumeration.</summary>
         <value>The current <see cref="T:System.Management.PropertyData" /> element in the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MoveNext">
@@ -97,16 +88,7 @@
         <summary>Moves to the next element in the <see cref="T:System.Management.PropertyDataCollection" /> enumeration.</summary>
         <returns>
           <see langword="true" /> if the enumerator was successfully advanced to the next element; <see langword="false" /> if the enumerator has passed the end of the collection.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Reset">
@@ -131,16 +113,7 @@
       <Parameters />
       <Docs>
         <summary>Resets the enumerator to the beginning of the <see cref="T:System.Management.PropertyDataCollection" /> enumeration.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerator.Current">

--- a/xml/System.Management/PropertyDataCollection.xml
+++ b/xml/System.Management/PropertyDataCollection.xml
@@ -84,9 +84,6 @@
 ## Remarks
  Properties can only be added to class definitions, not to instances. This method is only valid when invoked on a <xref:System.Management.PropertyDataCollection> in a <xref:System.Management.ManagementClass>.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -124,9 +121,6 @@
 ## Remarks
  Properties can only be added to class definitions, not to instances. This method is only valid when invoked on a <xref:System.Management.PropertyDataCollection> in a <xref:System.Management.ManagementClass>.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -162,9 +156,6 @@
 
 ## Remarks
  Properties can only be added to class definitions, not to instances. This method is only valid when invoked on a <xref:System.Management.PropertyDataCollection> in a <xref:System.Management.ManagementClass>.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
 
  ]]></format>
         </remarks>
@@ -206,16 +197,7 @@
         <param name="array">The array to which to copy the <see cref="T:System.Management.PropertyDataCollection" />.</param>
         <param name="index">The index from which to start copying.</param>
         <summary>Copies the <see cref="T:System.Management.PropertyDataCollection" /> into an array.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Collections.ICollection.CopyTo(System.Array,System.Int32)" />
       </Docs>
     </Member>
@@ -243,16 +225,7 @@
         <param name="propertyArray">The destination array to contain the copied <see cref="T:System.Management.PropertyDataCollection" />.</param>
         <param name="index">The index in the destination array from which to start copying.</param>
         <summary>Copies the <see cref="T:System.Management.PropertyDataCollection" /> to a specialized <see cref="T:System.Management.PropertyData" /> object array.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -276,20 +249,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the number of objects in the <see cref="T:System.Management.PropertyDataCollection" />.</summary>
-        <value>Returns an <see cref="T:System.Int32" /> value representing the number of objects in the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The number of objects in the collection.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value>The number of objects in the collection.</value>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.Count" />
       </Docs>
     </Member>
@@ -323,9 +284,6 @@
 
  If an enumerator is rewindable, the objects in the collection will be kept available for multiple enumerations.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -351,20 +309,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value indicating whether the object is synchronized.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether the object is synchronized.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- `true` if the object is synchronized; otherwise, `false`.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value><see langword="true" /> if the object is synchronized; otherwise, <see langword="false" />.</value>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.IsSynchronized" />
       </Docs>
     </Member>
@@ -390,22 +336,13 @@
       <Docs>
         <param name="propertyName">The name of the property to retrieve.</param>
         <summary>Gets the specified property from the <see cref="T:System.Management.PropertyDataCollection" />, using [] syntax. This property is the indexer for the <see cref="T:System.Management.PropertyDataCollection" /> class.</summary>
-        <value>Returns a <see cref="T:System.Management.PropertyData" /> containing the data for a specified property in the collection.</value>
+        <value>The data for a specified property in the collection.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## Property Value
- A <xref:System.Management.PropertyData>, based on the name specified.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
- The following example gets the **Freespace** property from a <xref:System.Management.ManagementClass>.
+
+The following example gets the **Freespace** property from a <xref:System.Management.ManagementClass>.
 
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_PropertyDataCollection_Item/cs/PropertyDataCollection_Item.cs" id="Snippet1":::
  :::code language="vb" source="~/snippets/visualbasic/System.Management/PropertyDataCollection/Item/PropertyDataCollection_Item.vb" id="Snippet1":::
@@ -442,9 +379,6 @@
 ## Remarks
  Properties can only be removed from class definitions, not from instances. This method is only valid when invoked on a property collection in a <xref:System.Management.ManagementClass>.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -470,20 +404,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the object to be used for synchronization.</summary>
-        <value>Returns an <see cref="T:System.Object" /> value containing the object to be used for synchronization.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The object to be used for synchronization.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value>The object to be used for synchronization.</value>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.SyncRoot" />
       </Docs>
     </Member>

--- a/xml/System.Management/PutOptions.xml
+++ b/xml/System.Management/PutOptions.xml
@@ -148,7 +148,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the type of commit to be performed for the object.</summary>
-        <value>One of the enumeration values that indicates the type of commit to be performed for the object. The default value is <see cref="F:System.Management.PutType.Update" />.</value>
+        <value>One of the enumeration values that indicates the type of commit to be performed for the object. The default value is <see cref="F:System.Management.PutType.UpdateOnly" />.</value>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/xml/System.Management/PutOptions.xml
+++ b/xml/System.Management/PutOptions.xml
@@ -52,16 +52,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.PutOptions" /> class for put operations, using default values. This is the parameterless constructor.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -83,16 +74,7 @@
       <Docs>
         <param name="context">A provider-specific, named-value pairs context object to be passed through to the provider.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.PutOptions" /> class for committing a WMI object, using the specified provider-specific context.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -121,16 +103,7 @@
           <see langword="true" /> if the returned objects should contain amended (locale-aware) qualifiers; otherwise, <see langword="false" />.</param>
         <param name="putType">The type of commit to be performed (update or create).</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.PutOptions" /> class for committing a WMI object, using the specified option values.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clone">
@@ -153,16 +126,7 @@
       <Docs>
         <summary>Returns a copy of the object.</summary>
         <returns>The cloned object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>
@@ -184,20 +148,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the type of commit to be performed for the object.</summary>
-        <value>One of the enumeration values that indicates the type of commit to be performed for the object.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- The default value is <xref:System.Management.PutType>.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value>One of the enumeration values that indicates the type of commit to be performed for the object. The default value is <xref:System.Management.PutType>.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UseAmendedQualifiers">
@@ -220,19 +172,7 @@
         <summary>Gets or sets a value indicating whether the objects returned from WMI should contain amended information. Typically, amended information is localizable information attached to the WMI object, such as object and property descriptions.</summary>
         <value>
           <see langword="true" /> if the objects returned from WMI should contain amended information; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if the objects returned from WMI should contain amended information; otherwise, `false`. The default value is `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/PutOptions.xml
+++ b/xml/System.Management/PutOptions.xml
@@ -148,7 +148,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the type of commit to be performed for the object.</summary>
-        <value>One of the enumeration values that indicates the type of commit to be performed for the object. The default value is <xref:System.Management.PutType>.</value>
+        <value>One of the enumeration values that indicates the type of commit to be performed for the object. The default value is <see cref="F:System.Management.PutType.Update" />.</value>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/xml/System.Management/QualifierData.xml
+++ b/xml/System.Management/QualifierData.xml
@@ -26,14 +26,14 @@
   <Docs>
     <summary>Contains information about a WMI qualifier.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Examples  
- The following example lists qualifier information about the **Win32_Service** class using the <xref:System.Management.QualifierData> class. For more information about **Win32_Service**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example lists qualifier information about the **Win32_Service** class using the <xref:System.Management.QualifierData> class. For more information about **Win32_Service**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_QualifierData/cs/QualifierData.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/QualifierData/Overview/QualifierData.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/QualifierData/Overview/QualifierData.vb" id="Snippet1":::
+
  ]]></format>
     </remarks>
   </Docs>
@@ -56,19 +56,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating whether the qualifier is amended.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether the qualifier is amended.</value>
+        <value><see langword="true" /> if the qualifier is amended; otherwise, <see langword="false" />.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Amended qualifiers are qualifiers whose value can be localized through WMI. Localized qualifiers reside in separate namespaces in WMI and can be merged into the basic class definition when retrieved.  
-  
-## Property Value  
- `true` if this qualifier is amended; otherwise, `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Amended qualifiers are qualifiers whose value can be localized through WMI. Localized qualifiers reside in separate namespaces in WMI and can be merged into the basic class definition when retrieved.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -91,20 +85,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets a value indicating whether the qualifier has been defined locally on this class or has been propagated from a base class.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether the qualifier has been defined locally on this class or has been propagated from a base class.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if the qualifier has been defined locally on this class; otherwise, `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value><see langword="true" /> if the qualifier has been defined locally on this class; otherwise, <see langword="false" />.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsOverridable">
@@ -125,20 +107,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating whether the value of the qualifier can be overridden when propagated.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether the value of the qualifier can be overridden when propagated.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if the value of the qualifier can be overridden when propagated; otherwise, `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value><see langword="true" /> if the value of the qualifier can be overridden when propagated; otherwise, <see langword="false" />.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -159,26 +129,16 @@
       </ReturnValue>
       <Docs>
         <summary>Represents the name of the qualifier.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the name of the qualifier.</value>
+        <value>The name of the qualifier.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- The name of the qualifier.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example lists qualifier information about the **Win32_Service** class using the <xref:System.Management.QualifierData> class. For more information about **Win32_Service**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example lists qualifier information about the **Win32_Service** class using the <xref:System.Management.QualifierData> class. For more information about **Win32_Service**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_QualifierData_Name/cs/QualifierData_Name.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/QualifierData/Name/QualifierData_Name.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/QualifierData/Name/QualifierData_Name.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -201,20 +161,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating whether the qualifier should be propagated to instances of the class.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether the qualifier should be propagated to instances of the class.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if this qualifier should be propagated to instances of the class; otherwise, `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value><see langword="true" /> if the qualifier should be propagated to instances of the class; otherwise, <see langword="false" />.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PropagatesToSubclass">
@@ -235,20 +183,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating whether the qualifier should be propagated to subclasses of the class.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether the qualifier should be propagated to subclasses of the class.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- `true` if the qualifier should be propagated to subclasses of this class; otherwise, `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value><see langword="true" /> if the qualifier should be propagated to subclasses of the class; otherwise, <see langword="false" />.</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -269,27 +205,19 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the value of the qualifier.</summary>
-        <value>Returns an <see cref="T:System.Object" /> value containing the value of the qualifier.</value>
+        <value>The value of the qualifier.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Qualifiers can only be of the following subset of CIM types: string, uint16, uint32, sint32, uint64, sint64, real32, real64, or bool.  
-  
-## Property Value  
- The value of the qualifier.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example lists qualifier information about the **Win32_Service** class using the <xref:System.Management.QualifierData> class. For more information about **Win32_Service**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Qualifiers can only be of the following subset of CIM types: string, uint16, uint32, sint32, uint64, sint64, real32, real64, or bool.
+
+## Examples
+ The following example lists qualifier information about the **Win32_Service** class using the <xref:System.Management.QualifierData> class. For more information about **Win32_Service**, see the [Windows Management Instrumentation](/windows/desktop/wmisdk/wmi-start-page) documentation.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_QualifierData_Value/cs/QualifierData_Value.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/QualifierData/Value/QualifierData_Value.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/QualifierData/Value/QualifierData_Value.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Management/QualifierDataCollection+QualifierDataEnumerator.xml
+++ b/xml/System.Management/QualifierDataCollection+QualifierDataEnumerator.xml
@@ -30,14 +30,14 @@
   <Docs>
     <summary>Represents the enumerator for <see cref="T:System.Management.QualifierData" /> objects in the <see cref="T:System.Management.QualifierDataCollection" />.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Examples  
- The following example enumerates through all the qualifiers in the **Win32_LogicalDisk** class and displays their values.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example enumerates through all the qualifiers in the **Win32_LogicalDisk** class and displays their values.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_QualifierDataEnumerator/cs/QualifierDataEnumerator.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/QualifierDataCollection+QualifierDataEnumerator/Overview/QualifierDataEnumerator.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/QualifierDataCollection+QualifierDataEnumerator/Overview/QualifierDataEnumerator.vb" id="Snippet1":::
+
  ]]></format>
     </remarks>
   </Docs>
@@ -61,16 +61,7 @@
       <Docs>
         <summary>Gets or sets the current <see cref="T:System.Management.QualifierData" /> in the <see cref="T:System.Management.QualifierDataCollection" /> enumeration.</summary>
         <value>The current <see cref="T:System.Management.QualifierData" /> element in the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MoveNext">
@@ -97,16 +88,7 @@
         <summary>Moves to the next element in the <see cref="T:System.Management.QualifierDataCollection" /> enumeration.</summary>
         <returns>
           <see langword="true" /> if the enumerator was successfully advanced to the next element; <see langword="false" /> if the enumerator has passed the end of the collection.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Reset">
@@ -131,16 +113,7 @@
       <Parameters />
       <Docs>
         <summary>Resets the enumerator to the beginning of the <see cref="T:System.Management.QualifierDataCollection" /> enumeration.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerator.Current">

--- a/xml/System.Management/QualifierDataCollection.xml
+++ b/xml/System.Management/QualifierDataCollection.xml
@@ -78,16 +78,7 @@
         <param name="qualifierName">The name of the <see cref="T:System.Management.QualifierData" /> to be added to the <see cref="T:System.Management.QualifierDataCollection" />.</param>
         <param name="qualifierValue">The value for the new qualifier.</param>
         <summary>Adds a <see cref="T:System.Management.QualifierData" /> to the <see cref="T:System.Management.QualifierDataCollection" />. This overload specifies the qualifier name and value.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Add">
@@ -126,16 +117,7 @@
         <param name="isOverridable">
           <see langword="true" /> to specify that this qualifier's value is overridable in instances of subclasses; otherwise, <see langword="false" />.</param>
         <summary>Adds a <see cref="T:System.Management.QualifierData" /> to the <see cref="T:System.Management.QualifierDataCollection" />. This overload specifies all property values for a <see cref="T:System.Management.QualifierData" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyTo">
@@ -174,16 +156,7 @@
         <param name="array">The array to which to copy the <see cref="T:System.Management.QualifierDataCollection" />.</param>
         <param name="index">The index from which to start copying.</param>
         <summary>Copies the <see cref="T:System.Management.QualifierDataCollection" /> into an array.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Collections.ICollection.CopyTo(System.Array,System.Int32)" />
       </Docs>
     </Member>
@@ -211,16 +184,7 @@
         <param name="qualifierArray">The specialized array of <see cref="T:System.Management.QualifierData" /> objects to which to copy the <see cref="T:System.Management.QualifierDataCollection" />.</param>
         <param name="index">The index from which to start copying.</param>
         <summary>Copies the <see cref="T:System.Management.QualifierDataCollection" /> into a specialized              <see cref="T:System.Management.QualifierData" /> array.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Count">
@@ -245,19 +209,7 @@
       <Docs>
         <summary>Gets the number of <see cref="T:System.Management.QualifierData" /> objects in the <see cref="T:System.Management.QualifierDataCollection" />.</summary>
         <value>The number of objects in the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The number of objects in the collection.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.Count" />
       </Docs>
     </Member>
@@ -291,9 +243,6 @@
 
  If an enumerator is rewindable, the objects in the collection will be kept available for multiple enumerations.
 
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
  ]]></format>
         </remarks>
       </Docs>
@@ -321,19 +270,7 @@
         <summary>Gets a value indicating whether the object is synchronized (thread-safe).</summary>
         <value>
           <see langword="true" /> if the object is synchronized; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- `true` if the object is synchronized; otherwise, `false`.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.IsSynchronized" />
       </Docs>
     </Member>
@@ -360,19 +297,7 @@
         <param name="qualifierName">The name of the <see cref="T:System.Management.QualifierData" /> to access in the <see cref="T:System.Management.QualifierDataCollection" />.</param>
         <summary>Gets the specified <see cref="T:System.Management.QualifierData" /> from the <see cref="T:System.Management.QualifierDataCollection" />.</summary>
         <value>The data for a specified qualifier in the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- A <xref:System.Management.QualifierData>, based on the name specified.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Remove">
@@ -397,16 +322,7 @@
       <Docs>
         <param name="qualifierName">The name of the <see cref="T:System.Management.QualifierData" /> to remove.</param>
         <summary>Removes a <see cref="T:System.Management.QualifierData" /> from the <see cref="T:System.Management.QualifierDataCollection" /> by name.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SyncRoot">
@@ -431,19 +347,7 @@
       <Docs>
         <summary>Gets the object to be used for synchronization.</summary>
         <value>The object to be used for synchronization.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The object to be used for synchronization.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.SyncRoot" />
       </Docs>
     </Member>

--- a/xml/System.Management/RelatedObjectQuery.xml
+++ b/xml/System.Management/RelatedObjectQuery.xml
@@ -52,16 +52,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.RelatedObjectQuery" /> class. This is the parameterless constructor.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -83,16 +74,7 @@
       <Docs>
         <param name="queryOrSourceObject">The query string or the path of the source object.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.RelatedObjectQuery" /> class. If the specified string can be successfully parsed as a WQL query, it is considered to be the query string; otherwise, it is assumed to be the path of the source object for the query. In this case, the query is assumed to be an instance query.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -116,16 +98,7 @@
         <param name="sourceObject">The path of the source object for this query.</param>
         <param name="relatedClass">The related objects' class.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.RelatedObjectQuery" /> class for the given source object and related class. The query is assumed to be an instance query (as opposed to a schema query).</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -162,16 +135,7 @@
         <param name="relatedRole">The role that the related objects are required to play in the relationship.</param>
         <param name="thisRole">The role that the source class is required to play in the relationship.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.RelatedObjectQuery" /> class for a schema query using the given set of parameters. This constructor is used for schema queries only: the first parameter must be set to <see langword="true" /> .</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -208,16 +172,7 @@
         <param name="classDefinitionsOnly">
           <see langword="true" /> to return only the class definitions of the related objects; otherwise, false .</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.RelatedObjectQuery" /> class for the given set of parameters. The query is assumed to be an instance query (as opposed to a schema query).</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BuildQuery">
@@ -239,16 +194,7 @@
       <Parameters />
       <Docs>
         <summary>Builds the query string according to the current property values.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClassDefinitionsOnly">
@@ -269,19 +215,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating that for all instances that adhere to the query, only their class definitions be returned. This parameter is only valid for instance queries.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating that for all instances that adhere to the query, only their class definitions are to be returned.</value>
+        <value><see langword="true"/> if the query requests only class definitions of the result set; otherwise, <see langword="false"/>.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new flag.  
-  
-## Property Value  
- `true` if the query requests only class definitions of the result set; otherwise, `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new flag.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -306,16 +246,7 @@
       <Docs>
         <summary>Creates a copy of the object.</summary>
         <returns>The copied object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>
@@ -337,19 +268,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating whether this is a schema query or an instance query.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether this is a schema query.</value>
+        <value><see langword="true"/> if this query should be evaluated over the schema; otherwise, <see langword="false"/>.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new query type.  
-  
-## Property Value  
- `true` if this query should be evaluated over the schema; `false` if the query should be evaluated over instances.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new query type.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -376,16 +301,7 @@
       <Docs>
         <param name="query">The query string to be parsed.</param>
         <summary>Parses the query string and sets the property values accordingly.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RelatedClass">
@@ -406,27 +322,19 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the class of the endpoint objects (the related class).</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the related class name.</value>
+        <value>The related class name.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new related class.  
-  
-## Property Value  
- A string containing the related class name.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example sets a WMI class to be related to a <xref:System.Management.RelatedObjectQuery>.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new related class.
+
+## Examples
+ The following example sets a WMI class to be related to a <xref:System.Management.RelatedObjectQuery>.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_RelatedObjectQuery_RelatedClass/cs/RelatedObjectQuery_RelatedClass.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/RelatedObjectQuery/RelatedClass/RelatedObjectQuery_RelatedClass.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/RelatedObjectQuery/RelatedClass/RelatedObjectQuery_RelatedClass.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -449,19 +357,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a qualifier required to be defined on the related objects.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the name of the qualifier required on the related object.</value>
+        <value>The name of the qualifier required on the related object.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new qualifier.  
-  
-## Property Value  
- A string containing the name of the qualifier required on the related objects.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new qualifier.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -484,19 +386,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the role that the related objects returned should be playing in the relationship.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the role of the related objects.</value>
+        <value>The role of the related objects.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new role.  
-  
-## Property Value  
- A string containing the role of the related objects.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new role.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -519,27 +415,19 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the type of relationship (association).</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the relationship class name.</value>
+        <value>The relationship class name.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new relationship class.  
-  
-## Property Value  
- A string containing the relationship class name.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example sets the type of relationship between a WMI class and a <xref:System.Management.RelatedObjectQuery>.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new relationship class.
+
+## Examples
+ The following example sets the type of relationship between a WMI class and a <xref:System.Management.RelatedObjectQuery>.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_RelatedObjectQuery_RelationshipClass/cs/RelatedObjectQuery_RelationshipClass.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/RelatedObjectQuery/RelationshipClass/RelatedObjectQuery_RelationshipClass.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/RelatedObjectQuery/RelationshipClass/RelatedObjectQuery_RelationshipClass.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -562,19 +450,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a qualifier required to be defined on the relationship objects.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the name of the qualifier required on the relationship objects.</value>
+        <value>The name of the qualifier required on the relationship objects.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new qualifier.  
-  
-## Property Value  
- A string containing the name of the qualifier required on the relationship objects.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new qualifier.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -597,19 +479,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the source object to be used for the query. For instance queries, this is typically an instance path. For schema queries, this is typically a class name.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the path of the object to be used for the query.</value>
+        <value>The path of the object to be used for the query.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new source object.  
-  
-## Property Value  
- A string representing the path of the object to be used for the query.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new source object.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -632,19 +508,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the role that the source object should be playing in the relationship.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the role of this object.</value>
+        <value>The role of this object.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new role.  
-  
-## Property Value  
- A string containing the role of this object.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new role.
+
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Management/RelationshipQuery.xml
+++ b/xml/System.Management/RelationshipQuery.xml
@@ -52,16 +52,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.RelationshipQuery" /> class. This is the parameterless constructor.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -84,21 +75,14 @@
         <param name="queryOrSourceObject">The query string or the class name for this query.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.RelationshipQuery" /> class. If the specified string can be successfully parsed as a WQL query, it is considered to be the query string; otherwise, it is assumed to be the path of the source object for the query. In this case, the query is assumed to be an instances query.</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
-   
-  
-## Examples  
- The following example sets the type of relationship between a WMI class and a <xref:System.Management.RelatedObjectQuery>.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Examples
+ The following example sets the type of relationship between a WMI class and a <xref:System.Management.RelatedObjectQuery>.
+
  :::code language="csharp" source="~/snippets/csharp/VS_Snippets_WindowsServer/wminet_RelationshipQuery-S/cs/RelationshipQuery-S.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Management/RelationshipQuery/.ctor/RelationshipQuery-S.vb" id="Snippet1":::  
-  
+ :::code language="vb" source="~/snippets/visualbasic/System.Management/RelationshipQuery/.ctor/RelationshipQuery-S.vb" id="Snippet1":::
+
  ]]></format>
         </remarks>
       </Docs>
@@ -124,16 +108,7 @@
         <param name="sourceObject">The path of the source object for this query.</param>
         <param name="relationshipClass">The type of relationship for which to query.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.RelationshipQuery" /> class for the given source object and relationship class. The query is assumed to be an instance query (as opposed to a schema query).</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -164,16 +139,7 @@
         <param name="relationshipQualifier">A qualifier required to be present on the relationship class.</param>
         <param name="thisRole">The role that the source class is required to play in the relationship.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.RelationshipQuery" /> class for a schema query using the given set of parameters. This constructor is used for schema queries only, so the first parameter must be true.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -203,16 +169,7 @@
         <param name="thisRole">The role that the source object is required to play in the relationship.</param>
         <param name="classDefinitionsOnly">When this method returns, it contains a Boolean that indicates that only class definitions for the resulting objects are returned.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.RelationshipQuery" /> class for the given set of parameters. The query is assumed to be an instance query (as opposed to a schema query).</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BuildQuery">
@@ -234,16 +191,7 @@
       <Parameters />
       <Docs>
         <summary>Builds the query string according to the current property values.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClassDefinitionsOnly">
@@ -264,19 +212,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating that only the class definitions of the relevant relationship objects be returned.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating that only the class definitions of the relevant relationship objects be returned.</value>
+        <value><see langword="true"/> if the query requests only class definitions of the result set; otherwise, <see langword="false"/>.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. As a side-effect, the query string is rebuilt to reflect the new flag.  
-  
-## Property Value  
- `true` if the query requests only class definitions of the result set; otherwise, `false`.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. As a side-effect, the query string is rebuilt to reflect the new flag.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -301,16 +243,7 @@
       <Docs>
         <summary>Creates a copy of the object.</summary>
         <returns>The copied object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>
@@ -332,19 +265,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating whether this query is a schema query or an instance query.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether this query is a schema query.</value>
+        <value><see langword="true"/> if this query should be evaluated over the schema; otherwise, <see langword="false"/>.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new query type.  
-  
-## Property Value  
- `true` if this query should be evaluated over the schema; `false` if the query should be evaluated over instances.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new query type.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -371,16 +298,7 @@
       <Docs>
         <param name="query">The query string to be parsed.</param>
         <summary>Parses the query string and sets the property values accordingly.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RelationshipClass">
@@ -401,19 +319,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the class of the relationship objects wanted in the query.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the relationship class name.</value>
+        <value>The relationship class name.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new class.  
-  
-## Property Value  
- A string containing the relationship class name.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new class.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -436,19 +348,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a qualifier required on the relationship objects.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the name of the qualifier required on the relationship objects.</value>
+        <value>The name of the qualifier required on the relationship objects.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new qualifier.  
-  
-## Property Value  
- A string containing the name of the qualifier required on the relationship objects.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new qualifier.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -471,19 +377,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the source object for this query.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the path of the object to be used for the query.</value>
+        <value>The path of the object to be used for the query.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new source object.  
-  
-## Property Value  
- A string representing the path of the object to be used for the query.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new source object.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -506,19 +406,13 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the role of the source object in the relationship.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the role of this object.</value>
+        <value>The role of this object.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new role.  
-  
-## Property Value  
- A string containing the role of this object.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new role.
+
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Management/SelectQuery.xml
+++ b/xml/System.Management/SelectQuery.xml
@@ -411,7 +411,7 @@
         <ReturnType>System.Collections.Specialized.StringCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Ggets or sets an array of property names to be selected in the query.</summary>
+        <summary>Gets or sets an array of property names to be selected in the query.</summary>
         <value>The names of the properties to be selected in the query.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[

--- a/xml/System.Management/SelectQuery.xml
+++ b/xml/System.Management/SelectQuery.xml
@@ -52,16 +52,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.SelectQuery" /> class. This is the parameterless constructor.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -85,13 +76,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.SelectQuery" /> class for the specified query or the specified class name.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a <xref:System.Management.SelectQuery> by specifying a query.
@@ -128,13 +112,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example initializes a <xref:System.Management.SelectQuery> by specifying a condition.
 
@@ -168,13 +145,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.SelectQuery" /> class with the specified class name and condition.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a <xref:System.Management.SelectQuery> by specifying a WMI class name and a condition.
@@ -212,13 +182,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
 ## Examples
  The following example initializes a <xref:System.Management.SelectQuery> by specifying a WMI class name, condition, and array of properties.
 
@@ -248,16 +211,7 @@
       <Parameters />
       <Docs>
         <summary>Builds the query string according to the current property values.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClassName">
@@ -278,7 +232,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the class name to be selected from in the query.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the name of the class in the query.</value>
+        <value>The name of the class in the query.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -286,14 +240,6 @@
  Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new class name.
 
  A value for the **ClassName** property would replace the \<className> item in a SELECT query of the form "SELECT * FROM \<className> WHERE \<condition>".
-
-## Property Value
- A string representing the name of the class in the query.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a <xref:System.Management.SelectQuery> by specifying a query and then changes the <xref:System.Management.SelectQuery.ClassName> property.
@@ -325,16 +271,7 @@
       <Docs>
         <summary>Creates a copy of the object.</summary>
         <returns>The copied object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Condition">
@@ -355,7 +292,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the condition to be applied in the SELECT query.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the condition to be applied to the SELECT query.</value>
+        <value>The condition to be applied to the SELECT query.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -363,12 +300,6 @@
  Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new condition.
 
  A value for the **Condition** property would replace the \<condition> item in a SELECT query of the form "SELECT * FROM \<className> WHERE \<condition>".
-
-## Property Value
- A string containing the condition to be applied in the SELECT query.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
 
  ]]></format>
         </remarks>
@@ -392,18 +323,12 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value indicating whether this query is a schema query or an instances query.</summary>
-        <value>Returns a <see cref="T:System.Boolean" /> value indicating whether the query is a schema query.</value>
+        <value><see langword="true"/> if this query should be evaluated over the schema; <see langword="false"/> if the query should be evaluated over instances.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new query type.
-
-## Property Value
- `true` if this query should be evaluated over the schema; `false` if the query should be evaluated over instances.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
 
  ]]></format>
         </remarks>
@@ -431,16 +356,7 @@
       <Docs>
         <param name="query">The query string to be parsed.</param>
         <summary>Parses the query string and sets the property values accordingly.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QueryString">
@@ -461,20 +377,12 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the query in the <see cref="T:System.Management.SelectQuery" /> object, in string form.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the query.</value>
+        <value>The query.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  Setting this property value overrides any previous value stored in the object. In addition, setting this property causes the other members of the object to be updated when the string is reparsed.
-
-## Property Value
- A string representing the query.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a <xref:System.Management.SelectQuery> with the parameterless constructor and then changes the <xref:System.Management.SelectQuery.QueryString> property.
@@ -504,7 +412,7 @@
       </ReturnValue>
       <Docs>
         <summary>Ggets or sets an array of property names to be selected in the query.</summary>
-        <value>Returns a <see cref="T:System.Collections.Specialized.StringCollection" /> containing the names of the properties to be selected in the query.</value>
+        <value>The names of the properties to be selected in the query.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -512,12 +420,6 @@
  Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new properties.
 
  A value for the **SelectedProperties** property would replace the \<property> item in a SELECT query of the form "SELECT \<property> FROM \<className> WHERE \<condition>".
-
-## Property Value
- A <xref:System.Collections.Specialized.StringCollection> containing the names of the properties to be selected in the query.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
 
  ]]></format>
         </remarks>

--- a/xml/System.Management/StoppedEventArgs.xml
+++ b/xml/System.Management/StoppedEventArgs.xml
@@ -47,19 +47,7 @@
       <Docs>
         <summary>Gets the completion status of the operation.</summary>
         <value>The status of the operation.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- A <xref:System.Management.ManagementStatus> value representing the status of the operation.  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Management/WqlEventQuery.xml
+++ b/xml/System.Management/WqlEventQuery.xml
@@ -52,16 +52,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.WqlEventQuery" /> class. This is the parameterless constructor.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -85,13 +76,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.WqlEventQuery" /> class based on the given query string or event class name.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a <xref:System.Management.WqlEventQuery> by specifying a query and then initializes a <xref:System.Management.WqlEventQuery> by specifying an event.
@@ -124,16 +108,7 @@
         <param name="eventClassName">The name of the event class to query.</param>
         <param name="condition">The condition to apply to events of the specified class.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.WqlEventQuery" /> class for the specified event class name, with the specified condition.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -159,13 +134,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.WqlEventQuery" /> class for the specified event class, with the specified latency time.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a <xref:System.Management.WqlEventQuery> by specifying an event and a time span value specifying the latency acceptable for receiving this event.
@@ -200,16 +168,7 @@
         <param name="condition">The condition to apply to events of the specified class.</param>
         <param name="groupWithinInterval">The specified interval at which WMI sends one <c>aggregate event</c>, rather than many events.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.WqlEventQuery" /> class with the specified event class name, condition, and grouping interval.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -237,13 +196,6 @@
         <summary>Initializes a new instance of the <see cref="T:System.Management.WqlEventQuery" /> class with the specified event class name, polling interval, and condition.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example creates the event query: "SELECT * FROM __InstanceCreationEvent *WITHIN* 10 WHERE TargetInstance ISA Win32_Service ", which sends notification of the creation of **Win32_Service** instances, with a 10-second polling interval.
@@ -280,16 +232,7 @@
         <param name="groupWithinInterval">The specified interval at which WMI sends one <c>aggregate event</c>, rather than many events.</param>
         <param name="groupByPropertyList">The properties in the event class by which the events should be grouped.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.WqlEventQuery" /> class with the specified event class name, condition, grouping interval, and grouping properties.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -324,11 +267,6 @@
         <remarks>
           <format type="text/markdown"><![CDATA[
 
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
 ## Examples
 
  The following example creates the event query: "SELECT * FROM __InstanceCreationEvent WHERE TargetInstance ISA Win32_NTLogEvent GROUP WITHIN 600 BY TargetInstance.SourceName HAVING NumberOfEvents > 15", which delivers aggregate events only if the number of **Win32_NTLogEvent** events received from the same source exceeds 15.
@@ -359,16 +297,7 @@
       <Parameters />
       <Docs>
         <summary>Builds the query string according to the current property values.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clone">
@@ -391,16 +320,7 @@
       <Docs>
         <summary>Creates a copy of the object.</summary>
         <returns>The copied object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>
@@ -422,20 +342,14 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the condition to be applied to events of the specified class.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the condition or conditions in the event query.</value>
+        <value>The condition or conditions in the event query.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new condition.
 
-## Property Value
  The condition is represented as a string, containing one or more clauses of the form: \<propName> \<operator> \<value> combined with logical operators. \<propName> must represent a property defined on the event class specified in this query.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new <xref:System.Management.WqlEventQuery> and displays the event query string.
@@ -465,20 +379,12 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the event class to query.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the name of the event class in the event query.</value>
+        <value>The name of the event class in the event query.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new class name.
-
-## Property Value
- A string containing the name of the event class to query.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new <xref:System.Management.WqlEventQuery> and displays the event query string.
@@ -508,20 +414,12 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets properties in the event to be used for grouping events of the same type.</summary>
-        <value>Returns a <see cref="T:System.Collections.Specialized.StringCollection" /> containing the properties in the event to be used for grouping events of the same type.</value>
+        <value>The properties in the event to be used for grouping events of the same type, or <see langword="null" /> if no grouping is required.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new grouping.
-
-## Property Value
- Null, if no grouping is required; otherwise, a collection of event property names.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new <xref:System.Management.WqlEventQuery> and displays the event query string.
@@ -551,20 +449,12 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the interval to be used for grouping events of the same type.</summary>
-        <value>Returns a <see cref="T:System.TimeSpan" /> value containing the interval used for grouping events of the same type.</value>
+        <value>The interval used for grouping events of the same type, or <see langword="null" /> if no grouping is required.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new interval.
-
-## Property Value
- Null, if there is no grouping involved; otherwise, the interval in which WMI should group events of the same type.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new <xref:System.Management.WqlEventQuery> and displays the event query string.
@@ -594,20 +484,12 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the condition to be applied to the aggregation of events, based on the number of events received.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the condition applied to the aggregation of events, based on the number of events received.</value>
+        <value>The condition applied to the aggregation of events, based on the number of events received, or <see langword="null" /> if no aggregation is required.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
  Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new grouping condition.
-
-## Property Value
- Null, if no aggregation or no condition should be applied; otherwise, a condition of the form "NumberOfEvents \<operator> \<value>".
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new <xref:System.Management.WqlEventQuery> and displays the event query string.
@@ -641,16 +523,7 @@
       <Docs>
         <param name="query">The query string to be parsed.</param>
         <summary>Parses the query string and sets the property values accordingly.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QueryLanguage">
@@ -671,20 +544,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets  the language of the query.</summary>
-        <value>Returns a <see cref="T:System.String" /> value that contains the query language that the query is written in.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- The value of this property in this object is always "WQL".
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
- ]]></format>
-        </remarks>
+        <value>The query language that the query is written in. The value of this property is always "WQL".</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QueryString">
@@ -705,19 +566,9 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the string representing the query.</summary>
-        <value>Returns a <see cref="T:System.String" /> value containing the query.</value>
+        <value>The query.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-## Property Value
- A string representing the query.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new <xref:System.Management.WqlEventQuery> and displays the event query string.
@@ -747,7 +598,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the polling interval to be used in this query.</summary>
-        <value>Returns a <see cref="T:System.TimeSpan" /> value containing the polling interval used in the event query.</value>
+        <value>The polling interval used in the event query, if polling is required; otherwise, <see langword="null" />.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -755,14 +606,6 @@
  This property should only be set in cases where there is no *event provider* for the event requested, and WMI is required to poll for the requested condition.
 
  Setting this property value overrides any previous value stored in the object. The query string is rebuilt to reflect the new interval.
-
-## Property Value
- Null, if there is no polling involved; otherwise, a valid <xref:System.TimeSpan> value if polling is required.
-
-## .NET Framework Security
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
 
 ## Examples
  The following example initializes a new <xref:System.Management.WqlEventQuery> that represents the query: "SELECT * FROM __InstanceCreationEvent *WITHIN* 1 WHERE TargetInstance ISA 'Win32_Process'".

--- a/xml/System.Management/WqlObjectQuery.xml
+++ b/xml/System.Management/WqlObjectQuery.xml
@@ -52,16 +52,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Management.WqlObjectQuery" /> class. This is the parameterless constructor.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -83,16 +74,7 @@
       <Docs>
         <param name="query">The representation of the data query.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Management.WqlObjectQuery" /> class initialized to the specified query.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clone">
@@ -115,16 +97,7 @@
       <Docs>
         <summary>Creates a copy of the object.</summary>
         <returns>The copied object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.ICloneable.Clone" />
       </Docs>
     </Member>
@@ -146,20 +119,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the language of the query.</summary>
-        <value>The language of the query.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-## Property Value  
- The value of this property is always "WQL".  
-  
-## .NET Framework Security  
- Full trust for the immediate caller. This member cannot be used by partially trusted code. For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).  
-  
- ]]></format>
-        </remarks>
+        <value>The language of the query. The value of this property is always "WQL".</value>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
.NET Framework API ref has moved to its own repo (https://github.com/dotnet/dotnetfw-api-docs), so we can clean up .NET Framework remarks, exceptions, and code examples out of this repo. Contributes to #12513.

Removes remarks and examples related to:

- .NET Framework versions
- Code-access security
- Configuring apps via app.config file
- App domains

Also removes *all* remarks from obsolete APIs.

*Hide whitespace changes*