### PR TITLE
Remove .NET Framework remarks (System.Security)

### DIFF
--- a/xml/System.Security/AllowPartiallyTrustedCallersAttribute.xml
+++ b/xml/System.Security/AllowPartiallyTrustedCallersAttribute.xml
@@ -60,31 +60,7 @@
 
 ## Remarks
 > [!IMPORTANT]
-> Partially trusted code is no longer supported. This attribute has no effect in .NET Core.
-
-> [!NOTE]
->  The .NET Framework 4 introduces new security rules that affect the behavior of the <xref:System.Security.AllowPartiallyTrustedCallersAttribute> attribute (see [Security-Transparent Code, Level 2](/dotnet/framework/misc/security-transparent-code-level-2)). In the .NET Framework 4, all code defaults to security-transparent, that is, partially trusted. However, you can annotate individual types and members to assign them other transparency attributes. For this and other security changes, see [Security Changes](/dotnet/framework/security/security-changes).
-
- .NET Framework version 2.0 () assemblies must be strong-named to effectively use the <xref:System.Security.AllowPartiallyTrustedCallersAttribute> (APTCA) attribute. .NET Framework 4 () assemblies do not have to be strong-named for the APTCA attribute to be effective, and they can contain transparent, security-critical and security-safe-critical code. For more information about applying attributes at the assembly level, see [Applying Attributes](/dotnet/standard/attributes/applying-attributes).
-
- By default, if a strong-named,  assembly does not explicitly apply this attribute at the assembly level, it can be called only by other assemblies that are granted full trust. This restriction is enforced by placing a <xref:System.Security.Permissions.SecurityAction.LinkDemand> for `FullTrust` on every public or protected method on every publicly accessible class in the assembly. Assemblies that are intended to be called by partially trusted code can declare their intent through the use of <xref:System.Security.AllowPartiallyTrustedCallersAttribute>. An example of the declaration in C# is `[assembly:AllowPartiallyTrustedCallers]`; an example in Visual Basic is `<assembly:AllowPartiallyTrustedCallers>`.
-
-> [!CAUTION]
->  The presence of this assembly-level attribute prevents the default behavior of placing `FullTrust` <xref:System.Security.Permissions.SecurityAction.LinkDemand> security checks, and makes the assembly callable from any other (partially or fully trusted) assembly.
-
- When the APTCA attribute is present, all other security checks function as intended, including any class-level or method-level declarative security attributes that are present. This attribute blocks only the implicit, fully trusted caller demand.
-
- This is not a declarative security attribute, but a regular attribute (it derives from <xref:System.Attribute?displayProperty=nameWithType>, not from <xref:System.Security.Permissions.SecurityAttribute?displayProperty=nameWithType>).
-
- For more information, see [Using Libraries from Partially Trusted Code](/dotnet/framework/misc/using-libraries-from-partially-trusted-code).
-
-
-
-## Examples
- The following example shows how to use the <xref:System.Security.AllowPartiallyTrustedCallersAttribute> class.
-
- :::code language="csharp" source="~/snippets/csharp/System.Security/AllowPartiallyTrustedCallersAttribute/Overview/AllowPartiallyTrustedCallersAttribute.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Security/AllowPartiallyTrustedCallersAttribute/Overview/allowpartiallytrustedcallersattribute.vb" id="Snippet1":::
+> Partially trusted code is no longer supported. This attribute has no effect in modern .NET.
 
  ]]></format>
     </remarks>
@@ -126,19 +102,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Security.AllowPartiallyTrustedCallersAttribute" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This attribute should be applied only at the assembly level.
-
-
-
-## Examples
- For an example of how to use this constructor, see the code example provided for the <xref:System.Security.AllowPartiallyTrustedCallersAttribute> class.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PartialTrustVisibilityLevel">
@@ -178,38 +142,7 @@
       <Docs>
         <summary>Gets or sets the default partial trust visibility for code that is marked with the <see cref="T:System.Security.AllowPartiallyTrustedCallersAttribute" /> (APTCA) attribute.</summary>
         <value>One of the enumeration values. The default is <see cref="F:System.Security.PartialTrustVisibilityLevel.VisibleToAllHosts" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The following examples demonstrate how to use this property.
-
-- Default, unconditional APTCA:
-
-    ```
-    [assembly: AllowPartiallyTrustedCallers]
-    ```
-
-     Defaults to <xref:System.Security.PartialTrustVisibilityLevel.VisibleToAllHosts>.
-
-- Explicit, unconditional APTCA:
-
-    ```
-    [assembly: AllowPartiallyTrustedCallers(PartialTrustVisibilityLevel=VisibleToAllHosts)]
-    ```
-
-     The assembly can always be called by partial-trust code.
-
-- Explicit, conditional APTCA:
-
-    ```
-    [assembly: AllowPartiallyTrustedCallers(PartialTrustVisibilityLevel=NotVisibleByDefault)]
-    ```
-
-     The assembly has been audited for partial trust, but it is not visible to partial-trust code by default. To make the assembly visible to partial-trust code, add it to the <xref:System.AppDomainSetup.PartialTrustVisibleAssemblies?displayProperty=nameWithType> property.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security/CodeAccessPermission.xml
+++ b/xml/System.Security/CodeAccessPermission.xml
@@ -57,23 +57,8 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Code access permissions use a stack walk to ensure that all callers of the code have been granted a permission. If a permission object is `null`, it is handled the same as a permission object with the state <xref:System.Security.Permissions.PermissionState.None?displayProperty=nameWithType>.
-
- The call stack is typically represented as growing down, so that methods higher in the call stack call methods lower in the call stack.
-
- Inheritors of the <xref:System.Security.CodeAccessPermission> class must be granted full trust to function correctly as permissions extending the security infrastructure. To determine that the inheritors are fully trusted, <xref:System.Security.CodeAccessPermission> issues an <xref:System.Security.Permissions.SecurityAction.InheritanceDemand> for <xref:System.Security.Permissions.SecurityPermissionFlag.ControlEvidence> = `true` and <xref:System.Security.Permissions.SecurityPermissionFlag.ControlPolicy> = `true`.
-
  ]]></format>
     </remarks>
-    <block subset="none" type="overrides">
-      <para>When you inherit from <see cref="T:System.Security.CodeAccessPermission" />, you must also implement the <see cref="T:System.Security.Permissions.IUnrestrictedPermission" /> interface.
-
- The following <see cref="T:System.Security.CodeAccessPermission" /> members must be overridden: <see cref="M:System.Security.CodeAccessPermission.Copy" />, <see cref="M:System.Security.CodeAccessPermission.Intersect(System.Security.IPermission)" />, <see cref="M:System.Security.CodeAccessPermission.IsSubsetOf(System.Security.IPermission)" />, <see cref="M:System.Security.CodeAccessPermission.ToXml" />, <see cref="M:System.Security.CodeAccessPermission.FromXml(System.Security.SecurityElement)" />, and <see cref="M:System.Security.CodeAccessPermission.Union(System.Security.IPermission)" />.
-
- You must also define a constructor that takes a <see cref="T:System.Security.Permissions.PermissionState" /> as its only parameter.
-
- You must apply the <see cref="T:System.SerializableAttribute" /> attribute to a class that inherits from <see cref="T:System.Security.CodeAccessPermission" />.</para>
-    </block>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -105,14 +90,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Security.CodeAccessPermission" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor is called to initialize state in the type whenever an instance of the derived class is created. Although you can explicitly call this constructor in the constructor declaration of the derived class constructor, this is not usually necessary; most compilers will automatically generate the call for you.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Assert">
@@ -151,21 +129,7 @@
       <Parameters />
       <Docs>
         <summary>Declares that the calling code can access the resource protected by a permission demand through the code that calls this method, even if callers higher in the stack have not been granted permission to access the resource. Using <see cref="M:System.Security.CodeAccessPermission.Assert" /> can create security issues.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The call stack is typically represented as growing down, so that methods higher in the call stack call methods lower in the call stack. Calling <xref:System.Security.CodeAccessPermission.Assert*> prevents a stack walk originating lower in the call stack from proceeding up the call stack beyond the code that calls this method. Therefore, even if callers higher on the call stack do not have the requisite permissions to access a resource, they can still access it through the code that calls this method on the necessary permission. An assertion is effective only if the code that calls <xref:System.Security.CodeAccessPermission.Assert*> passes the security check for the permission that it is asserting.
-
- The call to <xref:System.Security.CodeAccessPermission.Assert*> is effective until the calling code returns to its caller. Only one <xref:System.Security.CodeAccessPermission.Assert*> can be active on a frame. An attempt to call <xref:System.Security.CodeAccessPermission.Assert*> when an active <xref:System.Security.CodeAccessPermission.Assert*> exists on the frame results in a <xref:System.Security.SecurityException>. Call <xref:System.Security.CodeAccessPermission.RevertAssert*> or <xref:System.Security.CodeAccessPermission.RevertAll*> to remove an active <xref:System.Security.CodeAccessPermission.Assert*>.
-
- <xref:System.Security.CodeAccessPermission.Assert*> is ignored for a permission not granted because a demand for that permission will not succeed. However, if code lower on the call stack calls <xref:System.Security.CodeAccessPermission.Demand*> for that permission, a <xref:System.Security.SecurityException> is thrown when the stack walk reaches the code that tried to call <xref:System.Security.CodeAccessPermission.Assert*>. This happens because the code that called <xref:System.Security.CodeAccessPermission.Assert*> has not been granted the permission, even though it tried to <xref:System.Security.CodeAccessPermission.Assert*> it.
-
-> [!CAUTION]
->  Because calling <xref:System.Security.CodeAccessPermission.Assert*> removes the requirement that all code in the call chain must be granted permission to access the specified resource, it can open up security issues if used incorrectly or inappropriately. Therefore, it should be used with great caution.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">The calling code does not have <see cref="F:System.Security.Permissions.SecurityPermissionFlag.Assertion" />.
 
  -or-
@@ -214,14 +178,7 @@
       <Docs>
         <summary>When implemented by a derived class, creates and returns an identical copy of the current permission object.</summary>
         <returns>A copy of the current permission object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission object represents the same access to resources as the original permission object.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <block subset="none" type="overrides">
           <para>You must override this method in a derived class.</para>
         </block>
@@ -264,16 +221,7 @@
       <Parameters />
       <Docs>
         <summary>Forces a <see cref="T:System.Security.SecurityException" /> at run time if all callers higher in the call stack have not been granted the permission specified by the current instance.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is typically used by secure libraries to ensure that callers have permission to access a resource. For example, a file class in a secure class library calls <xref:System.Security.CodeAccessPermission.Demand*> for the necessary <xref:System.Security.Permissions.FileIOPermission> before performing a file operation requested by the caller.
-
- The permissions of the code that calls this method are not examined; the check begins from the immediate caller of that code and proceeds up the stack. The call stack is typically represented as growing down, so that methods higher in the call stack call methods lower in the call stack. <xref:System.Security.CodeAccessPermission.Demand*> succeeds only if no <xref:System.Security.SecurityException> is raised.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have the permission specified by the current instance.
 
  -or-
@@ -326,22 +274,7 @@
       <Parameters />
       <Docs>
         <summary>Prevents callers higher in the call stack from using the code that calls this method to access the resource specified by the current instance.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!IMPORTANT]
->  The <xref:System.Security.CodeAccessPermission.Deny*> method should be used only to protect resources from accidental access by fully trusted code. It should not be used to protect resources from intentional misuse by untrusted code. For example, if method `A` issues a <xref:System.Security.CodeAccessPermission.Deny*> for a permission and then calls method `B`, method `B` can overtly override the <xref:System.Security.CodeAccessPermission.Deny*> by issuing an <xref:System.Security.CodeAccessPermission.Assert*>. The called method is always higher in the stack. Therefore, if method `B` tries to access a protected resource, the security system begins checking for permissions with it because method `B` is the immediate caller, and then walks down the stack to confirm that there is no <xref:System.Security.CodeAccessPermission.Deny*> or <xref:System.Security.CodeAccessPermission.PermitOnly*> lower in the stack. Method `B`, which is trying to access the resource, can stop the stack walk immediately by using the <xref:System.Security.CodeAccessPermission.Assert*> method. In that case, the <xref:System.Security.CodeAccessPermission.Deny*> placed on the stack by method `A` (the calling method) is never discovered.
-
- This method prevents callers higher in the call stack from accessing the protected resource through the code that calls this method, even if those callers have been granted permission to access it. The call stack is typically represented as growing down, so that methods higher in the call stack call methods lower in the call stack.
-
- <xref:System.Security.CodeAccessPermission.Deny*> can limit the liability of the programmer or help prevent accidental security issues because it helps prevent the method that calls <xref:System.Security.CodeAccessPermission.Deny*> from being used to access the resource protected by the denied permission. If a method calls <xref:System.Security.CodeAccessPermission.Deny*> on a permission, and if a <xref:System.Security.CodeAccessPermission.Demand*> for that permission is invoked by a caller lower in the call stack, that security check will fail when it reaches the <xref:System.Security.CodeAccessPermission.Deny*>.
-
- The call to <xref:System.Security.CodeAccessPermission.Deny*> is effective until the calling code returns to its caller. Only one <xref:System.Security.CodeAccessPermission.Deny*> can be active on a frame. An attempt to call <xref:System.Security.CodeAccessPermission.Deny*> when an active <xref:System.Security.CodeAccessPermission.Deny*> exists on the frame results in a <xref:System.Security.SecurityException>. Call <xref:System.Security.CodeAccessPermission.RevertDeny*> or <xref:System.Security.CodeAccessPermission.RevertAll*> to remove an active <xref:System.Security.CodeAccessPermission.Deny*>. <xref:System.Security.CodeAccessPermission.Deny*> is ignored for a permission not granted because a demand for that permission will not succeed.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">There is already an active <see cref="M:System.Security.CodeAccessPermission.Deny" /> for the current frame.</exception>
         <block subset="none" type="overrides">
           <para>You cannot override this method.</para>
@@ -385,14 +318,7 @@
         <summary>Determines whether the specified <see cref="T:System.Security.CodeAccessPermission" /> object is equal to the current <see cref="T:System.Security.CodeAccessPermission" />.</summary>
         <returns>
           <see langword="true" /> if the specified <see cref="T:System.Security.CodeAccessPermission" /> object is equal to the current <see cref="T:System.Security.CodeAccessPermission" />; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- For more information, see <xref:System.Object.Equals*>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -434,14 +360,7 @@
       <Docs>
         <param name="elem">The XML encoding to use to reconstruct the security object.</param>
         <summary>When overridden in a derived class, reconstructs a security object with a specified state from an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Custom code that extends security objects needs to implement the <xref:System.Security.CodeAccessPermission.ToXml*> and <xref:System.Security.CodeAccessPermission.FromXml*> methods to make the objects security-encodable.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="elem" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <paramref name="elem" /> parameter does not contain the XML encoding for an instance of the same type as the current instance.
 
@@ -486,14 +405,7 @@
       <Docs>
         <summary>Gets a hash code for the <see cref="T:System.Security.CodeAccessPermission" /> object that is suitable for use in hashing algorithms and data structures such as a hash table.</summary>
         <returns>A hash code for the current <see cref="T:System.Security.CodeAccessPermission" /> object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The hash code for two instances of the same permission might be different, hence a hash code should not be used to compare two <xref:System.Security.CodeAccessPermission> objects.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Intersect">
@@ -536,14 +448,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>When implemented by a derived class, creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not an instance of the same class as the current permission.</exception>
         <block subset="none" type="overrides">
           <para>You must override this method in a derived class.</para>
@@ -591,25 +496,7 @@
         <summary>When implemented by a derived class, determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, a permission that represents access to C:\example.txt is a subset of a permission that represents access to C:\\. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- The following statements are required to be `true` for all overrides of the <xref:System.Security.CodeAccessPermission.IsSubsetOf*> method. *X*, *Y*, and *Z* represent custom code access permission objects that are not null references, *U* represents an unrestricted code access permission, and *N* represents an empty permission with a <xref:System.Security.Permissions.PermissionState> of <xref:System.Security.Permissions.PermissionState.None>.
-
-- *X*.IsSubsetOf(*X*) returns `true`.
-- *X*.IsSubsetOf(*Y*) returns the same value as *Y*.IsSubsetOf(*X*) if and only if *X* and *Y* represent the same set of permissions.
-- If *X*.IsSubsetOf(*Y*) and *Y*.IsSubsetOf(*Z*) both return `true`, *X*.IsSubsetOf(*Z*) returns `true`.
-- *X*.IsSubsetOf(*U*) returns `true`.
-- *X*.IsSubsetOf(*N*) returns `false`.
-- *N*.IsSubsetOf(*X*) returns `true`.
-
- If *X* and *Y* represent custom code access permission objects that are null references, *X*.IsSubsetOf(*Y*) returns `true`. If *Z* is also null, the compound set operation *X*.Union(*Y*).IsSubsetOf(*Z*) also returns `true` because the union of two null permissions is a null permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
         <block subset="none" type="overrides">
           <para>You must override this method in a derived class.</para>
@@ -652,22 +539,7 @@
       <Parameters />
       <Docs>
         <summary>Prevents callers higher in the call stack from using the code that calls this method to access all resources except for the resource specified by the current instance.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!IMPORTANT]
->  The <xref:System.Security.CodeAccessPermission.PermitOnly*> method should be used only to protect resources from accidental access by fully trusted code. It should not be used to protect resources from intentional misuse by untrusted code. For example, if method `A` issues a <xref:System.Security.CodeAccessPermission.PermitOnly*> for a permission and then calls method `B`, method `B` can overtly override the <xref:System.Security.CodeAccessPermission.PermitOnly*> by issuing an <xref:System.Security.CodeAccessPermission.Assert*>. The called method is always higher in the stack. Therefore, if method `B` tries to access a protected resource, the security system begins checking for permissions with it because method `B` is the immediate caller, and then walks down the stack to confirm that there is no <xref:System.Security.CodeAccessPermission.Deny*> or <xref:System.Security.CodeAccessPermission.PermitOnly*> lower in the stack. Method `B`, which is trying to access the resource, can stop the stack walk immediately by using the <xref:System.Security.CodeAccessPermission.Assert*> method. In that case, the <xref:System.Security.CodeAccessPermission.PermitOnly*> placed on the stack by method `A` (the calling method) is never discovered.
-
- <xref:System.Security.CodeAccessPermission.PermitOnly*> is similar to <xref:System.Security.CodeAccessPermission.Deny*>, in that both cause stack walks to fail when they would otherwise succeed. The difference is that <xref:System.Security.CodeAccessPermission.Deny*> specifies permissions that will cause the stack walk to fail, but <xref:System.Security.CodeAccessPermission.PermitOnly*> specifies the only permissions that do not cause the stack walk to fail.
-
- Call this method to ensure that your code can be used to access only the specified resources. The call to <xref:System.Security.CodeAccessPermission.PermitOnly*> is effective until the calling code returns to its caller. Only one <xref:System.Security.CodeAccessPermission.PermitOnly*> can be active on a frame. An attempt to call <xref:System.Security.CodeAccessPermission.PermitOnly*> when an active <xref:System.Security.CodeAccessPermission.PermitOnly*> exists on the frame results in a <xref:System.Security.SecurityException>. Call <xref:System.Security.CodeAccessPermission.RevertPermitOnly*> or <xref:System.Security.CodeAccessPermission.RevertAll*> to remove an active <xref:System.Security.CodeAccessPermission.PermitOnly*>.
-
- <xref:System.Security.CodeAccessPermission.PermitOnly*> is ignored for a permission not granted because a demand for that permission will not succeed. However, if code lower on the call stack later calls <xref:System.Security.CodeAccessPermission.Demand*> for that permission, a <xref:System.Security.SecurityException> is thrown when the stack walk reaches the code that tried to call <xref:System.Security.CodeAccessPermission.PermitOnly*>. This is because the code that called <xref:System.Security.CodeAccessPermission.PermitOnly*> has not been granted the permission, even though it called <xref:System.Security.CodeAccessPermission.PermitOnly*> for that permission. The call stack is typically represented as growing down, so that methods higher in the call stack call methods lower in the call stack.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">There is already an active <see cref="M:System.Security.CodeAccessPermission.PermitOnly" /> for the current frame.</exception>
         <block subset="none" type="overrides">
           <para>You cannot override this method.</para>
@@ -707,14 +579,7 @@
       <Parameters />
       <Docs>
         <summary>Causes all previous overrides for the current frame to be removed and no longer in effect.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If there are no overrides (<xref:System.Security.CodeAccessPermission.Assert*>, <xref:System.Security.CodeAccessPermission.Deny*>, or <xref:System.Security.CodeAccessPermission.PermitOnly*>) for the current frame, an <xref:System.ExecutionEngineException> is thrown.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.InvalidOperationException">There is no previous <see cref="M:System.Security.CodeAccessPermission.Assert" />, <see cref="M:System.Security.CodeAccessPermission.Deny" />, or <see cref="M:System.Security.CodeAccessPermission.PermitOnly" /> for the current frame.</exception>
       </Docs>
     </Member>
@@ -751,14 +616,7 @@
       <Parameters />
       <Docs>
         <summary>Causes any previous <see cref="M:System.Security.CodeAccessPermission.Assert" /> for the current frame to be removed and no longer in effect.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If there is no <xref:System.Security.CodeAccessPermission.Assert*> for the current frame, an <xref:System.ExecutionEngineException> is thrown.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.InvalidOperationException">There is no previous <see cref="M:System.Security.CodeAccessPermission.Assert" /> for the current frame.</exception>
       </Docs>
     </Member>
@@ -801,14 +659,7 @@
       <Parameters />
       <Docs>
         <summary>Causes any previous <see cref="M:System.Security.CodeAccessPermission.Deny" /> for the current frame to be removed and no longer in effect.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If there is no <xref:System.Security.CodeAccessPermission.Deny*> for the current frame, an <xref:System.ExecutionEngineException> is thrown.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.InvalidOperationException">There is no previous <see cref="M:System.Security.CodeAccessPermission.Deny" /> for the current frame.</exception>
       </Docs>
     </Member>
@@ -845,14 +696,7 @@
       <Parameters />
       <Docs>
         <summary>Causes any previous <see cref="M:System.Security.CodeAccessPermission.PermitOnly" /> for the current frame to be removed and no longer in effect.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If there is no <xref:System.Security.CodeAccessPermission.PermitOnly*> for the current frame, an <xref:System.ExecutionEngineException> is thrown.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.InvalidOperationException">There is no previous <see cref="M:System.Security.CodeAccessPermission.PermitOnly" /> for the current frame.</exception>
       </Docs>
     </Member>
@@ -890,14 +734,7 @@
       <Docs>
         <summary>Creates and returns a string representation of the current permission object.</summary>
         <returns>A string representation of the current permission object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is useful in debugging when you need to display the permission as a string.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -937,17 +774,7 @@
       <Docs>
         <summary>When overridden in a derived class, creates an XML encoding of the security object and its current state.</summary>
         <returns>An XML encoding of the security object, including any state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Custom code that extends security objects needs to implement the <xref:System.Security.CodeAccessPermission.ToXml*> and <xref:System.Security.CodeAccessPermission.FromXml*> methods to make the objects security-encodable.
-
- ]]></format>
-        </remarks>
-        <block subset="none" type="overrides">
-          <para>You must override this method in a derived class.</para>
-        </block>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -990,18 +817,8 @@
         <param name="other">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>When overridden in a derived class, creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.CodeAccessPermission.Union*> is a permission that represents all the operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.NotSupportedException">The <paramref name="other" /> parameter is not <see langword="null" />. This method is only supported at this level when passed <see langword="null" />.</exception>
-        <block subset="none" type="overrides">
-          <para>You must override this method in a derived class. You should return a copy of the permission if the value of the <paramref name="other" /> parameter is <see langword="null" />.</para>
-        </block>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security/HostProtectionException.xml
+++ b/xml/System.Security/HostProtectionException.xml
@@ -55,11 +55,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- A <xref:System.Security.Permissions.HostProtectionAttribute> attribute is used to determine if a type or member can be loaded, based on the host's protection preferences established when the common language runtime is started. If a type or member with an active <xref:System.Security.Permissions.HostProtectionAttribute> is called, a link demand occurs for that protection attribute. If the caller does not meet the demand for host protection, a <xref:System.Security.HostProtectionException> is thrown.
-
-> [!NOTE]
->  A <xref:System.Security.Permissions.HostProtectionAttribute> is not a permission, even though it is the target of a link demand. Because a <xref:System.Security.HostProtectionException> is thrown for a link demand, it cannot be handled, and therefore it cannot be trapped and processed in code.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -102,19 +97,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Security.HostProtectionException" /> class with default values.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The following table shows the initial property values for an instance of the <xref:System.Security.HostProtectionException> class.
-
-|Property|Value|
-|--------------|-----------|
-|<xref:System.Security.HostProtectionException.ProtectedResources*>|<xref:System.Security.Permissions.HostProtectionResource.None?displayProperty=nameWithType>|
-|<xref:System.Security.HostProtectionException.DemandedResources*>|<xref:System.Security.Permissions.HostProtectionResource.None?displayProperty=nameWithType>|
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -149,14 +132,7 @@
       <Docs>
         <param name="message">The message that describes the error.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.HostProtectionException" /> class with a specified error message.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The content of the `message` parameter should be understandable to the user. The caller of this constructor is required to ensure that this string has been localized for the current system culture.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -203,14 +179,7 @@
         <param name="info">The object that holds the serialized object data.</param>
         <param name="context">Contextual information about the source or destination.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.HostProtectionException" /> class using the provided serialization information and streaming context.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor is called during deserialization to reconstruct the exception object transmitted over a stream.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="info" /> is <see langword="null" />.</exception>
       </Docs>
@@ -249,14 +218,7 @@
         <param name="message">The error message that explains the reason for the exception.</param>
         <param name="e">The exception that is the cause of the current exception. If the <c>innerException</c> parameter is not <see langword="null" />, the current exception is raised in a <see langword="catch" /> block that handles the inner exception.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.HostProtectionException" /> class with a specified error message and a reference to the inner exception that is the cause of this exception.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An exception that is thrown as a direct result of a previous exception can include a reference to the previous exception in the <xref:System.Exception.InnerException> property. The <xref:System.Exception.InnerException> property returns the same value that is passed into the constructor, or `null` if the <xref:System.Exception.InnerException> property does not supply the inner exception value to the constructor.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -295,14 +257,7 @@
         <param name="protectedResources">A bitwise combination of the enumeration values that specify the host resources that are inaccessible to partially trusted code.</param>
         <param name="demandedResources">A bitwise combination of the enumeration values that specify the demanded host resources.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.HostProtectionException" /> class with a specified error message, the protected host resources, and the host resources that caused the exception to be thrown.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The `demandedResources` parameter specifies the demanded host protection categories that caused the exception to be thrown. For example, suppose that a method has a <xref:System.Security.Permissions.HostProtectionAttribute> attribute that indicates that the method exposes shared state. When the method is called, the <xref:System.Security.Permissions.HostProtectionAttribute> performs a link demand for shared state. If the host has set shared state as a prohibited category, then a <xref:System.Security.HostProtectionException> is raised with a `demandedResources` property value of <xref:System.Security.Permissions.HostProtectionResource.SharedState?displayProperty=nameWithType>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DemandedResources">
@@ -337,14 +292,7 @@
       <Docs>
         <summary>Gets or sets the demanded host protection resources that caused the exception to be thrown.</summary>
         <value>A bitwise combination of the <see cref="T:System.Security.Permissions.HostProtectionResource" /> values identifying the protection resources causing the exception to be thrown. The default is <see cref="F:System.Security.Permissions.HostProtectionResource.None" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property returns the demanded host protection categories that caused the exception to be thrown. For example, suppose that a method has a <xref:System.Security.Permissions.HostProtectionAttribute> attribute that indicates that the method exposes shared state. When the method is called, the <xref:System.Security.Permissions.HostProtectionAttribute> performs a link demand for shared state. If the host has set shared state as a prohibited category, then a <xref:System.Security.HostProtectionException> is raised, and the value of the <xref:System.Security.HostProtectionException.DemandedResources> property is <xref:System.Security.Permissions.HostProtectionResource.SharedState?displayProperty=nameWithType>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetObjectData">
@@ -386,14 +334,7 @@
         <param name="info">The serialized object data about the exception being thrown.</param>
         <param name="context">The contextual information about the source or destination.</param>
         <summary>Sets the specified <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object with information about the host protection exception.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.HostProtectionException.GetObjectData*> method sets a <xref:System.Runtime.Serialization.SerializationInfo> object with all the exception object data targeted for serialization. During deserialization, the exception is reconstructed from the <xref:System.Runtime.Serialization.SerializationInfo> transmitted over the stream.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="info" /> is <see langword="null" />.</exception>
       </Docs>
@@ -430,14 +371,7 @@
       <Docs>
         <summary>Gets or sets the host protection resources that are inaccessible to partially trusted code.</summary>
         <value>A bitwise combination of the <see cref="T:System.Security.Permissions.HostProtectionResource" /> values identifying the inaccessible host protection categories. The default is <see cref="F:System.Security.Permissions.HostProtectionResource.None" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property identifies the host protection categories that the host has specified as being inaccessible to code that is not fully trusted.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -473,14 +407,7 @@
       <Docs>
         <summary>Returns a string representation of the current host protection exception.</summary>
         <returns>A string representation of the current <see cref="T:System.Security.HostProtectionException" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The returned string is a textual representation of the exception.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security/HostSecurityManager.xml
+++ b/xml/System.Security/HostSecurityManager.xml
@@ -32,14 +32,13 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Allows the control and customization of security behavior for application domains.</summary>
+    <summary>Allows the control and customization of security behavior for hosts.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- When you create a new <xref:System.AppDomain>, the common language runtime queries the <xref:System.AppDomainManager> for the presence of a <xref:System.Security.HostSecurityManager>, which participates in making security decisions for the <xref:System.AppDomain>.  Host providers should implement a host security manager that inherits from the <xref:System.Security.HostSecurityManager> class.
 
-
+Host providers should implement a host security manager that inherits from the <xref:System.Security.HostSecurityManager> class.
 
 ## Examples
  The following example shows a very simple implementation of a <xref:System.Security.HostSecurityManager>.
@@ -134,9 +133,7 @@
 ## Remarks
  This method can be overridden by a derived class. The base implementation calls the application security manager to determine if the application should be executed.
 
- The base implementation does not use the activator evidence. However, an overridden implementation could use the activator evidence to determine the security evidence for the application domain attempting to activate the application.
-
-
+ The base implementation does not use the activator evidence. However, an overridden implementation could use the activator evidence to determine the security evidence.
 
 ## Examples
  The following example shows how to override the <xref:System.Security.HostSecurityManager.DetermineApplicationTrust*> method for a custom host security manager. This example is part of a larger example provided for the <xref:System.Security.HostSecurityManager> class.
@@ -197,9 +194,7 @@
  This property is called at <xref:System.AppDomain> creation time. It allows a host to supply a policy for the current <xref:System.AppDomain>.  A policy level consists of the following:
 
 - A set of code groups organized into a single rooted tree.
-
 - A set of named permission sets that are referenced by the code groups to specify permissions to be granted to code belonging to the code group.
-
 - A list of fully trusted assemblies.
 
 > [!IMPORTANT]
@@ -207,7 +202,7 @@
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete in the .NET Framework 4. To enable CAS policy for compatibility with earlier versions of the .NET Framework, use the <see href="/dotnet/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element">&lt;legacyCasPolicy&gt; element</see>.</exception>
+        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete.</exception>
       </Docs>
     </Member>
     <Member MemberName="Flags">
@@ -306,13 +301,11 @@
 
  To get a callback to this method, hosts must specify the <xref:System.Security.HostSecurityManagerOptions.HostAppDomainEvidence> flag in the <xref:System.Security.HostSecurityManager.Flags> property.
 
- This method of generating evidence allows hosts to delay evidence generation for an <xref:System.AppDomain> until the evidence is needed. In the .NET Framework version 3.5 and earlier versions, it was necessary to provide <xref:System.AppDomain> evidence at load time by overriding the <xref:System.Security.HostSecurityManager.ProvideAppDomainEvidence*> method. We recommend that you use <xref:System.Security.HostSecurityManager.GenerateAppDomainEvidence*> to provide evidence instead of overriding <xref:System.Security.HostSecurityManager.ProvideAppDomainEvidence*>.
+ This method of generating evidence allows hosts to delay evidence generation for an <xref:System.AppDomain> until the evidence is needed. We recommend that you use <xref:System.Security.HostSecurityManager.GenerateAppDomainEvidence*> to provide evidence instead of overriding <xref:System.Security.HostSecurityManager.ProvideAppDomainEvidence*>.
 
  The <xref:System.Security.HostSecurityManager.GenerateAppDomainEvidence*> method is called back into only for types of evidence that the host has specified in the override of the <xref:System.Security.HostSecurityManager.GetHostSuppliedAppDomainEvidenceTypes*> method.
 
  A return value of `null` indicates that the host cannot generate evidence of this specific type.
-
-
 
 ## Examples
  The following example shows how to override the <xref:System.Security.HostSecurityManager.ProvideAppDomainEvidence*> method for a custom host security manager. This example is part of a larger example provided for the <xref:System.Security.HostSecurityManager> class.
@@ -370,7 +363,7 @@
 
  To get a callback to this method, hosts must specify the <xref:System.Security.HostSecurityManagerOptions.HostAssemblyEvidence> flag in the <xref:System.Security.HostSecurityManager.Flags> property.
 
- This method of generating evidence allows hosts to delay evidence generation for an <xref:System.AppDomain> until the evidence is needed. In the .NET Framework 3.5 and earlier versions, it was necessary to provide <xref:System.AppDomain> evidence at load time by overriding the <xref:System.Security.HostSecurityManager.ProvideAppDomainEvidence*> method. We recommend that you use <xref:System.Security.HostSecurityManager.GenerateAssemblyEvidence*> to provide evidence instead of overriding <xref:System.Security.HostSecurityManager.ProvideAssemblyEvidence*>.
+ This method of generating evidence allows hosts to delay evidence generation for an <xref:System.AppDomain> until the evidence is needed. We recommend that you use <xref:System.Security.HostSecurityManager.GenerateAssemblyEvidence*> to provide evidence instead of overriding <xref:System.Security.HostSecurityManager.ProvideAssemblyEvidence*>.
 
  The <xref:System.Security.HostSecurityManager.GenerateAssemblyEvidence*> method is called back into only for types of evidence that the host has specified in the override of the <xref:System.Security.HostSecurityManager.GetHostSuppliedAssemblyEvidenceTypes*> method.
 

--- a/xml/System.Security/IPermission.xml
+++ b/xml/System.Security/IPermission.xml
@@ -85,22 +85,7 @@
     <remarks>
       <format type="text/markdown"><![CDATA[
 
-## Remarks
-
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
-
- Permissions in the common language runtime are objects that describe sets of operations that can be secured for specified resources. A permission object describes operations or access that is subject to security control; it does not represent access or a right to perform operations. Permissions are used by both application code and the .NET Framework security system in the following ways:
-
-- Code requests the permissions it needs in order to run.
-- The security system policy grants permissions to code in order for it to run.
-- Code demands that calling code has a permission.
-- Code overrides the security stack using assert/deny/permit-only.
-
-> [!NOTE]
->  If you write a new permission, you must implement this interface in your class.
-
-> [!IMPORTANT]
->  A permission can be accessed by multiple threads. When implementing this interface, you must guarantee that the <xref:System.Security.IPermission.IsSubsetOf*>, <xref:System.Security.IPermission.Intersect*>, <xref:System.Security.IPermission.Union*>, and <xref:System.Security.IPermission.Copy*> method implementations are thread safe.
 
  ]]></format>
     </remarks>
@@ -156,14 +141,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Demand">
@@ -215,18 +193,7 @@
       <Parameters />
       <Docs>
         <summary>Throws a <see cref="T:System.Security.SecurityException" /> at run time if the security requirement is not met.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is typically used by secure libraries to ensure that callers have permission to access a resource. For example, a file class in a secure class library calls <xref:System.Security.CodeAccessPermission.Demand*> for the necessary <xref:System.Security.Permissions.FileIOPermission> before performing a file operation requested by the caller.
-
- Although the majority of the classes that implement this interface method satisfy the security criteria by performing a full stack walk, a stack walk is not necessarily performed. An example of an implementation that does not perform a stack walk is <xref:System.Security.Permissions.PrincipalPermission.Demand*?displayProperty=nameWithType>.
-
- When a stack walk is performed, the permissions of the code that calls this method are not examined; the check begins from the immediate caller of that code and proceeds up the stack. The call stack is typically represented as growing down, so that methods higher in the call stack call methods lower in the call stack. <xref:System.Security.CodeAccessPermission.Demand*> succeeds only if no <xref:System.Security.SecurityException> is raised.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Intersect">
@@ -283,20 +250,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- The following statements are required to be true for all implementations of the <xref:System.Security.IPermission.Intersect*> method. `X` and `Y` represent <xref:System.Security.IPermission> object references that are not `null`.
-
-- `X`.Intersect(`X`) returns a value equal to `X`.
-- `X`.Intersect(`Y`) returns the same value as `Y`.Intersect(`X`).
-- `X`.Intersect(`null`) returns `null`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not an instance of the same class as the current permission.</exception>
       </Docs>
     </Member>
@@ -355,22 +309,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, a permission that represents access to C:\example.txt is a subset of a permission that represents access to C:\\. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- The following statements are required to be true for all implementations of the <xref:System.Security.IPermission.IsSubsetOf*> method. `X`, `Y`, and `Z` represent <xref:System.Security.IPermission> objects that are not `null`.
-
-- `X`.IsSubsetOf(`X`) returns `true`.
-- `X`.IsSubsetOf(`Y`) returns the same value as `Y`.IsSubsetOf(`X`) if and only if `X` and `Y` represent the same set of permissions.
-- If `X`.IsSubsetOf(`Y`) and `Y`.IsSubsetOf(`Z`) both return `true`, `X`.IsSubsetOf(`Z`) returns `true`.
-
- If `X` represents an empty <xref:System.Security.IPermission> object with a permission state of <xref:System.Security.Permissions.PermissionState.None> and `Y` represents an <xref:System.Security.IPermission> object that is `null`, `X`.IsSubsetOf(`Y`) returns `true`. If `Z` is also an empty permission, the compound set operation `X`.Union(Z).IsSubsetOf(Y) also returns `true` because the union of two empty permissions is an empty permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -428,20 +367,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.IPermission.Union*> is a permission that represents all the operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- The following statements are required to be true for all implementations of the <xref:System.Security.IPermission.Union*> method. `X` and `Y` represent <xref:System.Security.IPermission> objects that are not `null`.
-
-- `X`.Union(`X`) returns an object that has the same value as `X`.
-- `X`.Union(`Y`) returns an object that has the same value as the object returned by `Y`.Union(`X`).
-- `X`.Union(`null`) returns an object that has the same value as `X`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security/ISecurityEncodable.xml
+++ b/xml/System.Security/ISecurityEncodable.xml
@@ -79,15 +79,7 @@
  The XML representation of permissions is used to describe instances of permissions for code requests, declarative security permission sets, and security policy configuration.
 
 > [!NOTE]
->  You must implement this interface for any new permission object.
-
-
-
-## Examples
- This example shows how to define a permission class for use with code access security. All of the necessary permission interfaces are implemented.
-
- :::code language="csharp" source="~/snippets/csharp/System.Security/IPermission/Overview/Permission.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Security/ISecurityEncodable/Overview/permission.vb" id="Snippet1":::
+> You must implement this interface for any new permission object.
 
  ]]></format>
     </remarks>

--- a/xml/System.Security/IStackWalk.xml
+++ b/xml/System.Security/IStackWalk.xml
@@ -75,10 +75,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Partially trusted code always presents a security risk. It can sometimes be manipulated to perform actions on behalf of malicious code that does not have permission to access a resource. In this way, malicious code can achieve higher security access than it should be allowed.
-
- The common language runtime helps protect managed code from these attacks by running a stack walk on all calls. The stack walk requires that all code in the call stack has permission to access a protected resource. Because the code attempting the attack will always be somewhere in the call stack, it will be unable to exceed its own security permissions.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -130,21 +126,7 @@
       <Parameters />
       <Docs>
         <summary>Asserts that the calling code can access the resource identified by the current permission object, even if callers higher in the stack have not been granted permission to access the resource.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Calling <xref:System.Security.IStackWalk.Assert*> stops the permission check on callers higher in the call stack. Therefore, even if these callers do not have the requisite permissions, they can still access resources. An assertion is effective only if the code that calls <xref:System.Security.IStackWalk.Assert*> passes the security check for the permission that it is asserting.
-
- A call to <xref:System.Security.IStackWalk.Assert*> is effective until the calling code returns to its caller or until a subsequent call to <xref:System.Security.IStackWalk.Assert*> renders the previous assertion ineffective. Also, <xref:System.Security.CodeAccessPermission.RevertAssert*> or <xref:System.Security.CodeAccessPermission.RevertAll*> removes a pending <xref:System.Security.IStackWalk.Assert*>.
-
- <xref:System.Security.IStackWalk.Assert*> is ignored for a permission not granted because a demand for that permission will not succeed. However, if code lower on the call stack calls <xref:System.Security.IStackWalk.Demand*> for that permission, a <xref:System.Security.SecurityException> is thrown when the stack walk reaches the code that tried to call <xref:System.Security.IStackWalk.Assert*>. This happens because the code that called <xref:System.Security.IStackWalk.Assert*> has not been granted the permission, even though it tried to <xref:System.Security.IStackWalk.Assert*> it.
-
-> [!CAUTION]
->  Because calling <xref:System.Security.IStackWalk.Assert*> removes the requirement that all code in the call chain must be granted permission to access the specified resource, it can open up security vulnerabilities if used incorrectly or inappropriately. Therefore, it should be used with great caution.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">The calling code does not have <see cref="F:System.Security.Permissions.SecurityPermissionFlag.Assertion" />.</exception>
         <related type="Article" href="/dotnet/framework/misc/using-the-assert-method">Using the Assert Method</related>
       </Docs>
@@ -196,16 +178,7 @@
       <Parameters />
       <Docs>
         <summary>Determines at run time whether all callers in the call stack have been granted the permission specified by the current permission object.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is typically used by secure libraries to ensure that callers have permission to access a resource. For example, a file class in a secure class library calls <xref:System.Security.IStackWalk.Demand*> for the necessary <xref:System.Security.Permissions.FileIOPermission> before performing a file operation requested by the caller.
-
- The permissions of the code that calls this method are not examined; the check begins from the immediate caller of that code and proceeds up the stack. <xref:System.Security.IStackWalk.Demand*> succeeds only if no <xref:System.Security.SecurityException> is raised.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">A caller higher in the call stack does not have the permission specified by the current permission object.
 
  -or-
@@ -260,21 +233,7 @@
       <Parameters />
       <Docs>
         <summary>Causes every <see cref="M:System.Security.IStackWalk.Demand" /> for the current object that passes through the calling code to fail.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method prevents callers higher in the call stack from accessing the protected resource through the code that calls this method, even if those callers have been granted permission to access it. The call stack is typically represented as growing down, so that methods higher in the call stack call methods lower in the call stack.
-
- <xref:System.Security.IStackWalk.Deny*> can limit the liability of the programmer or help prevent accidental security vulnerabilities because it helps prevent the method that calls <xref:System.Security.IStackWalk.Deny*> from being used to access the resource protected by the denied permission. If a method calls <xref:System.Security.IStackWalk.Deny*> on a permission, and if a <xref:System.Security.IStackWalk.Demand*> for that permission is invoked by a caller lower in the call stack, that security check will fail when it reaches the <xref:System.Security.IStackWalk.Deny*>.
-
- <xref:System.Security.IStackWalk.Deny*> is ignored for a permission not granted because a demand for that permission will not succeed.
-
- ]]></format>
-        </remarks>
-        <block subset="none" type="overrides">
-          <para>You cannot override this method.</para>
-        </block>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PermitOnly">
@@ -324,16 +283,7 @@
       <Parameters />
       <Docs>
         <summary>Causes every <see cref="M:System.Security.IStackWalk.Demand" /> for all objects except the current one that passes through the calling code to fail, even if code higher in the call stack has been granted permission to access other resources.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.IStackWalk.PermitOnly*> is similar to <xref:System.Security.IStackWalk.Deny*>, in that both cause stack walks to fail when they would otherwise succeed. The difference is that <xref:System.Security.IStackWalk.Deny*> specifies permissions that will cause the stack walk to fail, but <xref:System.Security.IStackWalk.PermitOnly*> specifies the only permissions that do not cause the stack walk to fail. Call this method to ensure that your code can be used to access only the specified resources.
-
- <xref:System.Security.IStackWalk.PermitOnly*> is ignored for a permission not granted because a demand for that permission will not succeed. However, if code lower on the call stack later calls <xref:System.Security.IStackWalk.Demand*> for that permission, a <xref:System.Security.SecurityException> is thrown when the stack walk reaches the code that tried to call <xref:System.Security.IStackWalk.PermitOnly*>. This is because the code that called <xref:System.Security.IStackWalk.PermitOnly*> has not been granted the permission, even though it called <xref:System.Security.IStackWalk.PermitOnly*> for that permission. The call stack is typically represented as growing down, so that methods higher in the call stack call methods lower in the call stack.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security/NamedPermissionSet.xml
+++ b/xml/System.Security/NamedPermissionSet.xml
@@ -374,7 +374,6 @@
         <returns>
           <see langword="true" /> if the specified <see cref="T:System.Security.NamedPermissionSet" /> is equal to the current <see cref="T:System.Security.NamedPermissionSet" /> object; otherwise, <see langword="false" />.</returns>
         <remarks>To be added.</remarks>
-        </remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">

--- a/xml/System.Security/NamedPermissionSet.xml
+++ b/xml/System.Security/NamedPermissionSet.xml
@@ -47,8 +47,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Named permission sets are used in security policy administration to specify the permissions to be granted to code that belongs to certain code groups. Names are strings of alphanumeric characters. Description strings can consist of any printable characters.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -132,14 +130,7 @@
       <Docs>
         <param name="name">The name for the new named permission set.</param>
         <summary>Initializes a new, empty instance of the <see cref="T:System.Security.NamedPermissionSet" /> class with the specified name.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Using this constructor creates a named permission set with no permissions but with an <xref:System.Security.Permissions.PermissionState.Unrestricted> permission state. A named permission set in an unrestricted state effectively contains all permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface. The named permission set will contain all built-in permissions as well as all custom user-defined permissions that implement <xref:System.Security.Permissions.IUnrestrictedPermission>. All permissions will have the equivalent of an `Unrestricted` permission state. Permissions that do not implement <xref:System.Security.Permissions.IUnrestrictedPermission> will be empty instances.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="name" /> parameter is <see langword="null" /> or is an empty string ("").</exception>
       </Docs>
     </Member>
@@ -178,14 +169,7 @@
         <param name="name">The name for the new named permission set.</param>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.NamedPermissionSet" /> class with the specified name in either an unrestricted or a fully restricted state.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A named permission set in an unrestricted state effectively contains all permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface. The named permission set will contain all built-in permissions as well as all custom permissions. All permissions will have an `Unrestricted` <xref:System.Security.Permissions.PermissionState>. Permissions that do not implement <xref:System.Security.Permissions.IUnrestrictedPermission>, such as identity permissions, will be empty instances.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="name" /> parameter is <see langword="null" /> or is an empty string ("").</exception>
       </Docs>
     </Member>
@@ -349,14 +333,7 @@
       <Docs>
         <summary>Gets or sets the text description of the current named permission set.</summary>
         <value>A text description of the named permission set.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The description helps the administrator understand in words what permissions the set contains and its intended use.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -396,13 +373,7 @@
         <summary>Determines whether the specified <see cref="T:System.Security.NamedPermissionSet" /> object is equal to the current <see cref="T:System.Security.NamedPermissionSet" />.</summary>
         <returns>
           <see langword="true" /> if the specified <see cref="T:System.Security.NamedPermissionSet" /> is equal to the current <see cref="T:System.Security.NamedPermissionSet" /> object; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- For more information, see <xref:System.Object.Equals*>.
-
- ]]></format>
+        <remarks>To be added.</remarks>
         </remarks>
       </Docs>
     </Member>
@@ -442,14 +413,7 @@
       <Docs>
         <param name="et">A security element containing the XML representation of the named permission set.</param>
         <summary>Reconstructs a named permission set with a specified state from an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method recreates the state of a named permission set from an XML element previously created by <xref:System.Security.NamedPermissionSet.ToXml*>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="et" /> parameter is not a valid representation of a named permission set.</exception>
         <exception cref="T:System.ArgumentNullException">The <paramref name="et" /> parameter is <see langword="null" />.</exception>
       </Docs>
@@ -487,14 +451,7 @@
       <Docs>
         <summary>Gets a hash code for the <see cref="T:System.Security.NamedPermissionSet" /> object that is suitable for use in hashing algorithms and data structures such as a hash table.</summary>
         <returns>A hash code for the current <see cref="T:System.Security.NamedPermissionSet" /> object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The hash code for two instances of the same permission might differ, hence a hash code should not be used to compare two <xref:System.Security.NamedPermissionSet> objects.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -530,14 +487,7 @@
       <Docs>
         <summary>Gets or sets the name of the current named permission set.</summary>
         <value>The name of the named permission set.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Code groups refer to permission sets by name.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The name is <see langword="null" /> or is an empty string ("").</exception>
       </Docs>
     </Member>
@@ -575,14 +525,7 @@
       <Docs>
         <summary>Creates an XML element description of the named permission set.</summary>
         <returns>The XML representation of the named permission set.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use <xref:System.Security.NamedPermissionSet.FromXml*> to recreate the state represented by the returned element.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security/PartialTrustVisibilityLevel.xml
+++ b/xml/System.Security/PartialTrustVisibilityLevel.xml
@@ -42,18 +42,7 @@
   </Base>
   <Docs>
     <summary>Specifies the default partial-trust visibility for code that is marked with the <see cref="T:System.Security.AllowPartiallyTrustedCallersAttribute" /> (APTCA) attribute.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.PartialTrustVisibilityLevel> is passed as a property setting parameter to the <xref:System.Security.AllowPartiallyTrustedCallersAttribute.%23ctor*?displayProperty=nameWithType> constructor. If no parameter is passed to the constructor, the default is VisibleToAllHosts.
-
- You enable partially trusted assemblies that are identified as NotVisibleByDefault by adding them to the <xref:System.AppDomainSetup.PartialTrustVisibleAssemblies> property of their application domain. If you enable an assembly that references (directly or indirectly) other partially trusted assemblies that are NotVisibleByDefault, those other assemblies should be enabled as well.
-
- When an APTCA library that specifies a `PartialTrustVisibilityLevel` and that is eligible for code sharing is loaded for the first time, it is loaded into the shared domain. Whenever that assembly is loaded with the same `PartialTrustVisibilityLevel` into another domain, it will be shared. However, if the assembly is loaded with a different `PartialTrustVisibilityLevel`, it will not be shared.
-
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName="NotVisibleByDefault">

--- a/xml/System.Security/PermissionSet.xml
+++ b/xml/System.Security/PermissionSet.xml
@@ -97,8 +97,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- You can use <xref:System.Security.PermissionSet> to perform operations on several different permissions as a group.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -160,16 +158,7 @@
       <Docs>
         <param name="state">One of the enumeration values that specifies the permission set's access to resources.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.PermissionSet" /> class with the specified <see cref="T:System.Security.Permissions.PermissionState" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The `Unrestricted` state allows all permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface, while `None` allows no permissions.
-
- Use <xref:System.Security.PermissionSet.AddPermission*> on an empty <xref:System.Security.PermissionSet> to define the set in greater detail.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -220,17 +209,7 @@
       <Docs>
         <param name="permSet">The set from which to take the value of the new <see cref="T:System.Security.PermissionSet" />, or <see langword="null" /> to create an empty <see cref="T:System.Security.PermissionSet" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.PermissionSet" /> class with initial values taken from the <paramref name="permSet" /> parameter.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The new <xref:System.Security.PermissionSet> contains copies of the permissions contained in the specified <xref:System.Security.PermissionSet>.
-
-> [!NOTE]
->  This is equivalent to <xref:System.Security.PermissionSet.Copy*> when the `permSet` parameter is not `null`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AddPermission">
@@ -284,14 +263,7 @@
         <param name="perm">The permission to add.</param>
         <summary>Adds a specified permission to the <see cref="T:System.Security.PermissionSet" />.</summary>
         <returns>The union of the permission added and any permission of the same type that already exists in the <see cref="T:System.Security.PermissionSet" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If a permission of the same type as the added permission already exists in the <xref:System.Security.PermissionSet>, the new permission is the union of the existing permission object and the specified permission object. For example, if a permission that implements <xref:System.Security.Permissions.IUnrestrictedPermission> is added to an <xref:System.Security.Permissions.PermissionState.Unrestricted><xref:System.Security.PermissionSet>, the resulting union is the original `Unrestricted` <xref:System.Security.PermissionSet>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.InvalidOperationException">The method is called from a <see cref="T:System.Security.ReadOnlyPermissionSet" />.</exception>
         <block subset="none" type="overrides">
           <para>When you inherit from <see cref="T:System.Security.PermissionSet" />, you can change the behavior of the <see cref="M:System.Security.PermissionSet.AddPermission(System.Security.IPermission)" /> method by overriding the <see cref="M:System.Security.PermissionSet.AddPermissionImpl(System.Security.IPermission)" /> method.</para>
@@ -346,16 +318,7 @@
         <param name="perm">The permission to add.</param>
         <summary>Adds a specified permission to the <see cref="T:System.Security.PermissionSet" />.</summary>
         <returns>The union of the permission added and any permission of the same type that already exists in the <see cref="T:System.Security.PermissionSet" />, or <see langword="null" /> if <paramref name="perm" /> is <see langword="null" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.PermissionSet.AddPermissionImpl*> method is the implementation for the <xref:System.Security.PermissionSet.AddPermission*> method.
-
- If a permission of the same type as the added permission already exists in the <xref:System.Security.PermissionSet>, the new permission is the union of the existing permission object and the specified permission object. For example, if a permission that implements <xref:System.Security.Permissions.IUnrestrictedPermission> is added to an <xref:System.Security.Permissions.PermissionState.Unrestricted><xref:System.Security.PermissionSet>, the resulting union is the original `Unrestricted` <xref:System.Security.PermissionSet>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.InvalidOperationException">The method is called from a <see cref="T:System.Security.ReadOnlyPermissionSet" />.</exception>
       </Docs>
     </Member>
@@ -409,17 +372,7 @@
       <Parameters />
       <Docs>
         <summary>Declares that the calling code can access the resource protected by a permission demand through the code that calls this method, even if callers higher in the stack have not been granted permission to access the resource. Using <see cref="M:System.Security.PermissionSet.Assert" /> can create security vulnerabilities.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This is the only way to assert multiple permissions at the same time within a frame because only one <xref:System.Security.PermissionSet.Assert*> can be active on a frame. <xref:System.Security.PermissionSet.Assert*> is only effective for granted permissions. Call the <xref:System.Security.CodeAccessPermission.RevertAssert*?displayProperty=nameWithType> or <xref:System.Security.CodeAccessPermission.RevertAll*?displayProperty=nameWithType> method to cancel an active <xref:System.Security.PermissionSet.Assert*>.
-
-> [!CAUTION]
->  Because calling the <xref:System.Security.PermissionSet.Assert*> method removes the requirement that all code in the call chain must be granted permission to access the specified resource, it can open up security vulnerabilities if used incorrectly or inappropriately. Therefore, it should be used with great caution.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">The <see cref="T:System.Security.PermissionSet" /> instance asserted has not been granted to the asserting code.
 
  -or-
@@ -541,14 +494,7 @@
         <param name="outFormat">A string representing one of the following encoding formats: ASCII, Unicode, or Binary. Possible values are "XMLASCII" or "XML", "XMLUNICODE", and "BINARY".</param>
         <summary>Converts an encoded <see cref="T:System.Security.PermissionSet" /> from one XML encoding format to another XML encoding format.</summary>
         <returns>An encrypted permission set with the specified output format.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Do not use this method.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.NotImplementedException">In all cases.</exception>
       </Docs>
     </Member>
@@ -600,14 +546,7 @@
       <Docs>
         <summary>Creates a copy of the <see cref="T:System.Security.PermissionSet" />.</summary>
         <returns>A copy of the <see cref="T:System.Security.PermissionSet" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a <xref:System.Security.PermissionSet> represents the same access to resources as the original object. Changes made to the copy do not affect the original permission set.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -721,14 +660,7 @@
       <Docs>
         <summary>Gets the number of permission objects contained in the permission set.</summary>
         <value>The number of permission objects contained in the <see cref="T:System.Security.PermissionSet" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- In the `None` or `Unrestricted` state this returns zero, because no actual permission object instances are used.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Demand">
@@ -781,18 +713,7 @@
       <Parameters />
       <Docs>
         <summary>Forces a <see cref="T:System.Security.SecurityException" /> at run time if all callers higher in the call stack have not been granted the permissions specified by the current instance.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use <xref:System.Security.PermissionSet.Demand*> on a <xref:System.Security.PermissionSet> to ensure that all callers have all permissions in the set with one operation.
-
- The permissions of the code that calls this method are not examined; the check begins from the immediate caller of that code and proceeds up the stack. The call stack is typically represented as growing down, so that methods higher in the call stack call methods lower in the call stack. <xref:System.Security.PermissionSet.Demand*> succeeds only if no <xref:System.Security.SecurityException> is thrown.
-
- If the <xref:System.Security.PermissionSet> contains permissions that do not inherit from <xref:System.Security.CodeAccessPermission>, the `Demand` methods of those permissions are called as well.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">A caller in the call chain does not have the permission demanded.</exception>
       </Docs>
     </Member>
@@ -852,18 +773,7 @@
       <Parameters />
       <Docs>
         <summary>Causes any <see cref="M:System.Security.PermissionSet.Demand" /> that passes through the calling code for a permission that has an intersection with a permission of a type contained in the current <see cref="T:System.Security.PermissionSet" /> to fail.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method prevents callers higher in the call stack from accessing the protected resource through the code that calls this method, even if those callers have been granted permission to access it. The call stack is typically represented as growing down, so that methods higher in the call stack call methods lower in the call stack.
-
- <xref:System.Security.PermissionSet.Deny*> can limit the liability of the programmer or help prevent accidental security vulnerabilities because it helps prevent the method that calls <xref:System.Security.PermissionSet.Deny*> from being used to access the resource protected by the denied permission. If a method calls <xref:System.Security.PermissionSet.Deny*> on a permission, and if a <xref:System.Security.PermissionSet.Demand*> for that permission is invoked by a caller lower in the call stack, that security check fails when it reaches the <xref:System.Security.PermissionSet.Deny*>.
-
- <xref:System.Security.PermissionSet.Deny*> is ignored for a permission that is not granted because a demand for that permission cannot succeed.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">A previous call to <see cref="M:System.Security.PermissionSet.Deny" /> has already restricted the permissions for the current stack frame.</exception>
       </Docs>
     </Member>
@@ -918,16 +828,7 @@
         <summary>Determines whether the specified <see cref="T:System.Security.PermissionSet" /> or <see cref="T:System.Security.NamedPermissionSet" /> object is equal to the current <see cref="T:System.Security.PermissionSet" />.</summary>
         <returns>
           <see langword="true" /> if the specified object is equal to the current <see cref="T:System.Security.PermissionSet" /> object; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Equality is determined by the permissions contained in the permission set specified by `obj`. `obj` can be either a <xref:System.Security.PermissionSet> object or a <xref:System.Security.NamedPermissionSet> object. If `obj` is a <xref:System.Security.NamedPermissionSet>, the name and description are ignored.
-
- For more information, see <xref:System.Object.Equals(System.Object)?displayProperty=nameWithType>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -1043,14 +944,7 @@
       <Docs>
         <summary>Returns an enumerator for the permissions of the set.</summary>
         <returns>An enumerator object for the permissions of the set.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use the enumerator as an index to access individual permission objects in the set.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <block subset="none" type="overrides">
           <para>When you inherit from <see cref="T:System.Security.PermissionSet" />, you can change the behavior of the <see cref="M:System.Security.PermissionSet.GetEnumerator" /> method by overriding the <see cref="M:System.Security.PermissionSet.GetEnumeratorImpl" /> method.</para>
         </block>
@@ -1101,14 +995,7 @@
       <Docs>
         <summary>Returns an enumerator for the permissions of the set.</summary>
         <returns>An enumerator object for the permissions of the set.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.PermissionSet.GetEnumeratorImpl*> method is the implementation for the <xref:System.Security.PermissionSet.GetEnumerator*> method.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -1158,14 +1045,7 @@
       <Docs>
         <summary>Gets a hash code for the <see cref="T:System.Security.PermissionSet" /> object that is suitable for use in hashing algorithms and data structures such as a hash table.</summary>
         <returns>A hash code for the current <see cref="T:System.Security.PermissionSet" /> object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The hash code for two instances of the same permission set might be different, so a hash code should not be used to compare two <xref:System.Security.PermissionSet> objects.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetPermission">
@@ -1219,14 +1099,7 @@
         <param name="permClass">The type of the desired permission object.</param>
         <summary>Gets a permission object of the specified type, if it exists in the set.</summary>
         <returns>A copy of the permission object of the type specified by the <paramref name="permClass" /> parameter contained in the <see cref="T:System.Security.PermissionSet" />, or <see langword="null" /> if none exists.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The method returns `null` for an `Unrestricted` <xref:System.Security.PermissionSet>. Although an `Unrestricted` <xref:System.Security.PermissionSet> effectively contains all permissions, it does not have any actual instances to return.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <block subset="none" type="overrides">
           <para>When you inherit from <see cref="T:System.Security.PermissionSet" />, you can change the behavior of the <see cref="M:System.Security.PermissionSet.GetPermission(System.Type)" /> method by overriding the <see cref="M:System.Security.PermissionSet.GetPermissionImpl(System.Type)" /> method.</para>
         </block>
@@ -1280,16 +1153,7 @@
         <param name="permClass">The type of the permission object.</param>
         <summary>Gets a permission object of the specified type, if it exists in the set.</summary>
         <returns>A copy of the permission object, of the type specified by the <paramref name="permClass" /> parameter, contained in the <see cref="T:System.Security.PermissionSet" />, or <see langword="null" /> if none exists.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.PermissionSet.GetPermissionImpl*> method is the implementation for the <xref:System.Security.PermissionSet.GetPermission*> method.
-
- The method returns `null` for an `Unrestricted` <xref:System.Security.PermissionSet>. Although an `Unrestricted` <xref:System.Security.PermissionSet> effectively contains all permissions, it does not have any actual instances to return.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Intersect">
@@ -1343,16 +1207,7 @@
         <param name="other">A permission set to intersect with the current <see cref="T:System.Security.PermissionSet" />.</param>
         <summary>Creates and returns a permission set that is the intersection of the current <see cref="T:System.Security.PermissionSet" /> and the specified <see cref="T:System.Security.PermissionSet" />.</summary>
         <returns>A new permission set that represents the intersection of the current <see cref="T:System.Security.PermissionSet" /> and the specified target. This object is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permission sets is a permission set that describes the set of operations they both describe in common. Specifically, it represents the minimum permissions such that any demand that passes both permission sets also passes their intersection.
-
- For each type of permission that is present in both sets, the two instances of those permissions are intersected using the permission's `Intersect` method; the resulting permission is included in the resulting <xref:System.Security.PermissionSet>. Permission types that exist in only one of the two sets are excluded from the resulting set.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsEmpty">
@@ -1404,14 +1259,7 @@
         <summary>Gets a value indicating whether the <see cref="T:System.Security.PermissionSet" /> is empty.</summary>
         <returns>
           <see langword="true" /> if the <see cref="T:System.Security.PermissionSet" /> is empty; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A <xref:System.Security.PermissionSet> can be empty and yet contain instances of permissions if those permissions are in the fully-restricted state. Permissions are in a fully restricted state if their `IsSubsetOf` methods return `true` when `null` is passed as a parameter.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsReadOnly">
@@ -1461,14 +1309,7 @@
       <Docs>
         <summary>Gets a value indicating whether the collection is read-only.</summary>
         <value>Always <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A <xref:System.Security.PermissionSet> cannot be read-only, so this property is always `false`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSubsetOf">
@@ -1523,14 +1364,7 @@
         <summary>Determines whether the current <see cref="T:System.Security.PermissionSet" /> is a subset of the specified <see cref="T:System.Security.PermissionSet" />.</summary>
         <returns>
           <see langword="true" /> if the current <see cref="T:System.Security.PermissionSet" /> is a subset of the <paramref name="target" /> parameter; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A <xref:System.Security.PermissionSet> is a subset of the target <xref:System.Security.PermissionSet> if all demands that succeed for the <xref:System.Security.PermissionSet> also succeed for the target. That is, the target contains at least the permissions contained in the subset.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSynchronized">
@@ -1583,16 +1417,7 @@
       <Docs>
         <summary>Gets a value indicating whether the collection is guaranteed to be thread safe.</summary>
         <value>Always <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.PermissionSet> does not automatically handle thread safety, so this property is always `false`.
-
- This method is required to support <xref:System.Collections.ICollection>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsUnrestricted">
@@ -1644,14 +1469,7 @@
         <summary>Determines whether the <see cref="T:System.Security.PermissionSet" /> is <see langword="Unrestricted" />.</summary>
         <returns>
           <see langword="true" /> if the <see cref="T:System.Security.PermissionSet" /> is <see langword="Unrestricted" />; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An `Unrestricted` <xref:System.Security.PermissionSet> effectively contains all permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PermitOnly">
@@ -1704,16 +1522,7 @@
       <Parameters />
       <Docs>
         <summary>Causes any <see cref="M:System.Security.PermissionSet.Demand" /> that passes through the calling code for any <see cref="T:System.Security.PermissionSet" /> that is not a subset of the current <see cref="T:System.Security.PermissionSet" /> to fail.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.PermissionSet.PermitOnly*> is similar to <xref:System.Security.PermissionSet.Deny*>, in that both cause stack walks to fail when they would otherwise succeed. The difference is that <xref:System.Security.PermissionSet.Deny*> specifies permissions that will cause the stack walk to fail, but <xref:System.Security.PermissionSet.PermitOnly*> specifies the only permissions that do not cause the stack walk to fail. Call this method to ensure that your code can be used to access only the specified resources.
-
- <xref:System.Security.PermissionSet.PermitOnly*> is ignored for a permission not granted because a demand for that permission cannot succeed. However, if code lower on the call stack later calls <xref:System.Security.PermissionSet.Demand*> for that permission, a <xref:System.Security.SecurityException> is thrown when the stack walk reaches the code that tried to call <xref:System.Security.PermissionSet.PermitOnly*>. This is because the code that called <xref:System.Security.PermissionSet.PermitOnly*> has not been granted the permission, even though it called <xref:System.Security.PermissionSet.PermitOnly*> for that permission. The call stack is typically represented as growing down, so that methods higher in the call stack call methods lower in the call stack.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemovePermission">
@@ -1767,16 +1576,7 @@
         <param name="permClass">The type of permission to delete.</param>
         <summary>Removes a permission of a certain type from the set.</summary>
         <returns>The permission removed from the set.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!IMPORTANT]
-> You cannot remove permissions from an unrestricted permission set. The permission set remains unrestricted after you attempt to remove the permission, and no exception is thrown.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.InvalidOperationException">The method is called from a <see cref="T:System.Security.ReadOnlyPermissionSet" />.</exception>
         <block subset="none" type="overrides">
           <para>When you inherit from <see cref="T:System.Security.PermissionSet" />, you can change the behavior of the <see cref="M:System.Security.PermissionSet.RemovePermission(System.Type)" /> method by overriding the <see cref="M:System.Security.PermissionSet.RemovePermissionImpl(System.Type)" /> method.</para>
@@ -1831,17 +1631,7 @@
         <param name="permClass">The type of the permission to remove.</param>
         <summary>Removes a permission of a certain type from the set.</summary>
         <returns>The permission removed from the set.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.PermissionSet.RemovePermissionImpl*> method is the implementation for the <xref:System.Security.PermissionSet.RemovePermission*> method.
-
-> [!IMPORTANT]
->  You cannot remove permissions from an unrestricted permission set. The permission set remains unrestricted after you attempt to remove the permission, and an exception is not thrown.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.InvalidOperationException">The method is called from a <see cref="T:System.Security.ReadOnlyPermissionSet" />.</exception>
       </Docs>
     </Member>
@@ -1891,14 +1681,7 @@
       <Parameters />
       <Docs>
         <summary>Causes any previous <see cref="M:System.Security.CodeAccessPermission.Assert" /> for the current frame to be removed and no longer be in effect.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If there is no <xref:System.Security.CodeAccessPermission.Assert*> for the current frame, an <xref:System.ExecutionEngineException> is thrown.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.InvalidOperationException">There is no previous <see cref="M:System.Security.CodeAccessPermission.Assert" /> for the current frame.</exception>
       </Docs>
     </Member>
@@ -1953,14 +1736,7 @@
         <param name="perm">The permission to set.</param>
         <summary>Sets a permission to the <see cref="T:System.Security.PermissionSet" />, replacing any existing permission of the same type.</summary>
         <returns>The set permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method removes any existing permission object of the same type from the <xref:System.Security.PermissionSet> and replaces it with the `perm` parameter. If a permission that implements <xref:System.Security.Permissions.IUnrestrictedPermission> is set on a <xref:System.Security.PermissionSet> that is <xref:System.Security.Permissions.PermissionState.Unrestricted>, the resulting <xref:System.Security.PermissionSet> is no longer `Unrestricted`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.InvalidOperationException">The method is called from a <see cref="T:System.Security.ReadOnlyPermissionSet" />.</exception>
         <block subset="none" type="overrides">
           <para>When you inherit from <see cref="T:System.Security.PermissionSet" />, you can change the behavior of the <see cref="M:System.Security.PermissionSet.SetPermission(System.Security.IPermission)" /> method by overriding the <see cref="M:System.Security.PermissionSet.SetPermissionImpl(System.Security.IPermission)" /> method.</para>
@@ -2015,16 +1791,7 @@
         <param name="perm">The permission to set.</param>
         <summary>Sets a permission to the <see cref="T:System.Security.PermissionSet" />, replacing any existing permission of the same type.</summary>
         <returns>The set permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.PermissionSet.SetPermissionImpl*> method is the implementation for the <xref:System.Security.PermissionSet.SetPermission*> method.
-
- This method removes any existing permission object of the same type from the <xref:System.Security.PermissionSet> and replaces it with the `perm` parameter. If a permission that implements <xref:System.Security.Permissions.IUnrestrictedPermission> is set on a <xref:System.Security.PermissionSet> that is <xref:System.Security.Permissions.PermissionState.Unrestricted>, the resulting <xref:System.Security.PermissionSet> is no longer `Unrestricted`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.InvalidOperationException">The method is called from a <see cref="T:System.Security.ReadOnlyPermissionSet" />.</exception>
       </Docs>
     </Member>
@@ -2084,14 +1851,7 @@
       <Docs>
         <summary>Gets the root object of the current collection.</summary>
         <value>The root object of the current collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is required to support <xref:System.Collections.ICollection>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Runtime.Serialization.IDeserializationCallback.OnDeserialization">
@@ -2199,14 +1959,7 @@
       <Docs>
         <summary>Returns a string representation of the <see cref="T:System.Security.PermissionSet" />.</summary>
         <returns>A representation of the <see cref="T:System.Security.PermissionSet" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The string representation is useful in debugging to see the state of a <xref:System.Security.PermissionSet>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -2314,14 +2067,7 @@
         <param name="other">The permission set to form the union with the current <see cref="T:System.Security.PermissionSet" />.</param>
         <summary>Creates a <see cref="T:System.Security.PermissionSet" /> that is the union of the current <see cref="T:System.Security.PermissionSet" /> and the specified <see cref="T:System.Security.PermissionSet" />.</summary>
         <returns>A new permission set that represents the union of the current <see cref="T:System.Security.PermissionSet" /> and the specified <see cref="T:System.Security.PermissionSet" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.PermissionSet.Union*> is a <xref:System.Security.PermissionSet> that represents all the operations represented by the current <xref:System.Security.PermissionSet> as well as all the operations represented by the specified <xref:System.Security.PermissionSet>. If either set is `Unrestricted`, the union is `Unrestricted` as well.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security/PolicyLevelType.xml
+++ b/xml/System.Security/PolicyLevelType.xml
@@ -34,19 +34,16 @@
   <Docs>
     <summary>Specifies the type of a managed code policy level.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The highest level of security policy is enterprise-wide. Successive lower levels of hierarchy represent further policy restrictions, but can never grant more permissions than allowed by higher levels. The policy levels in order are the following.  
-  
- 1. Enterprise  
-  
- 2. Machine  
-  
- 3. User  
-  
- 4. Application domain  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Remarks
+ The highest level of security policy is enterprise-wide. Successive lower levels of hierarchy represent further policy restrictions, but can never grant more permissions than allowed by higher levels. The policy levels in order are as follows:
+
+ 1. Enterprise
+ 2. Machine
+ 3. User
+ 4. Application domain
+
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Policy.PolicyLevel" />

--- a/xml/System.Security/SecureString.xml
+++ b/xml/System.Security/SecureString.xml
@@ -73,7 +73,6 @@ The following example demonstrates how to use a <xref:System.Security.SecureStri
     </example>
     <altmember cref="T:System.Runtime.InteropServices.ComVisibleAttribute" />
     <altmember cref="T:System.Runtime.InteropServices.Marshal" />
-    <altmember cref="T:System.Runtime.ConstrainedExecution.CriticalFinalizerObject" />
     <altmember cref="T:System.IDisposable" />
   </Docs>
   <Members>

--- a/xml/System.Security/SecurityContext.xml
+++ b/xml/System.Security/SecurityContext.xml
@@ -50,19 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
-> [!NOTE]
-> This type is marked obsolete starting in .NET 6.
-
- A <xref:System.Security.SecurityContext> object captures all security-related information for a logical thread, including the information contained in the <xref:System.Security.Principal.WindowsIdentity> and <xref:System.Threading.CompressedStack> objects. This configuration allows the Windows identity and the security elements on the stack to be propagated automatically when the <xref:System.Security.SecurityContext> is copied and transferred across asynchronous threads.
-
-> [!NOTE]
-> The common language runtime (CLR) is aware of impersonation operations performed using only managed code, not of impersonation performed outside of managed code, such as through platform invoke to unmanaged code or through direct calls to Win32 functions. Only managed <xref:System.Security.Principal.WindowsIdentity> objects can flow across asynchronous points, unless the `alwaysFlowImpersonationPolicy` element has been set to `true` (`<alwaysFlowImpersonationPolicy enabled="true"/>`). Setting the `alwaysFlowImpersonationPolicy` element to `true` specifies that the Windows identity always flows across asynchronous points, regardless of how impersonation was performed. For more information about flowing unmanaged impersonation across asynchronous points, see [&lt;alwaysFlowImpersonationPolicy&gt; Element](/dotnet/framework/configure-apps/file-schema/runtime/alwaysflowimpersonationpolicy-element).
-
- The <xref:System.Security.SecurityContext> is part of the larger <xref:System.Threading.ExecutionContext> and flows or migrates when the <xref:System.Threading.ExecutionContext> flows or migrates.
-
-> [!IMPORTANT]
-> This type implements the <xref:System.IDisposable> interface. When you have finished using the type, you should dispose of it either directly or indirectly. To dispose of the type directly, call its <xref:System.IDisposable.Dispose*> method in a `try`/`catch` block. To dispose of it indirectly, use a language construct such as `using` (in C#) or `Using` (in Visual Basic). For more information, see the "Using an Object that Implements IDisposable" section in the <xref:System.IDisposable> interface topic.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -100,15 +87,8 @@
       <Docs>
         <summary>Captures the security context for the current thread.</summary>
         <returns>The security context for the current thread.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The captured security context can be applied to another thread. The <xref:System.Security.SecurityContext> consists of the <xref:System.Threading.CompressedStack> and the <xref:System.Security.Principal.WindowsIdentity> for the executing thread.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.PlatformNotSupportedException">.NET 5+ (including .NET Core): In all cases.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="CreateCopy">
@@ -144,16 +124,8 @@
       <Docs>
         <summary>Creates a copy of the current security context.</summary>
         <returns>The security context for the current thread.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current context must have been acquired through a capture or a copy operation. This method is useful for applying a captured <xref:System.Security.SecurityContext> to multiple threads.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.InvalidOperationException">The current security context has been previously used, was marshaled across application domains, or was not acquired through the <see cref="M:System.Security.SecurityContext.Capture" /> method.</exception>
-        <exception cref="T:System.PlatformNotSupportedException">.NET 5+ (including .NET Core): In all cases.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="Dispose">
@@ -190,20 +162,8 @@
       <Parameters />
       <Docs>
         <summary>Releases all resources used by the current instance of the <see cref="T:System.Security.SecurityContext" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Call `Dispose` when you are finished using the <xref:System.Security.SecurityContext>. The `Dispose` method leaves the <xref:System.Security.SecurityContext> in an unusable state. After calling `Dispose`, you must release all references to the <xref:System.Security.SecurityContext> so the garbage collector can reclaim the memory that the <xref:System.Security.SecurityContext> was occupying.
-
- For more information, see [Cleaning Up Unmanaged Resources](/dotnet/standard/garbage-collection/unmanaged) and [Implementing a Dispose Method](/dotnet/standard/garbage-collection/implementing-dispose).
-
-> [!NOTE]
->  Always call `Dispose` before you release your last reference to the <xref:System.Security.SecurityContext>. Otherwise, the resources it is using will not be freed until the garbage collector calls the <xref:System.Security.SecurityContext> object's `Finalize` method.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.PlatformNotSupportedException">.NET 5+ (including .NET Core): In all cases.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="IsFlowSuppressed">
@@ -240,15 +200,8 @@
         <summary>Determines whether the flow of the security context has been suppressed.</summary>
         <returns>
           <see langword="true" /> if the flow has been suppressed; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.SecurityContext.IsFlowSuppressed*> method is used by infrastructure components to determine whether to transfer the <xref:System.Security.SecurityContext> information during asynchronous operations.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.PlatformNotSupportedException">.NET 5+ (including .NET Core): In all cases.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="IsWindowsIdentityFlowSuppressed">
@@ -285,15 +238,8 @@
         <summary>Determines whether the flow of the Windows identity portion of the current security context has been suppressed.</summary>
         <returns>
           <see langword="true" /> if the flow has been suppressed; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.SecurityContext.IsWindowsIdentityFlowSuppressed*> method is used by infrastructure components to determine whether to transfer the Windows identity information when the <xref:System.Security.SecurityContext> migrates during asynchronous operations.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.PlatformNotSupportedException">.NET 5+ (including .NET Core): In all cases.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="RestoreFlow">
@@ -328,16 +274,8 @@
       <Parameters />
       <Docs>
         <summary>Restores the flow of the security context across asynchronous threads.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.SecurityContext.RestoreFlow*> method is called by the <xref:System.Threading.AsyncFlowControl.Undo*?displayProperty=nameWithType> method to reverse the effect of a prior <xref:System.Security.SecurityContext.SuppressFlow*> method call.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.InvalidOperationException">The security context is <see langword="null" /> or an empty string.</exception>
-        <exception cref="T:System.PlatformNotSupportedException">.NET 5+ (including .NET Core): In all cases.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="Run">
@@ -379,25 +317,8 @@
         <param name="callback">The delegate that represents the method to run in the specified security context.</param>
         <param name="state">The object to pass to the callback method.</param>
         <summary>Runs the specified method in the specified security context on the current thread.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The security context for the current thread is returned to its previous state when the method call is complete.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.InvalidOperationException">
-          <paramref name="securityContext" /> is <see langword="null" />.
-
- -or-
-
- <paramref name="securityContext" /> was not acquired through a capture operation.
-
- -or-
-
- <paramref name="securityContext" /> has already been used as the argument to a <see cref="M:System.Security.SecurityContext.Run(System.Security.SecurityContext,System.Threading.ContextCallback,System.Object)" /> method call.</exception>
-        <exception cref="T:System.PlatformNotSupportedException">.NET 5+ (including .NET Core): In all cases.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="SuppressFlow">
@@ -433,21 +354,8 @@
       <Docs>
         <summary>Suppresses the flow of the security context across asynchronous threads.</summary>
         <returns>An <see cref="T:System.Threading.AsyncFlowControl" /> structure for restoring the flow.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to suppress the flow of <xref:System.Security.SecurityContext> information on the current thread for asynchronous operations.
-
- The common language runtime (CLR) is only aware of the impersonation operations performed using managed code. The CLR has no knowledge of impersonation performed outside of managed code, such as platform invokes to unmanaged code that does the impersonation, or through calls to Win32 functions. To flow identity across asynchronous points you must use the managed <xref:System.Security.Principal.WindowsIdentity> and <xref:System.Security.Principal.WindowsImpersonationContext> methods.
-
- Use the <xref:System.Threading.AsyncFlowControl.Undo*> method on the returned <xref:System.Threading.AsyncFlowControl> structure to return the <xref:System.Security.SecurityContext> object to its previous state.
-
- This method is protected with a <xref:System.Security.Permissions.SecurityAction.LinkDemand?displayProperty=nameWithType> for <xref:System.Security.Permissions.SecurityPermissionFlag.Infrastructure?displayProperty=nameWithType> permission. A fully trusted component can call this method to suppress the flow of the <xref:System.Security.SecurityContext> information during asynchronous calls. When the flow is suppressed, the <xref:System.Security.SecurityContext.Capture*> method returns `null`.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.PlatformNotSupportedException">.NET 5+ (including .NET Core): In all cases.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
     <Member MemberName="SuppressFlowWindowsIdentity">
@@ -483,20 +391,8 @@
       <Docs>
         <summary>Suppresses the flow of the Windows identity portion of the current security context across asynchronous threads.</summary>
         <returns>A structure for restoring the flow.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to suppress the flow of the Windows identity when the <xref:System.Security.SecurityContext> migrates across asynchronous threads.
-
- Use the <xref:System.Threading.AsyncFlowControl.Undo*> method on the returned <xref:System.Threading.AsyncFlowControl> structure to return the <xref:System.Security.SecurityContext> object to its previous state.
-
-> [!NOTE]
->  The common language runtime (CLR) is aware of impersonation operations performed using only managed code, not of impersonation performed outside of managed code, such as through platform invoke to unmanaged code or through direct calls to Win32 functions. Only managed <xref:System.Security.Principal.WindowsIdentity> objects can flow across asynchronous points, unless the `alwaysFlowImpersonationPolicy` element has been set to `true` (`<alwaysFlowImpersonationPolicy enabled="true"/>`). Setting the `alwaysFlowImpersonationPolicy` element to `true` specifies that the Windows identity always flows across asynchronous points, regardless of how impersonation was performed. For more information about flowing unmanaged impersonation across asynchronous points, see [\<alwaysFlowImpersonationPolicy> Element](/dotnet/framework/configure-apps/file-schema/runtime/alwaysflowimpersonationpolicy-element).
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.PlatformNotSupportedException">.NET 5+ (including .NET Core): In all cases.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.PlatformNotSupportedException">In all cases.</exception>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security/SecurityCriticalAttribute.xml
+++ b/xml/System.Security/SecurityCriticalAttribute.xml
@@ -57,23 +57,11 @@
     <remarks>
       <format type="text/markdown"><![CDATA[
 
-## Remarks
 > [!IMPORTANT]
-> Partially trusted code is no longer supported. This attribute has no effect in .NET Core.
-
- Security-critical operations are actions that affect code access security, such as elevation of privilege through suppression of code access security checks by using the <xref:System.Security.CodeAccessPermission.Assert*> method, calling unsafe managed code, and so forth. Either the <xref:System.Security.SecurityCriticalAttribute> attribute or the <xref:System.Security.SecuritySafeCriticalAttribute> attribute must be applied to code for the code to perform security-critical operations.
-
-> [!NOTE]
->  The <xref:System.Security.SecurityCriticalAttribute> is equivalent to a link demand for full trust. A type or member marked with the <xref:System.Security.SecurityCriticalAttribute> can be called only by fully trusted code; it does not have to demand specific permissions. It cannot be called by partially trusted code.
-
- Applying the <xref:System.Security.SecurityCriticalAttribute> at the assembly level identifies the assembly as a security-critical assembly. The entire assembly can be identified as critical by setting the scope parameter <xref:System.Security.SecurityCriticalScope.Everything?displayProperty=nameWithType>.
+> Partially trusted code is no longer supported. This attribute has no effect.
 
  ]]></format>
     </remarks>
-    <altmember cref="T:System.Security.SecurityTransparentAttribute" />
-    <altmember cref="T:System.Security.SecuritySafeCriticalAttribute" />
-    <related type="Article" href="/dotnet/framework/misc/security-transparent-code-level-1">Security-Transparent Code, Level 1</related>
-    <related type="Article" href="/dotnet/framework/misc/security-transparent-code-level-2">Security-Transparent Code, Level 2</related>
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
@@ -169,7 +157,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This constructor is provided for compatibility with the .NET Framework version 2.0 transparency model. It does not apply to the .NET Framework 4. For more information, see [Security-Transparent Code, Level 2](/dotnet/framework/misc/security-transparent-code-level-2).
+ This constructor is provided for compatibility with the .NET Framework 2.0 transparency model.
 
  ]]></format>
         </remarks>

--- a/xml/System.Security/SecurityElement.xml
+++ b/xml/System.Security/SecurityElement.xml
@@ -927,18 +927,8 @@
       <Docs>
         <param name="xml">The XML-encoded string from which to create the security element.</param>
         <summary>Creates a security element from an XML-encoded string.</summary>
-        <returns>A <see cref="T:System.Security.SecurityElement" /> created from the XML.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Do not use single quotation marks in the XML string; instead, use escaped double quotation marks. For example, instead of "`<value name='Company'>Microsoft</value>"` use "`<value name=\"Company\">Microsoft</value>"`.
-
- Using single quotation marks can result in either an exception being thrown or, in some cases, the single quotation marks being treated as text in the string.
-
- Evidence based security model is not supported on .NET Core and this method will return `null`.
- ]]></format>
-        </remarks>
+        <returns><see langword="null" />.</returns>
+        <remarks>The evidence-based security model is not supported on .NET and this method returns <see langword="null" />.</remarks>
         <exception cref="T:System.Security.XmlSyntaxException">
           <paramref name="xml" /> contains one or more single quotation mark characters.</exception>
         <exception cref="T:System.ArgumentNullException">

--- a/xml/System.Security/SecurityManager.xml
+++ b/xml/System.Security/SecurityManager.xml
@@ -47,8 +47,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Security provides methods to access and manipulate the security policy configuration. You cannot create instances of <xref:System.Security.SecurityManager>.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -93,16 +91,7 @@
         <summary>Gets or sets a value indicating whether code must have <see cref="F:System.Security.Permissions.SecurityPermissionFlag.Execution" /> in order to execute.</summary>
         <value>
           <see langword="true" /> if code must have <see cref="F:System.Security.Permissions.SecurityPermissionFlag.Execution" /> in order to execute; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If this property is `false`, even code without <xref:System.Security.Permissions.SecurityPermissionFlag.Execution> can execute. Execution checking is expensive and can eliminate the advantages of lazy policy resolution. This property is provided to disable execution checking when needed.
-
- A change to this property is not persisted until <xref:System.Security.SecurityManager.SavePolicy*> is called. New processes will not be affected by the change until it is persisted in the registry.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">The code that calls this method does not have <see cref="F:System.Security.Permissions.SecurityPermissionFlag.ControlPolicy" />.</exception>
       </Docs>
     </Member>
@@ -139,21 +128,7 @@
         <summary>Determines whether the current thread requires a security context capture if its security state has to be re-created at a later point in time.</summary>
         <returns>
           <see langword="false" /> if the stack contains no partially trusted application domains, no partially trusted assemblies, and no currently active <see cref="M:System.Security.CodeAccessPermission.PermitOnly" /> or <see cref="M:System.Security.CodeAccessPermission.Deny" /> modifiers; <see langword="true" /> if the common language runtime cannot guarantee that the stack contains none of these.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- You can use the <xref:System.Security.SecurityManager.CurrentThreadRequiresSecurityContextCapture*> method before you cache sensitive data that is obtained after successful security demands.
-
- If the <xref:System.Security.CodeAccessPermission.Assert*> method has been called higher on the stack, the data should not be cached without capturing the corresponding security context. Otherwise, sensitive data that is obtained under an <xref:System.Security.CodeAccessPermission.Assert*> may become available to code that is no longer be running with that <xref:System.Security.CodeAccessPermission.Assert*> in place.
-
-> [!IMPORTANT]
->  The return value is reliable only when it is `false`, which means that the thread is guaranteed not to require a security context capture. The method may return true when a security context capture is not necessary, to avoid security vulnerabilities.
-
- <xref:System.Security.SecurityManager.CurrentThreadRequiresSecurityContextCapture*> is security-critical because its main use is to avoid unnecessary security context captures, which indicates that the code using it is security-sensitive and must be audited.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetStandardSandbox">
@@ -191,31 +166,7 @@
         <param name="evidence">The host evidence to match to a permission set.</param>
         <summary>Gets a permission set that is safe to grant to an application that has the provided evidence.</summary>
         <returns>A permission set that can be used as a grant set for the application that has the provided evidence.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!NOTE]
->  In the .NET Framework 4, the host evidence in `evidence` must contain <xref:System.Security.Policy.Zone?displayProperty=nameWithType> evidence.
->
->  The following table shows the permission sets that are returned for each zone.
-
-| Zone                                           | Permission set  |
-|------------------------------------------------|-----------------|
-| <xref:System.Security.SecurityZone.MyComputer> | `FullTrust`     |
-| <xref:System.Security.SecurityZone.Intranet>   | `LocalIntranet` |
-| <xref:System.Security.SecurityZone.Trusted>    | `Internet`      |
-| <xref:System.Security.SecurityZone.Internet>   | `Internet`      |
-| <xref:System.Security.SecurityZone.Untrusted>  | None            |
-| <xref:System.Security.SecurityZone.NoZone>     | None            |
-
- Other evidence, such as <xref:System.Security.Policy.Url> or <xref:System.Security.Policy.Site>, may be considered.
-
- The returned permission set can be used by a sandbox to run the application. Note that this method does not specify policy, but helps a host to determine whether the permission set requested by an application is reasonable. This method can be used to map a zone to a sandbox.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="evidence" /> is <see langword="null" />.</exception>
       </Docs>
@@ -258,17 +209,7 @@
         <param name="zone">An output parameter that contains an <see cref="T:System.Collections.ArrayList" /> of granted <see cref="P:System.Security.Permissions.ZoneIdentityPermissionAttribute.Zone" /> objects.</param>
         <param name="origin">An output parameter that contains an <see cref="T:System.Collections.ArrayList" /> of granted <see cref="T:System.Security.Permissions.UrlIdentityPermission" /> objects.</param>
         <summary>Gets the granted zone identity and URL identity permission sets for the current assembly.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The recommended alternative to this method is to use the URL and Zone evidence for the executing assembly to call <xref:System.Security.SecurityManager.ResolvePolicy*> for each evidence type. The permission sets returned from the <xref:System.Security.SecurityManager.ResolvePolicy*> calls identify the permissions granted to the executing assembly based on its zone and URL of origin.
-
-> [!NOTE]
->  This member makes a link demand for the ECMA public key, which is not a valid cryptographic key but a pseudo key. Within the .NET Framework the link demand for the ECMA pseudo key is automatically converted to a link demand for the Microsoft public key. The security exception is based on the Microsoft public key, not the ECMA pseudo key.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">The request for <see cref="T:System.Security.Permissions.StrongNameIdentityPermission" /> failed.</exception>
       </Docs>
     </Member>
@@ -316,14 +257,7 @@
         <summary>Determines whether a permission is granted to the caller.</summary>
         <returns>
           <see langword="true" /> if the permissions granted to the caller include the permission <paramref name="perm" />; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Granting of permissions is determined by policy and is different from a demand subject to overrides, such as an assert. Also, <xref:System.Security.SecurityManager.IsGranted*> only tests the grant of the calling code assembly, independent of other callers on the stack.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LoadPolicyLevelFromFile">
@@ -387,7 +321,7 @@
  -or-
 
  The code that calls this method does not have <see cref="F:System.Security.Permissions.FileIOPermissionAccess.PathDiscovery" />.</exception>
-        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete in the .NET Framework 4. To enable CAS policy for compatibility with earlier versions of the .NET Framework, use the <see href="/dotnet/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element">&lt;legacyCasPolicy&gt; element</see>.</exception>
+        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete.</exception>
       </Docs>
     </Member>
     <Member MemberName="LoadPolicyLevelFromString">
@@ -481,17 +415,8 @@
       <Docs>
         <summary>Provides an enumerator to access the security policy hierarchy by levels, such as computer policy and user policy.</summary>
         <returns>An enumerator for <see cref="T:System.Security.Policy.PolicyLevel" /> objects that compose the security policy hierarchy.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The returned enumerator provides successive <xref:System.Security.Policy.PolicyLevel> objects that represent the policy at the respective (machine, user, enterprise, application domain) level of the hierarchy. These objects are the live policy objects; altering these objects can have unpredictable results.
-
- Minimum policy hierarchy consists of a machine level, an enterprise level, and a user level. However, the hierarchy can include additional levels.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete in the .NET Framework 4. To enable CAS policy for compatibility with earlier versions of the .NET Framework, use the <see href="/dotnet/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element">&lt;legacyCasPolicy&gt; element</see>.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete.</exception>
         <exception cref="T:System.Security.SecurityException">The code that calls this method does not have <see cref="F:System.Security.Permissions.SecurityPermissionFlag.ControlPolicy" />.</exception>
       </Docs>
     </Member>
@@ -548,15 +473,8 @@
         <param name="evidence">The evidence set used to evaluate policy.</param>
         <summary>Determines what permissions to grant to code based on the specified evidence.</summary>
         <returns>The set of permissions that can be granted by the security system.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method invokes the security policy engine, providing it with evidence of the calling code's identity. The result is determined by the security policy.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete in the .NET Framework 4. To enable CAS policy for compatibility with earlier versions of the .NET Framework, use the <see href="/dotnet/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element">&lt;legacyCasPolicy&gt; element</see>.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete.</exception>
       </Docs>
     </Member>
     <Member MemberName="ResolvePolicy">
@@ -601,15 +519,8 @@
         <param name="evidences">An array of evidence objects used to evaluate policy.</param>
         <summary>Determines what permissions to grant to code based on the specified evidence.</summary>
         <returns>The set of permissions that is appropriate for all of the provided evidence.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method invokes the security policy engine, providing it with an array of <xref:System.Security.Policy.Evidence> objects. The returned permission set represents only those permissions that apply to every evidence in the array. These permissions are either equivalent to, or a subset of the permissions that policy would have granted to each individual evidence. This method behaves as if you were performing an intersection on the results of resolving policy on each of the <xref:System.Security.Policy.Evidence> objects in the array.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete in the .NET Framework 4. To enable CAS policy for compatibility with earlier versions of the .NET Framework, use the <see href="/dotnet/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element">&lt;legacyCasPolicy&gt; element</see>.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete.</exception>
       </Docs>
     </Member>
     <Member MemberName="ResolvePolicy">
@@ -663,15 +574,8 @@
         <param name="denied">An output parameter that contains the set of permissions not granted.</param>
         <summary>Determines what permissions to grant to code based on the specified evidence and requests.</summary>
         <returns>The set of permissions that would be granted by the security system.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method invokes the security policy engine, providing it with evidence of the calling code's identity and the set of permissions the code requests. The result is determined by the security policy. This method returns the set of permissions that would be granted by the security system, and returns the set of permissions that would be denied as an output parameter. The effective granted permissions are those in the granted set that are not in the denied set.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete in the .NET Framework 4. To enable CAS policy for compatibility with earlier versions of the .NET Framework, use the <see href="/dotnet/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element">&lt;legacyCasPolicy&gt; element</see>.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete.</exception>
         <exception cref="T:System.Security.Policy.PolicyException">Policy fails to grant the minimum required permissions specified by the <paramref name="reqdPset" /> parameter.</exception>
       </Docs>
     </Member>
@@ -718,17 +622,8 @@
         <param name="evidence">The evidence set against which the policy is evaluated.</param>
         <summary>Gets a collection of code groups matching the specified evidence.</summary>
         <returns>An enumeration of the set of code groups matching the evidence.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is useful in analyzing how a specified policy configuration works with specific kinds of evidence.
-
- Code groups will be returned from all applicable levels of the policy hierarchy matching the `evidence` parameter.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete in the .NET Framework 4. To enable CAS policy for compatibility with earlier versions of the .NET Framework, use the <see href="/dotnet/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element">&lt;legacyCasPolicy&gt; element</see>.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete.</exception>
       </Docs>
     </Member>
     <Member MemberName="ResolveSystemPolicy">
@@ -773,15 +668,8 @@
         <param name="evidence">The evidence set used to evaluate policy.</param>
         <summary>Determines which permissions to grant to code based on the specified evidence, excluding the policy for the <see cref="T:System.AppDomain" /> level.</summary>
         <returns>The set of permissions that can be granted by the security system.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method invokes the security policy engine and provides it with evidence of the calling code's identity. The result is determined by the system security policy exclusive of any <xref:System.AppDomain> policy.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete in the .NET Framework 4. To enable CAS policy for compatibility with earlier versions of the .NET Framework, use the <see href="/dotnet/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element">&lt;legacyCasPolicy&gt; element</see>.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete.</exception>
       </Docs>
     </Member>
     <Member MemberName="SavePolicy">
@@ -823,16 +711,8 @@
       <Parameters />
       <Docs>
         <summary>Saves the modified security policy state.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method saves the policy as exposed by <xref:System.Security.SecurityManager.PolicyHierarchy*>, <xref:System.Security.Policy.PolicyLevel>, and other classes that represent configuration of the security policy. Unless this method is called, changes made to the policy objects will not be saved and will not affect subsequent application runs.
-
- ]]></format>
-        </remarks>
-        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete in the .NET Framework 4. To enable CAS policy for compatibility with earlier versions of the .NET Framework, use the <see href="/dotnet/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element">&lt;legacyCasPolicy&gt; element</see>.</exception>
-        <exception cref="T:System.Security.SecurityException">The code that calls this method does not have <see cref="F:System.Security.Permissions.SecurityPermissionFlag.ControlPolicy" />.</exception>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete.</exception>
       </Docs>
     </Member>
     <Member MemberName="SavePolicyLevel">
@@ -877,16 +757,9 @@
       <Docs>
         <param name="level">The policy level object to be saved.</param>
         <summary>Saves a modified security policy level loaded with <see cref="M:System.Security.SecurityManager.LoadPolicyLevelFromFile(System.String,System.Security.PolicyLevelType)" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Policy.PolicyLevel> will be saved to the same location from which it loaded.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">The code that calls this method does not have <see cref="F:System.Security.Permissions.SecurityPermissionFlag.ControlPolicy" />.</exception>
-        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete in the .NET Framework 4. To enable CAS policy for compatibility with earlier versions of the .NET Framework, use the <see href="/dotnet/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element">&lt;legacyCasPolicy&gt; element</see>.</exception>
+        <exception cref="T:System.NotSupportedException">This method uses code access security (CAS) policy, which is obsolete.</exception>
       </Docs>
     </Member>
     <Member MemberName="SecurityEnabled">
@@ -929,23 +802,7 @@
         <summary>Gets or sets a value indicating whether security is enabled.</summary>
         <value>
           <see langword="true" /> if security is enabled; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property is used by the [Caspol.exe (Code Access Security Policy Tool)](/dotnet/framework/tools/caspol-exe-code-access-security-policy-tool)
-
- `-security` (`-s`) option to turn off code-based security.
-
- <xref:System.Security.SecurityManager.SecurityEnabled*> provides a way for administrators to disable code access security. When code access security is disabled, all code access demands succeed. Effectively, this grants all code `FullTrust`. Disabling code access security bypasses the security system so that code might perform slightly better than the equivalent security policy granting `FullTrust` to all code. This property does not disable role-based security; therefore, <xref:System.Security.Permissions.PrincipalPermission> demands are not affected.
-
-> [!CAUTION]
->  Disabling code access security makes the system vulnerable to attacks by malicious code such as viruses and worms. Disabling code access security does not automatically block managed code from running in any way. It only causes managed code to run without restriction by the code access security system, and should only be done with the most extreme caution. Turning off security to gain extra performance should only be done when other security measures have been taken to help protect system security. Examples of other security precautions include disconnecting from public networks, physically securing computers, and so on.
-
- A change to this property is not persisted in the registry until <xref:System.Security.SecurityManager.SavePolicy*> is called. New processes will not be affected by the change until it is persisted in the registry. Changing the value of this property in a running process does not necessarily change the state in the expected manner. To ensure changes have taken effect, you must call <xref:System.Security.SecurityManager.SavePolicy*> and start a new process.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">The code that calls this method does not have <see cref="F:System.Security.Permissions.SecurityPermissionFlag.ControlPolicy" />.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security/SecurityRuleSet.xml
+++ b/xml/System.Security/SecurityRuleSet.xml
@@ -46,11 +46,10 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- This enumeration indicates which set of security rules the common language runtime should enforce for an assembly. For example, an assembly that is marked with `[SecurityRules(SecurityRuleSet.Level1)]` uses the .NET Framework version 2.0 transparency rules, where public security-critical types and members are treated as security-safe-critical outside the assembly. This requires security-critical types and members to perform a link demand for full trust to enforce security-critical behavior when they are accessed by external callers. Typically, level 1 rules should be used only for compatibility, such as for .NET Framework 2.0 assemblies. By default, .NET Framework 2.0 assemblies become level 2 assemblies when they are recompiled for .NET Framework 4. To compile these assemblies as level 1, you must mark them explicitly as level 1. For more information about level 1 behavior, see [Security-Transparent Code, Level 1](/dotnet/framework/misc/security-transparent-code-level-1). For information about level 2 behavior, see [Security-Transparent Code, Level 2](/dotnet/framework/misc/security-transparent-code-level-2).
+ This enumeration indicates which set of security rules the common language runtime should enforce for an assembly.
 
  ]]></format>
     </remarks>
-    <related type="Article" href="/dotnet/framework/security/security-changes">Security Changes in the .NET Framework Version 4.0</related>
   </Docs>
   <Members>
     <Member MemberName="Level1">

--- a/xml/System.Security/SecurityRulesAttribute.xml
+++ b/xml/System.Security/SecurityRulesAttribute.xml
@@ -50,17 +50,14 @@
   <Docs>
     <summary>Indicates the set of security rules the common language runtime should enforce for an assembly.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-> [!IMPORTANT]
-> Partially trusted code is no longer supported. This attribute has no effect in .NET Core.
+      <format type="text/markdown"><![CDATA[
 
- This class indicates which set of security rules the common language runtime should enforce for an assembly. For example, an assembly that is marked with `[SecurityRules(SecurityRuleSet.Level1)]` uses the .NET Framework version 2.0 transparency rules, where public security-critical types and members are treated as security-safe-critical outside the assembly. This requires security-critical types and members to perform a link demand for full trust to enforce security-critical behavior when they are accessed by external callers. Typically, level 1 rules should be used only for compatibility, such as for version 2.0 assemblies. For more information about level 1 behavior, see [Security-Transparent Code, Level 1](/dotnet/framework/misc/security-transparent-code-level-1). For information about level 2 behavior, see [Security-Transparent Code, Level 2](/dotnet/framework/misc/security-transparent-code-level-2).  
-  
+## Remarks
+> [!IMPORTANT]
+> Partially trusted code is no longer supported. This attribute has no effect.
+
  ]]></format>
     </remarks>
-    <related type="Article" href="/dotnet/framework/security/security-changes">Security Changes in the .NET Framework Version 4.0</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -100,15 +97,7 @@
       <Docs>
         <param name="ruleSet">One of the enumeration values that specifies the transparency rules set.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.SecurityRulesAttribute" /> class using the specified rule set value.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- When you specify the `ruleSet` parameter, use <xref:System.Security.SecurityRuleSet.Level1> for .NET Framework version 2.0 rules or <xref:System.Security.SecurityRuleSet.Level2> for .NET Framework 4 rules. For more information about <xref:System.Security.SecurityRuleSet.Level1> behavior, see [Security-Transparent Code, Level 1](/dotnet/framework/misc/security-transparent-code-level-1). For information about <xref:System.Security.SecurityRuleSet.Level2> behavior, see [Security-Transparent Code, Level 2](/dotnet/framework/misc/security-transparent-code-level-2).  
-  
- ]]></format>
-        </remarks>
-        <related type="Article" href="/dotnet/framework/security/security-changes">Security Changes in the .NET Framework Version 4.0</related>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RuleSet">
@@ -189,17 +178,7 @@
         <summary>Determines whether fully trusted transparent code should skip Microsoft intermediate language (MSIL) verification.</summary>
         <value>
           <see langword="true" /> if MSIL verification should be skipped; otherwise, <see langword="false" />. The default is <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks
-
-This property should be used only for optimization, because security guarantees made for transparent code cannot be enforced if the code is unverifiable.  
-
-If you use this property to skip MSIL verification for an assembly, use the `/transparent` option in the [Peverify tool](/dotnet/framework/tools/peverify-exe-peverify-tool) to statically verify that the assembly's transparent code meets type safety requirements.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security/SecuritySafeCriticalAttribute.xml
+++ b/xml/System.Security/SecuritySafeCriticalAttribute.xml
@@ -55,20 +55,13 @@
   <Docs>
     <summary>Identifies types or members as security-critical and safely accessible by transparent code.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-> [!IMPORTANT]
-> Partially trusted code is no longer supported. This attribute has no effect in .NET Core.
+      <format type="text/markdown"><![CDATA[
 
- Types or members that are marked with the <xref:System.Security.SecuritySafeCriticalAttribute> attribute can be accessed by partially trusted types and members. These partially trusted types and members can be within any assembly that is marked with the <xref:System.Security.SecurityTransparentAttribute> or <xref:System.Security.AllowPartiallyTrustedCallersAttribute> (APTCA) attribute, or they are partially trusted for other reasons, such as being loaded into partial trust. Code that is marked with the <xref:System.Security.SecuritySafeCriticalAttribute> must be subject to a rigorous security audit to ensure that it can be used safely in a secure execution environment. Security-safe-critical code must validate the permissions of callers to determine whether they have authority to access protected resources used by the code.  
-  
+> [!IMPORTANT]
+> Partially trusted code is no longer supported. This attribute has no effect in modern .NET.
+
  ]]></format>
     </remarks>
-    <altmember cref="T:System.Security.SecurityCriticalAttribute" />
-    <altmember cref="T:System.Security.SecurityTransparentAttribute" />
-    <related type="Article" href="/dotnet/framework/misc/security-transparent-code-level-1">Security-Transparent Code, Level 1</related>
-    <related type="Article" href="/dotnet/framework/misc/security-transparent-code-level-2">Security-Transparent Code, Level 2</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Security/SecurityTransparentAttribute.xml
+++ b/xml/System.Security/SecurityTransparentAttribute.xml
@@ -55,23 +55,13 @@
   <Docs>
     <summary>Specifies that an assembly cannot cause an elevation of privilege.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-> [!IMPORTANT]
-> Partially trusted code is no longer supported. This attribute has no effect in .NET Core.
+      <format type="text/markdown"><![CDATA[
 
- Transparent assemblies can be accessed from partially trusted code and cannot expose access to any protected resources or functionality. Code in the assembly is not allowed to suppress code access security checks and cannot cause an elevation of privilege.  
-  
-> [!NOTE]
->  Transparency is enforced by the just-in-time compiler, not by the security infrastructure code. Applying this attribute to an assembly allows the assembly to access only transparent and security-safe-critical types and members regardless of its permission set, including full trust. Transparent code that accesses a security-critical type or member results in a <xref:System.MethodAccessException> being thrown.  
-  
+> [!IMPORTANT]
+> Partially trusted code is no longer supported. This attribute has no effect.
+
  ]]></format>
     </remarks>
-    <altmember cref="T:System.Security.SecurityCriticalAttribute" />
-    <altmember cref="T:System.Security.SecurityTransparentAttribute" />
-    <related type="Article" href="/dotnet/framework/misc/security-transparent-code-level-1">Security-Transparent Code, Level 1</related>
-    <related type="Article" href="/dotnet/framework/misc/security-transparent-code-level-2">Security-Transparent Code, Level 2</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Security/SecurityTreatAsSafeAttribute.xml
+++ b/xml/System.Security/SecurityTreatAsSafeAttribute.xml
@@ -63,14 +63,12 @@
   <Docs>
     <summary>Identifies which of the nonpublic <see cref="T:System.Security.SecurityCriticalAttribute" /> members are accessible by transparent code within the assembly.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-> [!IMPORTANT]
-> Partially trusted code is no longer supported. This attribute has no effect in .NET Core.
+      <format type="text/markdown"><![CDATA[
 
- Types or members marked with the <xref:System.Security.SecurityCriticalAttribute> attribute and the <xref:System.Security.SecurityTreatAsSafeAttribute> attribute can be accessed by types and members within the assembly that are marked with the <xref:System.Security.SecurityTransparentAttribute> attribute.  
-  
+## Remarks
+> [!IMPORTANT]
+> Partially trusted code is no longer supported. This attribute has no effect.
+
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.SecurityTransparentAttribute" />

--- a/xml/System.Security/SuppressUnmanagedCodeSecurityAttribute.xml
+++ b/xml/System.Security/SuppressUnmanagedCodeSecurityAttribute.xml
@@ -52,28 +52,14 @@
   <Docs>
     <summary>Allows managed code to call into unmanaged code without a stack walk. This class cannot be inherited.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
+      <format type="text/markdown"><![CDATA[
+
+## Remarks
 > [!IMPORTANT]
-> Partially trusted code is no longer supported. This attribute has no effect in .NET Core.
-  
-> [!CAUTION]
->  Use this attribute with extreme care. Incorrect use can create security weaknesses.  
-  
- This attribute can be applied to methods that want to call into native code without incurring the performance loss of a run-time security check when doing so. The stack walk performed when calling unmanaged code is omitted at run time, resulting in substantial performance savings. Using this attribute in a class applies it to all contained methods.  
-  
- Generally, whenever managed code calls into unmanaged code (by PInvoke or COM interop into native code), there is a demand for the `UnmanagedCode` permission to ensure all callers have the necessary permission to allow this. By applying this explicit attribute, developers can suppress the demand at run time. The developer must take responsibility for assuring that the transition into unmanaged code is sufficiently protected by other means. The demand for the `UnmanagedCode` permission will still occur at link time. For example, if function A calls function B and function B is marked with <xref:System.Security.SuppressUnmanagedCodeSecurityAttribute>, function A will be checked for unmanaged code permission during just-in-time compilation, but not subsequently during run time.  
-  
- This attribute is only effective when applied to PInvoke methods (or classes that contain PInvoke methods) or the definition of an interface through which interop calls will be made. It will be ignored in all other contexts.  
-  
- This attribute is useful for implementing a class that provides access to system resources through unmanaged code. Code that does not have permission to access unmanaged code can call a class with this attribute to access unmanaged code. This is only safe if the writer of the class with this attribute has programmed the class to be secure. If not, this attribute is dangerous and can allow the code that uses it to be misused.  
-  
- This is not a declarative security attribute, but a regular attribute (it derives from <xref:System.Attribute>, not <xref:System.Security.Permissions.SecurityAttribute>).  
-  
+> Partially trusted code is no longer supported. This attribute has no effect.
+
  ]]></format>
     </remarks>
-    <related type="Article" href="/dotnet/standard/attributes/">Extending Metadata Using Attributes</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -111,14 +97,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Security.SuppressUnmanagedCodeSecurityAttribute" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The parameterless constructor initializes any fields to their default values.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
.NET Framework API ref has moved to its own repo (https://github.com/dotnet/dotnetfw-api-docs), so we can clean up .NET Framework remarks, exceptions, and code examples out of this repo. Contributes to #12513.

Removes remarks and examples related to:

- .NET Framework versions
- Code-access security
- Configuring apps via app.config file
- App domains

Also removes *all* remarks from obsolete APIs.

*Hide whitespace changes*