### PR TITLE
Remove .NET Framework remarks (System.Security.Permissions)

### DIFF
--- a/xml/System.Security.Permissions/CodeAccessSecurityAttribute.xml
+++ b/xml/System.Security.Permissions/CodeAccessSecurityAttribute.xml
@@ -91,18 +91,8 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This attribute class associates a <xref:System.Security.Permissions.SecurityAction>, for example, `Demand`, with a custom security attribute.
-
- The types that derive from <xref:System.Security.Permissions.CodeAccessSecurityAttribute> are used to help restrict access to resources or securable operations.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. Use the corresponding permission class derived from <xref:System.Security.CodeAccessPermission> for imperative security.
-
  ]]></format>
     </remarks>
-    <block subset="none" type="overrides">
-      <para>All permission attributes derived from this class must have only a single constructor that takes a <see cref="T:System.Security.Permissions.SecurityAction" /> as its only parameter.</para>
-    </block>
-    <altmember cref="T:System.Security.CodeAccessPermission" />
     <related type="Article" href="/dotnet/standard/attributes/">Extending Metadata Using Attributes</related>
   </Docs>
   <Members>
@@ -155,14 +145,7 @@
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</param>
         <summary>Initializes a new instance of <see cref="T:System.Security.Permissions.CodeAccessSecurityAttribute" /> with the specified <see cref="T:System.Security.Permissions.SecurityAction" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- You cannot create an instance of this class. You must inherit from this class to make use of its functionality.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <block subset="none" type="overrides">
           <para>Derived classes must have only one constructor that takes a <see cref="T:System.Security.Permissions.SecurityAction" /> as its only parameter.</para>
         </block>

--- a/xml/System.Security.Permissions/DataProtectionPermission.xml
+++ b/xml/System.Security.Permissions/DataProtectionPermission.xml
@@ -48,8 +48,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This permission is used to control the ability to encrypt data and memory using the <xref:System.Security.Cryptography.ProtectedData> and <xref:System.Security.Cryptography.ProtectedMemory> classes.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.DataProtectionPermissionAttribute" />
@@ -133,14 +131,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.DataProtectionPermission" /> class with the specified permission state.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates either `None` (fully restricted) or `Unrestricted` access to data and memory.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="state" /> is not a valid <see cref="T:System.Security.Permissions.PermissionState" /> value.</exception>
         <altmember cref="T:System.Security.Permissions.DataProtectionPermissionAttribute" />
@@ -178,14 +169,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of the permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Flags">
@@ -219,14 +203,7 @@
       <Docs>
         <summary>Gets or sets the data and memory protection flags.</summary>
         <value>A bitwise combination of the <see cref="T:System.Security.Permissions.DataProtectionPermissionFlags" /> values.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property specifies whether the `Protect` and `Unprotect` methods of the <xref:System.Security.Cryptography.ProtectedData> and <xref:System.Security.Cryptography.ProtectedMemory> classes can be used.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The specified value is not a valid combination of the <see cref="T:System.Security.Permissions.DataProtectionPermissionFlags" /> values.</exception>
       </Docs>
     </Member>
@@ -264,14 +241,7 @@
       <Docs>
         <param name="securityElement">A <see cref="T:System.Security.SecurityElement" /> that contains the XML encoding used to reconstruct the permission.</param>
         <summary>Reconstructs a permission with a specific state from an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.DataProtectionPermission.FromXml*> method reconstructs a <xref:System.Security.Permissions.DataProtectionPermission> object from an XML encoding defined by the <xref:System.Security.SecurityElement> class. Use the <xref:System.Security.Permissions.DataProtectionPermission.ToXml*> method to XML-encode the <xref:System.Security.Permissions.DataProtectionPermission>, including state information.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="securityElement" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
@@ -317,14 +287,7 @@
         <param name="target">A permission to intersect with the current permission. It must be the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both individual permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not <see langword="null" /> and does not specify a permission of the same type as the current permission.</exception>
       </Docs>
@@ -365,14 +328,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained in the specified permission.  For example, a permission for <xref:System.Security.Permissions.DataProtectionPermissionFlags.ProtectData> access is a subset of a permission for <xref:System.Security.Permissions.DataProtectionPermissionFlags.AllFlags> access.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not <see langword="null" /> and does not specify a permission of the same type as the current permission.</exception>
       </Docs>
@@ -413,14 +369,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission represents access to all resources protected by the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -455,14 +404,7 @@
       <Docs>
         <summary>Creates an XML encoding of the permission and its current state.</summary>
         <returns>An XML encoding of the permission, including state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use the <xref:System.Security.Permissions.DataProtectionPermission.FromXml*> method to restore the state information from a <xref:System.Security.SecurityElement>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -500,14 +442,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.DataProtectionPermission.Union*> is a permission that represents all operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not <see langword="null" /> and does not specify a permission of the same type as the current permission.</exception>
       </Docs>

--- a/xml/System.Security.Permissions/DataProtectionPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/DataProtectionPermissionAttribute.xml
@@ -48,10 +48,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> value that is used.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. <xref:System.Security.Permissions.DataProtectionPermissionAttribute> is used only for declarative security. For imperative security, use the <xref:System.Security.Permissions.DataProtectionPermission> class.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -122,16 +118,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.DataProtectionPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.DataProtectionPermission" /> that corresponds to the attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should only be called by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Flags">
@@ -200,14 +187,7 @@
         <summary>Gets or sets a value indicating whether data can be encrypted using the <see cref="T:System.Security.Cryptography.ProtectedData" /> class.</summary>
         <value>
           <see langword="true" /> if data can be encrypted; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If the value is `false`, a <xref:System.Security.SecurityException> occurs when the <xref:System.Security.Cryptography.ProtectedData.Protect*?displayProperty=nameWithType> method is called.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ProtectMemory">
@@ -242,14 +222,7 @@
         <summary>Gets or sets a value indicating whether memory can be encrypted using the <see cref="T:System.Security.Cryptography.ProtectedMemory" /> class.</summary>
         <value>
           <see langword="true" /> if memory can be encrypted; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If the value is `false`, a <xref:System.Security.SecurityException> occurs when the <xref:System.Security.Cryptography.ProtectedMemory.Protect*?displayProperty=nameWithType> method is called.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnprotectData">
@@ -284,14 +257,7 @@
         <summary>Gets or sets a value indicating whether data can be unencrypted using the <see cref="T:System.Security.Cryptography.ProtectedData" /> class.</summary>
         <value>
           <see langword="true" /> if data can be unencrypted; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If this value is `false`, a <xref:System.Security.SecurityException> occurs when the <xref:System.Security.Cryptography.ProtectedData.Unprotect*?displayProperty=nameWithType> method is called.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnprotectMemory">
@@ -326,14 +292,7 @@
         <summary>Gets or sets a value indicating whether memory can be unencrypted using the <see cref="T:System.Security.Cryptography.ProtectedMemory" /> class.</summary>
         <value>
           <see langword="true" /> if memory can be unencrypted; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If this value is `false`, a <xref:System.Security.SecurityException> occurs when the <xref:System.Security.Cryptography.ProtectedMemory.Unprotect*?displayProperty=nameWithType> method is called.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/DataProtectionPermissionFlags.xml
+++ b/xml/System.Security.Permissions/DataProtectionPermissionFlags.xml
@@ -41,17 +41,12 @@
   <Docs>
     <summary>Specifies the access permissions for encrypting data and memory.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This enumeration is used by the <xref:System.Security.Permissions.DataProtectionPermission> and <xref:System.Security.Permissions.DataProtectionPermissionAttribute> classes to protect access to encrypted data and memory using the <xref:System.Security.Cryptography.ProtectedData> and <xref:System.Security.Cryptography.ProtectedMemory> classes.  
-  
-> [!CAUTION]
->  Many of these flags can have powerful effects and should be granted only to highly trusted code.  
-  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Security.Permissions/EnvironmentPermission.xml
+++ b/xml/System.Security.Permissions/EnvironmentPermission.xml
@@ -51,11 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Environment variable names are designated by one or more case-insensitive name lists separated by semicolons, with separate lists for read and write access to the named variables. Write access includes the ability to create and delete environment variables as well as to change existing values.
-
-> [!NOTE]
-> In versions of .NET Framework before .NET Framework 4, you could use the <xref:System.Security.CodeAccessPermission.Deny*?displayProperty=nameWithType> method to prevent inadvertent access to system resources by trusted code. <xref:System.Security.CodeAccessPermission.Deny*> is now obsolete, and access to resources is now determined solely by the granted permission set for an assembly. To limit access to files, you must run partially trusted code in a sandbox and assign it permissions only to resources that the code is allowed to access. For information about running an application in a sandbox, see [How to: Run Partially Trusted Code in a Sandbox](/dotnet/framework/misc/how-to-run-partially-trusted-code-in-a-sandbox).
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.EnvironmentPermissionAttribute" />
@@ -105,14 +100,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.EnvironmentPermission" /> class with either restricted or unrestricted permission as specified.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates either fully restricted (`None`) or `Unrestricted` access to all environment variables.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -151,14 +139,7 @@
         <param name="flag">One of the <see cref="T:System.Security.Permissions.EnvironmentPermissionAccess" /> values.</param>
         <param name="pathList">A list of environment variables (semicolon-separated) to which access is granted.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.EnvironmentPermission" /> class with the specified access to the specified environment variables.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor allows only one of the <xref:System.Security.Permissions.EnvironmentPermissionAccess> values to be specified. This access applies to all listed environment variables. Use <xref:System.Security.Permissions.EnvironmentPermission.AddPathList*> to define complex permissions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="pathList" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <paramref name="flag" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.EnvironmentPermissionAccess" />.</exception>
       </Docs>
@@ -201,14 +182,7 @@
         <param name="flag">One of the <see cref="T:System.Security.Permissions.EnvironmentPermissionAccess" /> values.</param>
         <param name="pathList">A list of environment variables (semicolon-separated).</param>
         <summary>Adds access for the specified environment variables to the existing state of the permission.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to modify environment variable access by adding to the state of the current permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="pathList" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <paramref name="flag" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.EnvironmentPermissionAccess" />.</exception>
       </Docs>
@@ -247,14 +221,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -339,17 +306,7 @@
         <param name="flag">One of the <see cref="T:System.Security.Permissions.EnvironmentPermissionAccess" /> values that represents a single type of environment variable access.</param>
         <summary>Gets all environment variables with the specified <see cref="T:System.Security.Permissions.EnvironmentPermissionAccess" />.</summary>
         <returns>A list of environment variables (semicolon-separated) for the selected flag.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to get the state of the current permission. To get both `Read` and `Write` access states requires two calls to this method.
-
-> [!NOTE]
->  The `flag` parameter is limited to the values of <xref:System.Security.Permissions.EnvironmentPermissionAccess>, which represent single types of environment variable access. Those values are <xref:System.Security.Permissions.EnvironmentPermissionAccess.Read> and <xref:System.Security.Permissions.EnvironmentPermissionAccess.Write>. The values acceptable to `flag` do not include <xref:System.Security.Permissions.EnvironmentPermissionAccess.NoAccess> and <xref:System.Security.Permissions.EnvironmentPermissionAccess.AllAccess>, which do not represent single types of environment variable access.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="flag" /> is not a valid value of <see cref="T:System.Security.Permissions.EnvironmentPermissionAccess" />.
 
@@ -395,14 +352,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the state they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -444,14 +394,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a state that is wholly contained by the specified permission. For example, a permission that represents access to C:\example.txt is a subset of a permission that represents access to C:\\. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -493,14 +436,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission represents the union of all possible states of the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetPathList">
@@ -541,14 +477,7 @@
         <param name="flag">One of the <see cref="T:System.Security.Permissions.EnvironmentPermissionAccess" /> values.</param>
         <param name="pathList">A list of environment variables (semicolon-separated).</param>
         <summary>Sets the specified access to the specified environment variables to the existing state of the permission.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The previous state of the current permission is overwritten.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="pathList" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <paramref name="flag" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.EnvironmentPermissionAccess" />.</exception>
       </Docs>
@@ -627,14 +556,7 @@
         <param name="other">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.EnvironmentPermission.Union*> is a permission that represents all the states represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="other" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Permissions/EnvironmentPermissionAccess.xml
+++ b/xml/System.Security.Permissions/EnvironmentPermissionAccess.xml
@@ -50,11 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This enumeration is used by <xref:System.Security.Permissions.EnvironmentPermission>.
-
-> [!NOTE]
-> Although `NoAccess` and `AllAccess` appear in `EnvironmentPermissionAccess`, they are not valid for use as the parameter for <xref:System.Security.Permissions.EnvironmentPermission.GetPathList*?displayProperty=nameWithType> because they describe no environment variable access types or all environment variable access types, respectively, and <xref:System.Security.Permissions.EnvironmentPermission.GetPathList*> expects a single environment variable access type.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.EnvironmentPermission" />

--- a/xml/System.Security.Permissions/EnvironmentPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/EnvironmentPermissionAttribute.xml
@@ -45,18 +45,12 @@
   <Docs>
     <summary>Allows security actions for <see cref="T:System.Security.Permissions.EnvironmentPermission" /> to be applied to code using declarative security. This class cannot be inherited.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.  
-  
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.  
-  
- Environment variable names are case-insensitive. Multiple environment variable names are specified by separating the names using <xref:System.IO.Path.PathSeparator>.  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.EnvironmentPermission" />
@@ -134,14 +128,7 @@
       <Docs>
         <summary>Sets full access for the environment variables specified by the string value.</summary>
         <value>A list of environment variables for full access.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Environment variable names are case-insensitive. Multiple environment variable names are specified by separating the names using <xref:System.IO.Path.PathSeparator>.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.NotSupportedException">The get method is not supported for this property.</exception>
       </Docs>
     </Member>
@@ -179,16 +166,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.EnvironmentPermission" />.</summary>
         <returns>An <see cref="T:System.Security.Permissions.EnvironmentPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method should only be called by the security system, never by application code.  
-  
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Read">
@@ -224,14 +202,7 @@
       <Docs>
         <summary>Gets or sets read access for the environment variables specified by the string value.</summary>
         <value>A list of environment variables for read access.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Environment variable names are case-insensitive. Multiple environment variable names are specified by separating the names using <xref:System.IO.Path.PathSeparator>.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Write">
@@ -267,14 +238,7 @@
       <Docs>
         <summary>Gets or sets write access for the environment variables specified by the string value.</summary>
         <value>A list of environment variables for write access.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Environment variable names are case-insensitive. Multiple environment variable names are specified by separating the names using <xref:System.IO.Path.PathSeparator>.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/FileDialogPermission.xml
+++ b/xml/System.Security.Permissions/FileDialogPermission.xml
@@ -51,8 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This permission is typically used to provide limited access to user-specified files when <xref:System.Security.Permissions.FileIOPermission> is not granted.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.FileDialogPermissionAttribute" />
@@ -139,14 +137,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values (<see langword="Unrestricted" /> or <see langword="None" />).</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.FileDialogPermission" /> class with either restricted or unrestricted permission, as specified.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates either fully restricted (`None`) or `Unrestricted` access to **File** dialog boxes.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -221,14 +212,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of the permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -313,14 +297,7 @@
         <param name="target">A permission to intersect with the current permission. It must be the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -362,14 +339,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, a permission for <xref:System.Security.Permissions.FileDialogPermissionAccess.Open> access is a subset of a permission for <xref:System.Security.Permissions.FileDialogPermissionAccess.OpenSave> access.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -411,14 +381,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission represents access to all resources protected by the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -495,14 +458,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.FileDialogPermission.Union*> is a permission that represents all operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Permissions/FileDialogPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/FileDialogPermissionAttribute.xml
@@ -51,10 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.FileDialogPermission" />
@@ -132,16 +128,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.FileDialogPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.FileDialogPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should only be called by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Open">

--- a/xml/System.Security.Permissions/FileIOPermission.xml
+++ b/xml/System.Security.Permissions/FileIOPermission.xml
@@ -51,30 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This permission distinguishes between the following four types of file IO access provided by <xref:System.Security.Permissions.FileIOPermissionAccess>:
-
--   `Read`: Read access to the contents of the file or access to information about the file, such as its length or last modification time.
-
--   `Write`: Write access to the contents of the file or access to change information about the file, such as its name. Also allows for deletion and overwriting.
-
--   `Append`: Ability to write to the end of a file only. No ability to read.
-
--   `PathDiscovery`: Access to the information in the path itself. This helps protect sensitive information in the path, such as user names, as well as information about the directory structure that is revealed in the path. This value does not grant access to files or folders represented by the path.
-
-> [!NOTE]
->  Giving <xref:System.Security.Permissions.FileIOPermissionAccess.Write> access to an assembly is similar to granting it full trust. If an application should not write to the file system, it should not have <xref:System.Security.Permissions.FileIOPermissionAccess.Write> access.
-
- All these permissions are independent, meaning that rights to one do not imply rights to another. For example, `Write` permission does not imply permission to `Read` or `Append`. If more than one permission is desired, they can be combined using a bitwise OR as shown in the code example that follows. File permission is defined in terms of canonical absolute paths; calls should always be made with canonical file paths.
-
- <xref:System.Security.Permissions.FileIOPermission> describes protected operations on files and folders. The <xref:System.IO.File> class helps provide secure access to files and folders. The security access check is performed when the handle to the file is created. By doing the check at creation time, the performance impact of the security check is minimized. Opening a file happens once, while reading and writing can happen multiple times. Once the file is opened, no further checks are done. If the object is passed to an untrusted caller, it can be misused. For example, file handles should not be stored in public global statics where code with less permission can access them.
-
- <xref:System.Security.Permissions.FileIOPermissionAccess> specifies actions that can be performed on the file or folder. In addition, these actions can be combined using a bitwise OR to form complex instances.
-
- Access to a folder implies access to all the files it contains, as well as access to all the files and folders in its subfolders. For example, `Read` access to C:\folder1\ implies `Read` access to C:\folder1\file1.txt, C:\folder1\folder2\\, C:\folder1\folder2\file2.txt, and so on.
-
-> [!NOTE]
->  In versions of the .NET Framework before the .NET Framework 4, you could use the <xref:System.Security.CodeAccessPermission.Deny*?displayProperty=nameWithType> method to prevent inadvertent access to system resources by trusted code. <xref:System.Security.CodeAccessPermission.Deny*> is now obsolete, and access to resources is now determined solely by the granted permission set for an assembly. To limit access to files, you must run partially trusted code in a sandbox and assign it permissions only to resources that the code is allowed to access. For information about running an application in a sandbox, see [How to: Run Partially Trusted Code in a Sandbox](/dotnet/framework/misc/how-to-run-partially-trusted-code-in-a-sandbox).
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.FileIOPermissionAccess" />
@@ -124,14 +100,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> enumeration values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.FileIOPermission" /> class with fully restricted or unrestricted permission as specified.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates either fully restricted (`None`) or `Unrestricted` access to files and directories.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -170,14 +139,7 @@
         <param name="access">A bitwise combination of the <see cref="T:System.Security.Permissions.FileIOPermissionAccess" /> enumeration values.</param>
         <param name="path">The absolute path of the file or directory.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.FileIOPermission" /> class with the specified access to the designated file or directory.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor allows only one of the <xref:System.Security.Permissions.FileIOPermissionAccess> values to be specified for the specified file or directory. Use the <xref:System.Security.Permissions.FileIOPermission.AddPathList*> method to define complex permissions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="access" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.FileIOPermissionAccess" />.
 
  -or-
@@ -224,14 +186,7 @@
         <param name="access">A bitwise combination of the <see cref="T:System.Security.Permissions.FileIOPermissionAccess" /> enumeration values.</param>
         <param name="pathList">An array containing the absolute paths of the files and directories.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.FileIOPermission" /> class with the specified access to the designated files and directories.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor allows only one <xref:System.Security.Permissions.FileIOPermissionAccess> value to be specified for the specified files and directories. Use the <xref:System.Security.Permissions.FileIOPermission.AddPathList*> method to define complex permissions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="access" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.FileIOPermissionAccess" />.
 
  -or-
@@ -275,19 +230,7 @@
         <param name="actions">A bitwise combination of the <see cref="T:System.Security.AccessControl.AccessControlActions" /> enumeration values.</param>
         <param name="path">The absolute path of the file or directory.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.FileIOPermission" /> class with the specified access to the designated file or directory and the specified access rights to file control information.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor allows only one <xref:System.Security.Permissions.FileIOPermissionAccess> value to be specified for the specified file or directories. Use the <xref:System.Security.Permissions.FileIOPermission.AddPathList*> method to define complex permissions.
-
- The `control` parameter specifies whether the access control list (ACL) for the file or directory specified by `path` can be changed, viewed, or cannot be accessed.
-
-> [!IMPORTANT]
->  An access control list (ACL) describes individuals or groups who have, or do not have, rights to specific actions on the given file and its properties.  The ability to change or view an ACL is an important permission and should be granted with caution.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="access" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.FileIOPermissionAccess" />.
 
  -or-
@@ -335,19 +278,7 @@
         <param name="actions">A bitwise combination of the <see cref="T:System.Security.AccessControl.AccessControlActions" /> enumeration values.</param>
         <param name="pathList">An array containing the absolute paths of the files and directories.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.FileIOPermission" /> class with the specified access to the designated files and directories and the specified access rights to file control information.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor allows only one <xref:System.Security.Permissions.FileIOPermissionAccess> value to be specified for the specified files and directories. Use the <xref:System.Security.Permissions.FileIOPermission.AddPathList*> method to define complex permissions.
-
- The `control` parameter specifies whether the access control list (ACL) for the file or directory specified by `path` can be changed, viewed, or cannot be accessed.
-
-> [!IMPORTANT]
->  An access control list (ACL) describes individuals or groups who have, or do not have, rights to specific actions on the given file and its properties.  The ability to change or view an ACL is an important permission and should be granted with caution.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="access" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.FileIOPermissionAccess" />.
 
  -or-
@@ -403,14 +334,7 @@
         <param name="access">A bitwise combination of the <see cref="T:System.Security.Permissions.FileIOPermissionAccess" /> values.</param>
         <param name="path">The absolute path of a file or directory.</param>
         <summary>Adds access for the specified file or directory to the existing state of the permission.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to modify file and directory access by adding to the state of the current permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="access" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.FileIOPermissionAccess" />.
 
  -or-
@@ -462,14 +386,7 @@
         <param name="access">A bitwise combination of the <see cref="T:System.Security.Permissions.FileIOPermissionAccess" /> values.</param>
         <param name="pathList">An array containing the absolute paths of the files and directories.</param>
         <summary>Adds access for the specified files and directories to the existing state of the permission.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to modify file and directory access by adding to the state of the current permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="access" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.FileIOPermissionAccess" />.
 
  -or-
@@ -512,16 +429,7 @@
       <Docs>
         <summary>Gets or sets the permitted access to all files.</summary>
         <value>The set of file I/O flags for all files.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property gets or sets the permitted access to all files on the local computer and network drives.
-
- An individual <xref:System.Security.Permissions.FileIOPermissionAccess> value can be checked for using a bitwise AND operation.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AllLocalFiles">
@@ -557,16 +465,7 @@
       <Docs>
         <summary>Gets or sets the permitted access to all local files.</summary>
         <value>The set of file I/O flags for all local files.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Local files are files contained on the local computer. Any files not accessed through a network drive are local files.
-
- An individual <xref:System.Security.Permissions.FileIOPermissionAccess> value can be checked for using a bitwise AND operation.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Copy">
@@ -603,14 +502,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of the permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -650,14 +542,7 @@
         <summary>Determines whether the specified <see cref="T:System.Security.Permissions.FileIOPermission" /> object is equal to the current <see cref="T:System.Security.Permissions.FileIOPermission" />.</summary>
         <returns>
           <see langword="true" /> if the specified <see cref="T:System.Security.Permissions.FileIOPermission" /> is equal to the current <see cref="T:System.Security.Permissions.FileIOPermission" /> object; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- For more information, see <xref:System.Object.Equals*>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -738,14 +623,7 @@
       <Docs>
         <summary>Gets a hash code for the <see cref="T:System.Security.Permissions.FileIOPermission" /> object that is suitable for use in hashing algorithms and data structures such as a hash table.</summary>
         <returns>A hash code for the current <see cref="T:System.Security.Permissions.FileIOPermission" /> object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The hash code for two instances of the same permission might be different, hence a hash code should not be used to compare two <xref:System.Security.Permissions.FileIOPermission> objects.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetPathList">
@@ -785,17 +663,7 @@
         <param name="access">One of the <see cref="T:System.Security.Permissions.FileIOPermissionAccess" /> values that represents a single type of file access.</param>
         <summary>Gets all files and directories with the specified <see cref="T:System.Security.Permissions.FileIOPermissionAccess" />.</summary>
         <returns>An array containing the paths of the files and directories to which access specified by the <paramref name="access" /> parameter is granted.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to get the state of the current permission. To get the state of both `Read` and `Write` access, two calls to this method are required.
-
-> [!NOTE]
->  The `access` parameter is limited to the values of <xref:System.Security.Permissions.FileIOPermissionAccess>, which represent single types of file access. Those values are <xref:System.Security.Permissions.FileIOPermissionAccess.Read>, <xref:System.Security.Permissions.FileIOPermissionAccess.Write>, <xref:System.Security.Permissions.FileIOPermissionAccess.Append>, and <xref:System.Security.Permissions.FileIOPermissionAccess.PathDiscovery>. The values acceptable to `access` do not include <xref:System.Security.Permissions.FileIOPermissionAccess.NoAccess> and <xref:System.Security.Permissions.FileIOPermissionAccess.AllAccess>, which do not represent single types of file access.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="access" /> is not a valid value of <see cref="T:System.Security.Permissions.FileIOPermissionAccess" />.
 
@@ -841,14 +709,7 @@
         <param name="target">A permission to intersect with the current permission. It must be the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -890,14 +751,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is contained by the specified permission. For example, a permission that represents read access to C:\example.txt is a subset of a permission that represents read access to C:\\. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -939,14 +793,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission represents access to all resources protected by the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <MemberGroup MemberName="SetPathList">
@@ -1129,14 +976,7 @@
         <param name="other">A permission to combine with the current permission. It must be the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.FileIOPermission.Union*> is a permission that represents all the operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="other" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Permissions/FileIOPermissionAccess.xml
+++ b/xml/System.Security.Permissions/FileIOPermissionAccess.xml
@@ -50,13 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
-This enumeration is used with the <xref:System.Security.Permissions.FileIOPermission> class.
-
-> [!NOTE]
->  Giving `Write` access to an assembly is similar to granting it Full Trust. If an application should not write to the file system, it should not have Write access.
-
-Although `NoAccess` and `AllAccess` are members of `FileIOPermissionAccess`, they are not valid for use as the parameter for <xref:System.Security.Permissions.FileIOPermission.GetPathList*?displayProperty=nameWithtype> because they describe no file access types or all file access types, respectively. <xref:System.Security.Permissions.FileIOPermission.GetPathList*?displayProperty=nameWithType> expects a single file access type.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.IO.FileMode" />

--- a/xml/System.Security.Permissions/FileIOPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/FileIOPermissionAttribute.xml
@@ -51,15 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Files and directories are specified using absolute paths. When accessing files, a security check is performed when the file is created or opened. The security check is not done again unless the file is closed and reopened. Checking permissions when the file is first accessed minimizes the impact of the security check on application performance because opening a file happens only once, while reading and writing can happen multiple times.
-
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.
-
-> [!CAUTION]
-> `Unrestricted` <xref:System.Security.Permissions.FileIOPermission> grants permission for all paths within a file system, including multiple pathnames that can be used to access a single given file. To <xref:System.Security.CodeAccessPermission.Deny*> access to a file, you must `Deny` all possible paths to the file. For example, if \\\server\share is mapped to the network drive X, to `Deny` access to \\\server\share\file, you must `Deny` \\\server\share\file, X:\file and any other path that you can use to access the file.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.FileIOPermission" />
@@ -143,14 +134,7 @@
       <Docs>
         <summary>Gets or sets full access for the file or directory that is specified by the string value.</summary>
         <value>The absolute path of the file or directory for full access.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property sets access for a single file or directory. Use additional attributes to specify additional files and directories.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.NotSupportedException">The get method is not supported for this property.</exception>
       </Docs>
     </Member>
@@ -186,16 +170,7 @@
       <Docs>
         <summary>Gets or sets the permitted access to all files.</summary>
         <value>A bitwise combination of the <see cref="T:System.Security.Permissions.FileIOPermissionAccess" /> values that represents the permissions for all files. The default is <see cref="F:System.Security.Permissions.FileIOPermissionAccess.NoAccess" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property gets or sets the permitted access to all files on the local computer and network drives.
-
- An individual <xref:System.Security.Permissions.FileIOPermissionAccess> value can be determined by using a bitwise `AND` operation.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AllLocalFiles">
@@ -230,16 +205,7 @@
       <Docs>
         <summary>Gets or sets the permitted access to all local files.</summary>
         <value>A bitwise combination of the <see cref="T:System.Security.Permissions.FileIOPermissionAccess" /> values that represents the permissions for all local files. The default is <see cref="F:System.Security.Permissions.FileIOPermissionAccess.NoAccess" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Local files are files contained on the local computer. Any files that are not accessed through a network drive are local files.
-
- An individual <xref:System.Security.Permissions.FileIOPermissionAccess> value can be determined by using a bitwise `AND` operation.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Append">
@@ -275,14 +241,7 @@
       <Docs>
         <summary>Gets or sets append access for the file or directory that is specified by the string value.</summary>
         <value>The absolute path of the file or directory for append access.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property sets access for a single file or directory. Use additional attributes to specify additional files and directories.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ChangeAccessControl">
@@ -317,17 +276,7 @@
       <Docs>
         <summary>Gets or sets the file or directory in which access control information can be changed.</summary>
         <value>The absolute path of the file or directory in which access control information can be changed.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property gets or sets access for a single file or directory. Use additional <xref:System.Security.Permissions.FileIOPermissionAttribute> attributes to specify additional files and directories.
-
-> [!IMPORTANT]
->  An access control list (ACL) describes individuals or groups who have, or do not have, rights to specific actions on the given file and its properties.  The ability to change an ACL is an important permission and should be granted with caution.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreatePermission">
@@ -364,16 +313,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.FileIOPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.FileIOPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should be called only by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The path information for a file or directory for which access is to be secured contains invalid characters or wildcard specifiers.</exception>
       </Docs>
     </Member>
@@ -410,19 +350,7 @@
       <Docs>
         <summary>Gets or sets the file or directory to which to grant path discovery.</summary>
         <value>The absolute path of the file or directory.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Path discovery controls access to the information in the path itself. This helps protect sensitive information in the path, such as user names, as well as information about the directory structure revealed in the path. This value does not grant access to files or folders represented by the path.
-
-> [!NOTE]
->  For performance reasons, <xref:System.Security.Permissions.FileIOPermissionAttribute.PathDiscovery*> should be granted only to directories, not to files. For example, <xref:System.Security.Permissions.FileIOPermissionAttribute.PathDiscovery*> permission should be granted to paths such as C:\test and C:\test\\, not to files such as C:\test\example.txt.
-
- This property sets access for a single file or directory. Use additional attributes to specify additional files and directories.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Read">
@@ -458,14 +386,7 @@
       <Docs>
         <summary>Gets or sets read access for the file or directory specified by the string value.</summary>
         <value>The absolute path of the file or directory for read access.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property sets access for a single file or directory. Use additional attributes to specify additional files and directories.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ViewAccessControl">
@@ -500,17 +421,7 @@
       <Docs>
         <summary>Gets or sets the file or directory in which access control information can be viewed.</summary>
         <value>The absolute path of the file or directory in which access control information can be viewed.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property gets or sets access for a single file or directory. Use additional <xref:System.Security.Permissions.FileIOPermissionAttribute> attributes to specify additional files and directories.
-
-> [!IMPORTANT]
->  An access control list (ACL) describes individuals or groups who have, or do not have, rights to specific actions on the given file and its properties.  The ability to view an ACL is an important permission and should be granted with caution.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ViewAndModify">
@@ -545,17 +456,7 @@
       <Docs>
         <summary>Gets or sets the file or directory in which file data can be viewed and modified.</summary>
         <value>The absolute path of the file or directory in which file data can be viewed and modified.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property sets the <xref:System.Security.Permissions.FileIOPermissionAttribute.Append*>, <xref:System.Security.Permissions.FileIOPermissionAttribute.PathDiscovery*>, <xref:System.Security.Permissions.FileIOPermissionAttribute.Read*>, and <xref:System.Security.Permissions.FileIOPermissionAttribute.Write*> properties for a single file or directory. Use additional <xref:System.Security.Permissions.FileIOPermissionAttribute> attributes to specify additional files and directories. The access rights are for file data only; they do not include the access control properties <xref:System.Security.Permissions.FileIOPermissionAttribute.ViewAccessControl*> and <xref:System.Security.Permissions.FileIOPermissionAttribute.ChangeAccessControl*>.
-
-> [!NOTE]
->  The `get` accessor is provided for C# compiler compatibility. The C# compiler requires attribute properties to be read/write.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.NotSupportedException">The <see langword="get" /> accessor is called. The accessor is provided only for C# compiler compatibility.</exception>
       </Docs>
     </Member>
@@ -592,14 +493,7 @@
       <Docs>
         <summary>Gets or sets write access for the file or directory specified by the string value.</summary>
         <value>The absolute path of the file or directory for write access.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property sets access for a single file or directory. Use additional attributes to specify additional files and directories.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/GacIdentityPermission.xml
+++ b/xml/System.Security.Permissions/GacIdentityPermission.xml
@@ -46,13 +46,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Files are either in the global assembly cache, or they are not. There are no variations to the permission granted, so all <xref:System.Security.Permissions.GacIdentityPermission> objects are equal.
-
-> [!IMPORTANT]
->  Starting with .NET Framework 4, identity permissions are not used.
->
->  In .NET Framework versions 1.0 and 1.1, demands on the identity permissions are effective even when the calling assembly is fully trusted. That is, although the calling assembly has full trust, a demand for an identity permission fails if the assembly does not meet the demanded criteria. Starting with .NET Framework version 2.0, demands for identity permissions are ineffective if the calling assembly has full trust. This assures consistency for all permissions, eliminating the treatment of identity permissions as a special case.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -95,14 +88,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.GacIdentityPermission" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor creates a <xref:System.Security.Permissions.GacIdentityPermission> with a <xref:System.Security.Permissions.PermissionState> value of <xref:System.Security.Permissions.PermissionState.None>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -137,16 +123,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.GacIdentityPermission" /> class with fully restricted <see cref="T:System.Security.Permissions.PermissionState" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!NOTE]
-> Starting with .NET Framework version 2.0, identity permissions can have any permission state value. This means that identity permissions have the same behavior as permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="state" /> is not a valid <see cref="T:System.Security.Permissions.PermissionState" /> value.</exception>
       </Docs>
@@ -184,14 +161,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -229,14 +199,7 @@
       <Docs>
         <param name="securityElement">A <see cref="T:System.Security.SecurityElement" /> that contains the XML encoding to use to create the permission.</param>
         <summary>Creates a permission from an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.GacIdentityPermission.FromXml*> method creates a <xref:System.Security.Permissions.GacIdentityPermission> from an XML encoding defined by a <xref:System.Security.SecurityElement> object. Use the <xref:System.Security.Permissions.GacIdentityPermission.ToXml*> method to XML-encode the <xref:System.Security.Permissions.GacIdentityPermission>, including state information.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="securityElement" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
@@ -283,16 +246,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. The new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- A <xref:System.Security.Permissions.GacIdentityPermission> only supports set operations (the <xref:System.Security.Permissions.GacIdentityPermission.IsSubsetOf*>, <xref:System.Security.Permissions.GacIdentityPermission.Intersect*>, and <xref:System.Security.Permissions.GacIdentityPermission.Union*> methods) when the current permission is equal to the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
@@ -334,16 +288,7 @@
         <summary>Indicates whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission represents a set of operations that is wholly contained by the specified permission. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- A <xref:System.Security.Permissions.GacIdentityPermission> only supports set operations (the <xref:System.Security.Permissions.GacIdentityPermission.IsSubsetOf*>, <xref:System.Security.Permissions.GacIdentityPermission.Intersect*>, and <xref:System.Security.Permissions.GacIdentityPermission.Union*> methods) when the current permission is equal to the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
@@ -381,14 +326,7 @@
       <Docs>
         <summary>Creates an XML encoding of the permission and its current state.</summary>
         <returns>A <see cref="T:System.Security.SecurityElement" /> that represents the XML encoding of the permission, including any state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use the <xref:System.Security.Permissions.GacIdentityPermission.FromXml*> method to create a <xref:System.Security.Permissions.GacIdentityPermission> from a <xref:System.Security.SecurityElement>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -427,16 +365,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to the <xref:System.Security.Permissions.GacIdentityPermission.Union*> method is a permission that includes all the operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- A <xref:System.Security.Permissions.GacIdentityPermission> only supports set operations (the <xref:System.Security.Permissions.GacIdentityPermission.IsSubsetOf*>, <xref:System.Security.Permissions.GacIdentityPermission.Intersect*>, and <xref:System.Security.Permissions.GacIdentityPermission.Union*> methods) when the current permission is equal to the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>

--- a/xml/System.Security.Permissions/GacIdentityPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/GacIdentityPermissionAttribute.xml
@@ -50,19 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This class is used to ensure that callers are registered in the global assembly cache (GAC).
-
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> value that is used.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class, <xref:System.Security.Permissions.GacIdentityPermission>.
-
-> [!IMPORTANT]
-> Starting with .NET Framework 4, identity permissions aren't used.
->
-> Demands for identity permissions are ineffective if the calling assembly has full trust. This assures consistency for all permissions, eliminating the treatment of identity permissions as a special case.
-
- For more information about using attributes, see [Attributes](/dotnet/standard/attributes/).
-
  ]]></format>
     </remarks>
   </Docs>
@@ -99,18 +86,7 @@
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.GacIdentityPermissionAttribute" /> class with the specified <see cref="T:System.Security.Permissions.SecurityAction" /> value.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The constructor calls the base class to validate the <xref:System.Security.Permissions.SecurityAction> value.
-
- This constructor associates a <xref:System.Security.Permissions.SecurityAction> (for example, `Demand`) with the <xref:System.Security.Permissions.GacIdentityPermission>.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. Use <xref:System.Security.Permissions.GacIdentityPermission> for imperative security.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="action" /> parameter is not a valid <see cref="T:System.Security.Permissions.SecurityAction" /> value.</exception>
       </Docs>
     </Member>
@@ -147,16 +123,7 @@
       <Docs>
         <summary>Creates a new <see cref="T:System.Security.Permissions.GacIdentityPermission" /> object.</summary>
         <returns>A <see cref="T:System.Security.Permissions.GacIdentityPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should be called only by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission returned by this method.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/HostProtectionAttribute.xml
+++ b/xml/System.Security.Permissions/HostProtectionAttribute.xml
@@ -50,25 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This attribute affects only unmanaged applications that host the common language runtime and implement host protection, such as SQL Server. If the code is run in a client application or on a server that is not host-protected, the attribute "evaporates"; it is not detected and therefore not applied. When applied, the security action results in the creation of a link demand based on the host resources the class or method exposes.
-
-> [!IMPORTANT]
-> The purpose of this attribute is to enforce host-specific programming model guidelines, not security behavior.  Although a link demand is used to check for conformance to programming model requirements, the <xref:System.Security.Permissions.HostProtectionAttribute> is not a security permission.
-
- If the host does not have programming model requirements, the link demands do not occur.
-
- This attribute identifies the following:
-
-- Methods or classes that do not fit the host programming model, but are otherwise benign.
-- Methods or classes that do not fit the host programming model and could lead to destabilizing server-managed user code.
-- Methods or classes that do not fit the host programming model and could lead to a destabilization of the server process itself.
-
-> [!NOTE]
-> If you are creating a class library that is to be called by applications that may execute in a host protected environment, you should apply this attribute to members that expose <xref:System.Security.Permissions.HostProtectionResource> resource categories. The .NET Framework class library members with this attribute cause only the immediate caller to be checked.  Your library member must also cause a check of its immediate caller in the same manner.
-
-> [!NOTE]
-> Do not use the [Ngen.exe (Native Image Generator)](/dotnet/framework/tools/ngen-exe-native-image-generator) to create a native image of assemblies that are protected by the <xref:System.Security.Permissions.HostProtectionAttribute>. In a full-trust environment, the image is always loaded, without regard to the <xref:System.Security.Permissions.HostProtectionAttribute>, and in a partial-trust environment the image is not loaded.
-
  ]]></format>
     </remarks>
     <related type="Article" href="/dotnet/standard/attributes/">Extending Metadata Using Attributes</related>
@@ -112,14 +93,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.HostProtectionAttribute" /> class with default values.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor creates a <xref:System.Security.Permissions.HostProtectionAttribute> with all Boolean properties set to `false`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -154,14 +128,7 @@
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.HostProtectionAttribute" /> class with the specified <see cref="T:System.Security.Permissions.SecurityAction" /> value.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor should not be used. It is intended for infrastructure use.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="action" /> is not <see cref="F:System.Security.Permissions.SecurityAction.LinkDemand" />.</exception>
       </Docs>
@@ -199,16 +166,7 @@
       <Docs>
         <summary>Creates and returns a new host protection permission.</summary>
         <returns>An <see cref="T:System.Security.IPermission" /> that corresponds to the current attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should be called only by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission corresponding to the attribute that this method returns.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ExternalProcessMgmt">
@@ -244,14 +202,7 @@
         <summary>Gets or sets a value indicating whether external process management is exposed.</summary>
         <value>
           <see langword="true" /> if external process management is exposed; otherwise, <see langword="false" />. The default is <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Code that exposes external process management might create or destroy other processes.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="F:System.Security.Permissions.HostProtectionResource.ExternalProcessMgmt" />
       </Docs>
     </Member>
@@ -288,14 +239,7 @@
         <summary>Gets or sets a value indicating whether external threading is exposed.</summary>
         <value>
           <see langword="true" /> if external threading is exposed; otherwise, <see langword="false" />. The default is <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Code that exposes external threading creates or manipulates threads other than its own, which might be harmful to the host.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="F:System.Security.Permissions.HostProtectionResource.ExternalThreading" />
       </Docs>
     </Member>
@@ -332,14 +276,7 @@
         <summary>Gets or sets a value indicating whether resources might leak memory if the operation is terminated.</summary>
         <value>
           <see langword="true" /> if resources might leak memory on termination; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Code might cause a resource leak on termination, if not protected by a safe handle or some other means of ensuring the release of resources.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="F:System.Security.Permissions.HostProtectionResource.MayLeakOnAbort" />
       </Docs>
     </Member>
@@ -375,14 +312,7 @@
       <Docs>
         <summary>Gets or sets flags specifying categories of functionality that are potentially harmful to the host.</summary>
         <value>A bitwise combination of the <see cref="T:System.Security.Permissions.HostProtectionResource" /> values. The default is <see cref="F:System.Security.Permissions.HostProtectionResource.None" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.HostProtectionResource> flags specify the resources exposed by the method or class that are potentially harmful to the host.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="T:System.Security.Permissions.HostProtectionResource" />
       </Docs>
     </Member>
@@ -419,14 +349,7 @@
         <summary>Gets or sets a value indicating whether the security infrastructure is exposed.</summary>
         <value>
           <see langword="true" /> if the security infrastructure is exposed; otherwise, <see langword="false" />. The default is <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The use of a <xref:System.Security.Principal.WindowsIdentity> object to impersonate a user is an example of exposing the security infrastructure.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="F:System.Security.Permissions.HostProtectionResource.SecurityInfrastructure" />
       </Docs>
     </Member>
@@ -463,14 +386,7 @@
         <summary>Gets or sets a value indicating whether self-affecting process management is exposed.</summary>
         <value>
           <see langword="true" /> if self-affecting process management is exposed; otherwise, <see langword="false" />. The default is <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Self-affecting process management code might exit the current process, terminating the server.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="F:System.Security.Permissions.HostProtectionResource.SelfAffectingProcessMgmt" />
       </Docs>
     </Member>
@@ -507,14 +423,7 @@
         <summary>Gets or sets a value indicating whether self-affecting threading is exposed.</summary>
         <value>
           <see langword="true" /> if self-affecting threading is exposed; otherwise, <see langword="false" />. The default is <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Self-affecting threading manipulates threads in a way that only affects user code.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="F:System.Security.Permissions.HostProtectionResource.SelfAffectingThreading" />
       </Docs>
     </Member>
@@ -551,14 +460,7 @@
         <summary>Gets or sets a value indicating whether shared state is exposed.</summary>
         <value>
           <see langword="true" /> if shared state is exposed; otherwise, <see langword="false" />. The default is <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- When <xref:System.Security.Permissions.HostProtectionAttribute.SharedState*> is `true`, it indicates that a state is exposed that might be shared between threads.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="F:System.Security.Permissions.HostProtectionResource.SharedState" />
       </Docs>
     </Member>

--- a/xml/System.Security.Permissions/HostProtectionResource.xml
+++ b/xml/System.Security.Permissions/HostProtectionResource.xml
@@ -53,8 +53,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This enumeration is used by the <xref:System.Security.Permissions.HostProtectionAttribute> attribute.
-
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Security.Permissions/IUnrestrictedPermission.xml
+++ b/xml/System.Security.Permissions/IUnrestrictedPermission.xml
@@ -45,8 +45,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- All code access permissions should implement <xref:System.Security.Permissions.IUnrestrictedPermission>.
-
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Security.Permissions/IsolatedStorageContainment.xml
+++ b/xml/System.Security.Permissions/IsolatedStorageContainment.xml
@@ -46,28 +46,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Isolated storage uses evidence to determine a unique storage area for use by an application or component. The identity of an assembly uniquely determines the root of a virtual file system for use by that assembly. Thus, rather than many applications and components sharing a common resource such as the file system or registry, each has its own file area inherently assigned to it.
-
- Four basic isolation scopes are used when assigning isolated storage:
-
--   `User` - Code is always scoped according to the current user. The same assembly will receive different stores when being run by different users.
-
--   `Machine` - Code is always scoped according to the machine. The same assembly will receive the same stores when being run by different users on the same machine.
-
--   `Assembly` - Code is identified cryptographically by strong name (for example, Microsoft.Office.\* or Microsoft.Office.Word), by publisher (based on public key), by URL (for example, `http://www.fourthcoffee.com/process/grind.htm`), by site, or by zone.
-
--   `Domain` - Code is identified based on evidence associated with the application domain. Web application identity is derived from the site's URL, or by the Web page's URL, site, or zone. Local code identity is based on the application directory path.
-
- For definitions of URL, site, and zone, see <xref:System.Security.Permissions.UrlIdentityPermission>, <xref:System.Security.Permissions.SiteIdentityPermission>, and <xref:System.Security.Permissions.ZoneIdentityPermission>.
-
- These identities are grouped together, in which case the identities are applied one after another until the desired isolated storage is created. The valid groupings are User+Assembly and User+Assembly+Domain. This grouping of identities is useful in many different applications.
-
- If data is stored by domain, user, and assembly, the data is private in that only code in that assembly can access the data. The data store is also isolated by the application in which it runs, so that the assembly does not represent a potential leak by exposing data to other applications.
-
- Isolation by assembly and user could be used for user data that applies across multiple applications; for example, license information, or a user's personal information (name, authentication credentials, and so on) that is independent of an application.
-
- <xref:System.Security.Permissions.IsolatedStorageContainment> exposes flags that determine whether an application is allowed to use isolated storage and, if so, which identity combinations are allowed to use it. It also determines whether an application is allowed to store information in a location that can roam with a user (Windows Roaming User Profiles or Folder Redirection must be configured).
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.IsolatedStoragePermission" />

--- a/xml/System.Security.Permissions/IsolatedStorageFilePermission.xml
+++ b/xml/System.Security.Permissions/IsolatedStorageFilePermission.xml
@@ -47,13 +47,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The common language runtime (CLR) uses this class to control access to isolated storage.
-
- Isolated storage creates a unique storage area for use by an application or component. It provides true isolation in that the identity of an application uniquely determines the root of a virtual file system, which only that application can access. Thus, each application has its own file area automatically assigned to it. This file area is fully isolated from other applications, making it private to that application.
-
-> [!NOTE]
-> There is no effect if you use <xref:System.Security.CodeAccessPermission.Assert*>, <xref:System.Security.CodeAccessPermission.PermitOnly*>, or <xref:System.Security.CodeAccessPermission.Deny*> to add stack modifiers for usage or quota. Usage and quota are determined from evidence and a stack walk is not performed for demands, making the above operations ineffective.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.IsolatedStorageFilePermissionAttribute" />
@@ -95,14 +88,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.IsolatedStorageFilePermission" /> class with either fully restricted or unrestricted permission as specified.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Constructs either fully restricted (`None`) or `Unrestricted` access to isolated storage files.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -140,14 +126,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Intersect">
@@ -187,14 +166,7 @@
         <param name="target">A permission to intersect with the current permission object. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -236,14 +208,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, a permission that represents access to C:\example.txt is a subset of a permission that represents access to C:\\. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -280,14 +245,7 @@
       <Docs>
         <summary>Creates an XML encoding of the permission and its current state.</summary>
         <returns>An XML encoding of the permission, including any state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.IsolatedStorageFilePermission.ToXml*> method enables the <xref:System.Security.Permissions.IsolatedStorageFilePermission> to be XML-encoded for security purposes.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -327,14 +285,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.IsolatedStorageFilePermission.Union*> is a permission that represents all the operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Permissions/IsolatedStorageFilePermissionAttribute.xml
+++ b/xml/System.Security.Permissions/IsolatedStorageFilePermissionAttribute.xml
@@ -45,16 +45,12 @@
   <Docs>
     <summary>Allows security actions for <see cref="T:System.Security.Permissions.IsolatedStorageFilePermission" /> to be applied to code using declarative security. This class cannot be inherited.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.  
-  
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.IsolatedStorageFilePermission" />
@@ -134,16 +130,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.IsolatedStorageFilePermission" />.</summary>
         <returns>An <see cref="T:System.Security.Permissions.IsolatedStorageFilePermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method should only be called by the security system, never by application code.  
-  
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/IsolatedStoragePermission.xml
+++ b/xml/System.Security.Permissions/IsolatedStoragePermission.xml
@@ -45,14 +45,12 @@
   <Docs>
     <summary>Represents access to generic isolated storage capabilities.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This class is an abstract base class. This class is never instantiated; instead, classes that extend it and represent access to a particular type of isolated storage are used.  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.IsolatedStorageFilePermission" />
@@ -94,14 +92,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.IsolatedStoragePermission" /> class with either restricted or unrestricted permission as specified.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Creates either fully restricted (`None`) or `Unrestricted` access to isolated storage.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -143,10 +134,10 @@
         <summary>Reconstructs a permission with a specified state from an XML encoding.</summary>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="esd" /> parameter is <see langword="null" />.</exception>
-        <exception cref="T:System.ArgumentException">The <paramref name="esd" /> parameter is not a valid permission element.  
-  
- -or-  
-  
+        <exception cref="T:System.ArgumentException">The <paramref name="esd" /> parameter is not a valid permission element.
+
+ -or-
+
  The <paramref name="esd" /> parameter's version number is not valid.</exception>
       </Docs>
     </Member>
@@ -188,14 +179,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- An unrestricted permission represents access to any and all resources protected by the permission.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">

--- a/xml/System.Security.Permissions/IsolatedStoragePermissionAttribute.xml
+++ b/xml/System.Security.Permissions/IsolatedStoragePermissionAttribute.xml
@@ -41,18 +41,12 @@
   <Docs>
     <summary>Allows security actions for <see cref="T:System.Security.Permissions.IsolatedStoragePermission" /> to be applied to code using declarative security.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This class is an abstract base class. This class is never used instantiated; instead, classes that extend it and represent access to a particular type of isolated storage are used.  
-  
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.  
-  
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.IsolatedStoragePermission" />
@@ -95,14 +89,7 @@
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.IsolatedStoragePermissionAttribute" /> class with the specified <see cref="T:System.Security.Permissions.SecurityAction" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This constructor is called by derived class constructors to initialize states in this type.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UsageAllowed">

--- a/xml/System.Security.Permissions/KeyContainerPermission.xml
+++ b/xml/System.Security.Permissions/KeyContainerPermission.xml
@@ -50,8 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This permission is used to provide limited access to key containers.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.KeyContainerPermissionAttribute" />
@@ -137,14 +135,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.KeyContainerPermission" /> class with either restricted or unrestricted permission.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates either `None` (fully restricted) or `Unrestricted` access to key containers.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="state" /> is not a valid <see cref="T:System.Security.Permissions.PermissionState" /> value.</exception>
       </Docs>
@@ -222,14 +213,7 @@
       <Docs>
         <summary>Gets the collection of <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> objects associated with the current permission.</summary>
         <value>A <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntryCollection" /> containing the <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> objects for this <see cref="T:System.Security.Permissions.KeyContainerPermission" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Each <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry> object in the collection specifies the access rights for a specific key container.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Copy">
@@ -265,14 +249,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of the permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Flags">
@@ -307,14 +284,7 @@
       <Docs>
         <summary>Gets the key container permission flags that apply to all key containers associated with the permission.</summary>
         <value>A bitwise combination of the <see cref="T:System.Security.Permissions.KeyContainerPermissionFlags" /> values.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.KeyContainerPermission.Flags> property is set by the constructor.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -352,14 +322,7 @@
       <Docs>
         <param name="securityElement">A <see cref="T:System.Security.SecurityElement" /> that contains the XML encoding used to reconstruct the permission.</param>
         <summary>Reconstructs a permission with a specified state from an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.KeyContainerPermission.FromXml*> method reconstructs a <xref:System.Security.Permissions.KeyContainerPermission> object from an XML encoding defined by the <xref:System.Security.SecurityElement> class. Use the <xref:System.Security.Permissions.KeyContainerPermission.ToXml*> method to XML-encode the <xref:System.Security.Permissions.KeyContainerPermission>, including state information.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="securityElement" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
@@ -406,14 +369,7 @@
         <param name="target">A permission to intersect with the current permission. It must be the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both individual permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not <see langword="null" /> and does not specify a permission of the same type as the current permission.</exception>
       </Docs>
@@ -455,14 +411,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained in the specified permission. For example, a permission for <xref:System.Security.Permissions.KeyContainerPermissionFlags.Open> access is a subset of a permission for <xref:System.Security.Permissions.KeyContainerPermissionFlags.AllFlags> access.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not <see langword="null" /> and does not specify a permission of the same type as the current permission.</exception>
       </Docs>
@@ -504,14 +453,7 @@
         <summary>Determines whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission represents access to all resources protected by the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -547,14 +489,7 @@
       <Docs>
         <summary>Creates an XML encoding of the permission and its current state.</summary>
         <returns>A <see cref="T:System.Security.SecurityElement" /> that contains an XML encoding of the permission, including state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use the <xref:System.Security.Permissions.KeyContainerPermission.FromXml*> method to restore the state information from a <xref:System.Security.SecurityElement>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -593,14 +528,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.KeyContainerPermission.Union*> is a permission that represents all operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not <see langword="null" /> and does not specify a permission of the same type as the current permission.</exception>
       </Docs>

--- a/xml/System.Security.Permissions/KeyContainerPermissionAccessEntry.xml
+++ b/xml/System.Security.Permissions/KeyContainerPermissionAccessEntry.xml
@@ -46,8 +46,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This permission is intended to enable users to easily manage key containers when either a small number of keys is involved, or access is to be granted to only some keys.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -96,14 +94,7 @@
         <param name="parameters">A <see cref="T:System.Security.Cryptography.CspParameters" /> object that contains the cryptographic service provider (CSP) parameters.</param>
         <param name="flags">A bitwise combination of the <see cref="T:System.Security.Permissions.KeyContainerPermissionFlags" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> class, using the specified cryptographic service provider (CSP) parameters and access permissions.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor allows access rights to be assigned for specific key containers identified in a <xref:System.Security.Cryptography.CspParameters> object.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The resulting entry would have unrestricted access.</exception>
       </Docs>
     </Member>
@@ -141,14 +132,7 @@
         <param name="keyContainerName">The name of the key container.</param>
         <param name="flags">A bitwise combination of the <see cref="T:System.Security.Permissions.KeyContainerPermissionFlags" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> class, using the specified key container name and access permissions.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor allows you to specify access rights for specific key containers identified by name; use an asterisk ("*") to represent all the key containers.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The resulting entry would have unrestricted access.</exception>
       </Docs>
     </Member>
@@ -194,14 +178,7 @@
         <param name="keySpec">The key specification. See the <see cref="P:System.Security.Permissions.KeyContainerPermissionAccessEntry.KeySpec" /> property for values.</param>
         <param name="flags">A bitwise combination of the <see cref="T:System.Security.Permissions.KeyContainerPermissionFlags" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> class with the specified property values.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor allows access rights to be assigned for specific key containers. A `keySpec` or `providerType` value of -1 represents all key specifications or provider types. A `keyStore`, `providerName`, or `keyContainerName` of "*" represents all key stores, providers, or key containers. A `providerName` or `keyContainerName` that is `null` represents all providers or key containers.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The resulting entry would have unrestricted access.</exception>
       </Docs>
     </Member>
@@ -242,14 +219,7 @@
         <summary>Determines whether the specified <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> object is equal to the current instance.</summary>
         <returns>
           <see langword="true" /> if the specified <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> is equal to the current <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> object; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry.Equals*> method compares the properties of the two <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry> objects to determine if they are equal.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Flags">
@@ -284,18 +254,7 @@
       <Docs>
         <summary>Gets or sets the key container permissions.</summary>
         <value>A bitwise combination of the <see cref="T:System.Security.Permissions.KeyContainerPermissionFlags" /> values. The default is <see cref="F:System.Security.Permissions.KeyContainerPermissionFlags.NoFlags" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!CAUTION]
->  Many of these flags are powerful and permit access to key containers that should only be granted to highly trusted code.
-
- The most powerful of the flags are <xref:System.Security.Permissions.KeyContainerPermissionFlags.Create>, <xref:System.Security.Permissions.KeyContainerPermissionFlags.Delete>, <xref:System.Security.Permissions.KeyContainerPermissionFlags.Import>, <xref:System.Security.Permissions.KeyContainerPermissionFlags.Export>, <xref:System.Security.Permissions.KeyContainerPermissionFlags.Sign>, <xref:System.Security.Permissions.KeyContainerPermissionFlags.Decrypt>, and <xref:System.Security.Permissions.KeyContainerPermissionFlags.AllFlags>. For specific threats posed by the use of these flags, see individual flag descriptions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -331,14 +290,7 @@
       <Docs>
         <summary>Gets a hash code for the current instance that is suitable for use in hashing algorithms and data structures such as a hash table.</summary>
         <returns>A hash code for the current <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Serves as a hash function for the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry>, suitable for use in hashing algorithms and data structures such as a hash table.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="KeyContainerName">
@@ -373,14 +325,7 @@
       <Docs>
         <summary>Gets or sets the key container name.</summary>
         <value>The name of the key container.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use a value of "*" to apply the access entry to all key containers within the specified provider name and provider type.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The resulting entry would have unrestricted access.</exception>
       </Docs>
     </Member>
@@ -416,14 +361,7 @@
       <Docs>
         <summary>Gets or sets the key specification.</summary>
         <value>One of the AT_ values defined in the Wincrypt.h header file.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Valid values for this property are AT_KEYEXCHANGE (1) and AT_SIGNATURE (2). The default value is -1, representing all possible values.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The resulting entry would have unrestricted access.</exception>
       </Docs>
     </Member>
@@ -459,14 +397,7 @@
       <Docs>
         <summary>Gets or sets the name of the key store.</summary>
         <value>The name of the key store.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Valid values are "User", "Machine", or "*". If `null` is specified, the value is set to "\*".
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The resulting entry would have unrestricted access.</exception>
       </Docs>
     </Member>
@@ -502,14 +433,7 @@
       <Docs>
         <summary>Gets or sets the provider name.</summary>
         <value>The name of the provider.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An example of a provider name is "Microsoft Enhanced Cryptographic Provider". If `null` is specified, the enhanced cryptographic provider name is used.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The resulting entry would have unrestricted access.</exception>
       </Docs>
     </Member>
@@ -545,52 +469,7 @@
       <Docs>
         <summary>Gets or sets the provider type.</summary>
         <value>One of the PROV_ values defined in the Wincrypt.h header file.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The default value is -1, representing all possible values.
-
- The Wincrypt.h header file defines the following values:
-
--   \#define PROV_RSA_FULL 1
-
--   \#define PROV_RSA_SIG 2
-
--   \#define PROV_DSS 3
-
--   \#define PROV_FORTEZZA 4
-
--   \#define PROV_MS_EXCHANGE 5
-
--   \#define PROV_SSL 6
-
--   \#define PROV_RSA_SCHANNEL 12
-
--   \#define PROV_DSS_DH 13
-
--   \#define PROV_EC_ECDSA_SIG 14
-
--   \#define PROV_EC_ECNRA_SIG 15
-
--   \#define PROV_EC_ECDSA_FULL 16
-
--   \#define PROV_EC_ECNRA_FULL 17
-
--   \#define PROV_DH_SCHANNEL 18
-
--   \#define PROV_SPYRUS_LYNKS 20
-
--   \#define PROV_RNG 21
-
--   \#define PROV_INTEL_SEC 22
-
--   \#define PROV_REPLACE_OWF 23
-
--   \#define PROV_RSA_AES 24
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The resulting entry would have unrestricted access.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Permissions/KeyContainerPermissionAccessEntryCollection.xml
+++ b/xml/System.Security.Permissions/KeyContainerPermissionAccessEntryCollection.xml
@@ -53,8 +53,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry> objects specify access rights for specific key containers.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Collections.ICollection" />
@@ -124,14 +122,7 @@
         <param name="accessEntry">The <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> object to add.</param>
         <summary>Adds a <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> object to the collection.</summary>
         <returns>The index at which the new element was inserted.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry> object is added to the end of the collection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="accessEntry" /> is <see langword="null" />.</exception>
       </Docs>
@@ -168,14 +159,7 @@
       <Parameters />
       <Docs>
         <summary>Removes all the <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> objects from the collection.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to empty the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryCollection>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CopyTo">
@@ -304,14 +288,7 @@
       <Docs>
         <summary>Gets the number of items in the collection.</summary>
         <value>The number of <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> objects in the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryCollection.Count> property to determine the number of <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry> objects in the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryCollection> collection. The <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryCollection.Count> property is commonly used when iterating through the collection to determine the upper bound of the collection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.IsSynchronized" />
         <altmember cref="T:System.Collections.ICollection" />
         <altmember cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" />
@@ -350,23 +327,7 @@
       <Docs>
         <summary>Returns a <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator" /> object that can be used to iterate through the objects in the collection.</summary>
         <returns>A <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator" /> object that can be used to iterate through the collection.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to create a <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator> object that can be used to iterate through the collection to get each item.
-
- Use the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current> property of the enumerator to get the item currently pointed to in the collection.
-
- Use the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> method of the enumerator to move to the next item in the collection.
-
- Use the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Reset*> method of the enumerator to move to the initial position.
-
-> [!NOTE]
->  After you create a <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator> object or use the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Reset*> method to move the enumerator to the first item in the collection, you must call the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> method. Otherwise, the item represented by the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current> property is undefined.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="T:System.Collections.IEnumerator" />
       </Docs>
     </Member>
@@ -406,14 +367,7 @@
         <param name="accessEntry">The <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> object to locate.</param>
         <summary>Gets the index in the collection of the specified <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> object, if it exists in the collection.</summary>
         <returns>The index of the specified <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> object in the collection, or -1 if no match is found.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to determine the index number of the specified <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry> object in the collection. If the specified <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry> object is not found, an value of -1 is returned.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSynchronized">
@@ -452,14 +406,7 @@
         <summary>Gets a value indicating whether the collection is synchronized (thread safe).</summary>
         <value>
           <see langword="false" /> in all cases.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property implements the <xref:System.Collections.ICollection.IsSynchronized?displayProperty=nameWithType> property and always returns `false`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.IsSynchronized" />
         <altmember cref="T:System.Collections.ICollection" />
       </Docs>
@@ -500,14 +447,7 @@
         <param name="index">The zero-based index of the element to access.</param>
         <summary>Gets the item at the specified index in the collection.</summary>
         <value>The <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> object at the specified index in the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this indexer to get a <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry> object from the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryCollection> at the specified index, using array notation.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="index" /> is greater than or equal to the collection count.</exception>
         <exception cref="T:System.InvalidOperationException">
@@ -550,14 +490,7 @@
       <Docs>
         <param name="accessEntry">The <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> object to remove.</param>
         <summary>Removes the specified <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> object from the collection.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- When you remove an item from the collection, the index values change for subsequent items in the collection. All information about the removed item is deleted. Use this method when you want to remove a specific item by specifying the actual item to remove. To remove all items from the list, use the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryCollection.Clear*> method.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="accessEntry" /> is <see langword="null" />.</exception>
       </Docs>
@@ -597,16 +530,7 @@
       <Docs>
         <summary>Gets an object that can be used to synchronize access to the collection.</summary>
         <value>An object that can be used to synchronize access to the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The object returned in this implementation is the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryCollection> object itself.
-
- For more information on the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryCollection.SyncRoot> property, see the <xref:System.Collections.ICollection.SyncRoot> property of the <xref:System.Collections.ICollection?displayProperty=nameWithType> interface.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="P:System.Collections.ICollection.SyncRoot" />
         <altmember cref="T:System.Collections.ICollection" />
       </Docs>
@@ -647,15 +571,7 @@
       <Docs>
         <summary>Returns a <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator" /> object that can be used to iterate through the objects in the collection.</summary>
         <returns>A <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator" /> object that can be used to iterate through the collection.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-This member is an explicit interface member implementation. It can be used only when the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryCollection> instance is cast to an <xref:System.Collections.IEnumerable> interface.
-
-          ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/KeyContainerPermissionAccessEntryEnumerator.xml
+++ b/xml/System.Security.Permissions/KeyContainerPermissionAccessEntryEnumerator.xml
@@ -50,18 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Enumerators allow only reading the data in the collection. Enumerators cannot be used to modify the underlying collection.
-
- Initially, the enumerator is positioned before the first element in the collection. The <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Reset*> method also brings the enumerator back to this position. At this position, calling the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current> property throws an exception. Therefore, you must call the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> method to advance the enumerator to the first element of the collection before reading the value of the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current> property.
-
- <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current*> returns the same object until either <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> or <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Reset*> is called. <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> sets <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current*> to the next element.
-
- After the end of the collection is passed, the enumerator is positioned after the last element in the collection, and calling <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> returns `false`. If the last call to <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> returned `false`, calling <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current*> throws an exception. To reset <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current*> to the first element of the collection, call <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Reset*> followed by a call to <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*>.
-
- An enumerator remains valid as long as the collection remains unchanged. If changes are made to the collection, such as adding, modifying, or deleting elements, the enumerator is irrecoverably invalidated and the next call to <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> or <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Reset*> throws an <xref:System.InvalidOperationException>. If the collection is modified between calling <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> and <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current*>, <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current*> returns the element to which it is currently set, even if the enumerator is already invalidated.
-
- The enumerator does not have exclusive access to the collection; therefore, enumerating through a collection is intrinsically not a thread-safe procedure. Even when a collection is synchronized, other threads can still modify the collection, which causes the enumerator to throw an exception. To guarantee thread safety during enumeration, you can either lock the collection during the entire enumeration or catch the exceptions resulting from changes made by other threads.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -126,16 +114,7 @@
       <Docs>
         <summary>Gets the current entry in the collection.</summary>
         <value>The current <see cref="T:System.Security.Permissions.KeyContainerPermissionAccessEntry" /> object in the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- When the enumerator is created, it does not point to an object, so the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current> property is not valid and will throw an exception if it is accessed. You must first call the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> method to position the cursor at the first object in the collection.
-
- Getting the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current> property multiple times with no intervening calls to <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> will return the same <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry> object each time.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.InvalidOperationException">The <see cref="P:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current" /> property is accessed before first calling the <see cref="M:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext" /> method. The cursor is located before the first object in the collection.
 
  -or-
@@ -180,18 +159,7 @@
         <summary>Moves to the next element in the collection.</summary>
         <returns>
           <see langword="true" /> if the enumerator was successfully advanced to the next element; <see langword="false" /> if the enumerator has passed the end of the collection.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> method returns `false` immediately if there are no objects in the collection.
-
- <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> returns `true` until it has reached the end of the collection. It then returns `false` for each successive call. However, once <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> has returned `false`, accessing the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current> property throws an exception.
-
- Upon creation, an enumerator is positioned before the first <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry> object in the collection, and the first call to <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> positions the enumerator to the first object in the collection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Reset">
@@ -229,16 +197,7 @@
       <Parameters />
       <Docs>
         <summary>Resets the enumerator to the beginning of the collection.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An enumerator moves in a forward-only direction. Use this method to return to the beginning of the collection.
-
- The <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Reset*> method positions the cursor at the first object in the collection. After calling <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Reset*>, you do not need to call <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.MoveNext*> to move the cursor forward to the first object.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="System.Collections.IEnumerator.Current">
@@ -276,14 +235,7 @@
       <Docs>
         <summary>Gets the current object in the collection.</summary>
         <value>The current object in the collection.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Do not call this method; use the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntryEnumerator.Current> property instead.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/KeyContainerPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/KeyContainerPermissionAttribute.xml
@@ -204,16 +204,6 @@
       <MemberSignature Language="DocId" Value="P:System.Security.Permissions.KeyContainerPermissionAttribute.KeySpec" />
       <MemberSignature Language="VB.NET" Value="Public Property KeySpec As Integer" />
       <MemberSignature Language="F#" Value="member this.KeySpec : int with get, set" Usage="System.Security.Permissions.KeyContainerPermissionAttribute.KeySpec" />
- ]]></format>
-        </remarks>
-      </Docs>
-    </Member>
-    <Member MemberName="KeySpec">
-      <MemberSignature Language="C#" Value="public int KeySpec { get; set; }" />
-      <MemberSignature Language="ILAsm" Value=".property instance int32 KeySpec" />
-      <MemberSignature Language="DocId" Value="P:System.Security.Permissions.KeyContainerPermissionAttribute.KeySpec" />
-      <MemberSignature Language="VB.NET" Value="Public Property KeySpec As Integer" />
-      <MemberSignature Language="F#" Value="member this.KeySpec : int with get, set" Usage="System.Security.Permissions.KeyContainerPermissionAttribute.KeySpec" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; property int KeySpec { int get(); void set(int value); };" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>

--- a/xml/System.Security.Permissions/KeyContainerPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/KeyContainerPermissionAttribute.xml
@@ -44,16 +44,12 @@
   <Docs>
     <summary>Allows security actions for <see cref="T:System.Security.Permissions.KeyContainerPermission" /> to be applied to code using declarative security. This class cannot be inherited.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> value that is used.  
-  
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. <xref:System.Security.Permissions.KeyContainerPermissionAttribute> is used only for declarative security. For imperative security, use the <xref:System.Security.Permissions.KeyContainerPermission> class.  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.KeyContainerPermission" />
@@ -129,16 +125,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.KeyContainerPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.KeyContainerPermission" /> that corresponds to the attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method should only be called by the security system, never by application code.  
-  
- At compile time, attributes convert security declarations to a serialized form in metadata. The metadata is created from the permission object that this method returns.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Flags">
@@ -173,18 +160,7 @@
       <Docs>
         <summary>Gets or sets the key container permissions.</summary>
         <value>A bitwise combination of the <see cref="T:System.Security.Permissions.KeyContainerPermissionFlags" /> values. The default is <see cref="F:System.Security.Permissions.KeyContainerPermissionFlags.NoFlags" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-> [!CAUTION]
->  Many of these flags are powerful and permit access to key containers that should be granted only to highly trusted code.  
-  
- The most powerful of the flags are <xref:System.Security.Permissions.KeyContainerPermissionFlags.Create>, <xref:System.Security.Permissions.KeyContainerPermissionFlags.Delete>, <xref:System.Security.Permissions.KeyContainerPermissionFlags.Import>, <xref:System.Security.Permissions.KeyContainerPermissionFlags.Export>, <xref:System.Security.Permissions.KeyContainerPermissionFlags.Sign>, <xref:System.Security.Permissions.KeyContainerPermissionFlags.Decrypt>, and <xref:System.Security.Permissions.KeyContainerPermissionFlags.AllFlags>. For specific threats posed by the use of these flags, see individual flag descriptions.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="KeyContainerName">
@@ -219,12 +195,15 @@
       <Docs>
         <summary>Gets or sets the name of the key container.</summary>
         <value>The name of the key container.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Use a value of "*" to apply the access entry to all key containers within the specified provider name and provider type.  
-  
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="KeySpec">
+      <MemberSignature Language="C#" Value="public int KeySpec { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 KeySpec" />
+      <MemberSignature Language="DocId" Value="P:System.Security.Permissions.KeyContainerPermissionAttribute.KeySpec" />
+      <MemberSignature Language="VB.NET" Value="Public Property KeySpec As Integer" />
+      <MemberSignature Language="F#" Value="member this.KeySpec : int with get, set" Usage="System.Security.Permissions.KeyContainerPermissionAttribute.KeySpec" />
  ]]></format>
         </remarks>
       </Docs>
@@ -261,14 +240,7 @@
       <Docs>
         <summary>Gets or sets the key specification.</summary>
         <value>One of the AT_ values defined in the Wincrypt.h header file.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- If no value is specified, the AT_KEYEXCHANGE value (1) is used. Valid values for this property are AT_KEYEXCHANGE (1) and AT_SIGNATURE (2).  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="KeyStore">
@@ -303,14 +275,7 @@
       <Docs>
         <summary>Gets or sets the name of the key store.</summary>
         <value>The name of the key store. The default is "*".</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Valid values are "User", "Machine", and "*". If `null` is specified, the value is set to "\*".  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ProviderName">
@@ -345,14 +310,7 @@
       <Docs>
         <summary>Gets or sets the provider name.</summary>
         <value>The name of the provider.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- An example of a provider name is "Microsoft Enhanced Cryptographic Provider". If `null` is specified, the enhanced cryptographic provider name is used.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ProviderType">
@@ -387,52 +345,7 @@
       <Docs>
         <summary>Gets or sets the provider type.</summary>
         <value>One of the PROV_ values defined in the Wincrypt.h header file.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- If no value is specified, PROV_RSA_FULL (1) is used.  
-  
- The following values are defined in the Wincrypt.h header file:  
-  
--   \#define PROV_RSA_FULL 1  
-  
--   \#define PROV_RSA_SIG 2  
-  
--   \#define PROV_DSS 3  
-  
--   \#define PROV_FORTEZZA 4  
-  
--   \#define PROV_MS_EXCHANGE 5  
-  
--   \#define PROV_SSL 6  
-  
--   \#define PROV_RSA_SCHANNEL 12  
-  
--   \#define PROV_DSS_DH 13  
-  
--   \#define PROV_EC_ECDSA_SIG 14  
-  
--   \#define PROV_EC_ECNRA_SIG 15  
-  
--   \#define PROV_EC_ECDSA_FULL 16  
-  
--   \#define PROV_EC_ECNRA_FULL 17  
-  
--   \#define PROV_DH_SCHANNEL 18  
-  
--   \#define PROV_SPYRUS_LYNKS 20  
-  
--   \#define PROV_RNG 21  
-  
--   \#define PROV_INTEL_SEC 22  
-  
--   \#define PROV_REPLACE_OWF 23  
-  
--   \#define PROV_RSA_AES 24  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/KeyContainerPermissionFlags.xml
+++ b/xml/System.Security.Permissions/KeyContainerPermissionFlags.xml
@@ -45,13 +45,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This enumeration is used by members of the <xref:System.Security.Permissions.KeyContainerPermissionAccessEntry> class.
-
-> [!CAUTION]
-> Many of these flags can have powerful effects and should be granted only to highly trusted code.
->
-> The most powerful flags are `Create`, `Delete`, `Import`, `Export`, `Sign`, `Decrypt`, and `AllFlags`. For specific threats that the use of these flags can present, see the member descriptions.
-
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Security.Permissions/MediaPermission.xml
+++ b/xml/System.Security.Permissions/MediaPermission.xml
@@ -57,8 +57,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This permission uses the values of the <xref:System.Security.Permissions.MediaPermissionAudio>, <xref:System.Security.Permissions.MediaPermissionImage>, and <xref:System.Security.Permissions.MediaPermissionVideo> enumerations.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -133,14 +131,7 @@
       <Docs>
         <param name="permissionAudio">An enumerated value of <see cref="T:System.Security.Permissions.MediaPermissionAudio" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.MediaPermission" /> class by specifying the audio permission level.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The default values for image and video permissions are <xref:System.Security.Permissions.MediaPermissionImage.SafeImage> and <xref:System.Security.Permissions.MediaPermissionVideo.SafeVideo>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -174,14 +165,7 @@
       <Docs>
         <param name="permissionImage">An enumerated value of <see cref="T:System.Security.Permissions.MediaPermissionImage" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.MediaPermission" /> class by specifying the image permission level.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The default values for audio and video permissions are <xref:System.Security.Permissions.MediaPermissionAudio.SafeAudio> and <xref:System.Security.Permissions.MediaPermissionVideo.SafeVideo>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -215,14 +199,7 @@
       <Docs>
         <param name="permissionVideo">An enumerated value of <see cref="T:System.Security.Permissions.MediaPermissionVideo" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.MediaPermission" /> class by specifying the video permission level.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The default values for audio and image permissions are <xref:System.Security.Permissions.MediaPermissionAudio.SafeAudio> and <xref:System.Security.Permissions.MediaPermissionImage.SafeImage>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -256,14 +233,7 @@
       <Docs>
         <param name="state">An enumerated value of <see cref="T:System.Security.Permissions.PermissionState" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.MediaPermission" /> class by specifying a permission state.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If `state` is set to <xref:System.Security.Permissions.PermissionState.Unrestricted>, all media types are granted full permission to play or display with no restrictions. If `state` is set to <xref:System.Security.Permissions.PermissionState.None>, all media types are restricted from playing or displaying.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -370,14 +340,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -525,16 +488,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, a permission that represents access to C:\example.txt is a subset of a permission that represents access to C:\\.
-
- If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsUnrestricted">
@@ -573,14 +527,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the audio, image, and video permissions are all unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The return value is `true` when the media permission values are <xref:System.Security.Permissions.MediaPermissionAudio.AllAudio>, <xref:System.Security.Permissions.MediaPermissionImage.AllImage>, and <xref:System.Security.Permissions.MediaPermissionVideo.SafeVideo>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">

--- a/xml/System.Security.Permissions/MediaPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/MediaPermissionAttribute.xml
@@ -57,10 +57,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- <xref:System.Security.Permissions.MediaPermissionAttribute> controls the ability for audio, image, and video media to work in a partial-trust Windows Presentation Foundation (WPF) application. The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class, <xref:System.Security.Permissions.MediaPermission>.
-
  ]]></format>
     </remarks>
     <related type="Article" href="/dotnet/standard/attributes/">Extending Metadata Using Attributes</related>
@@ -97,14 +93,7 @@
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</param>
         <summary>Initializes a new instance of <see cref="T:System.Security.Permissions.MediaPermissionAttribute" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The default media values are <xref:System.Security.Permissions.MediaPermissionAudio.AllAudio>, <xref:System.Security.Permissions.MediaPermissionImage.NoImage>, and <xref:System.Security.Permissions.MediaPermissionVideo.NoVideo>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Audio">
@@ -138,14 +127,7 @@
       <Docs>
         <summary>Gets or sets the audio permission level for the <see cref="T:System.Security.Permissions.MediaPermissionAttribute" />.</summary>
         <value>The state of the <see cref="T:System.Security.Permissions.MediaPermissionAudio" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The default is <xref:System.Security.Permissions.MediaPermissionAudio.SafeAudio>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreatePermission">
@@ -180,16 +162,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.MediaPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.MediaPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should only be called by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Image">
@@ -223,14 +196,7 @@
       <Docs>
         <summary>Gets or sets the image permission level for the <see cref="T:System.Security.Permissions.MediaPermissionAttribute" />.</summary>
         <value>The state of the <see cref="T:System.Security.Permissions.MediaPermissionImage" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The default is <xref:System.Security.Permissions.MediaPermissionImage.SafeImage>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Video">
@@ -264,14 +230,7 @@
       <Docs>
         <summary>Gets or sets the video permission level for the <see cref="T:System.Security.Permissions.MediaPermissionAttribute" />.</summary>
         <value>The state of the <see cref="T:System.Security.Permissions.MediaPermissionVideo" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The default is <xref:System.Security.Permissions.MediaPermissionVideo.SafeVideo>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/MediaPermissionAudio.xml
+++ b/xml/System.Security.Permissions/MediaPermissionAudio.xml
@@ -52,8 +52,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Use this enumeration to set the <xref:System.Security.Permissions.MediaPermissionAudio> property of the <xref:System.Security.Permissions.MediaPermission> class. The default is SafeAudio.
-
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Security.Permissions/MediaPermissionImage.xml
+++ b/xml/System.Security.Permissions/MediaPermissionImage.xml
@@ -52,8 +52,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Use this enumeration to set the <xref:System.Security.Permissions.MediaPermission.Image> property of the <xref:System.Security.Permissions.MediaPermission> class. The default is SafeImage.
-
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Security.Permissions/MediaPermissionVideo.xml
+++ b/xml/System.Security.Permissions/MediaPermissionVideo.xml
@@ -52,8 +52,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Use this enumeration to set the <xref:System.Security.Permissions.MediaPermission.Video> property of the <xref:System.Security.Permissions.MediaPermission> class. The default is SafeVideo.
-
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Security.Permissions/PermissionSetAttribute.xml
+++ b/xml/System.Security.Permissions/PermissionSetAttribute.xml
@@ -51,12 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The <xref:System.Security.Permissions.PermissionSetAttribute> properties <xref:System.Security.Permissions.PermissionSetAttribute.Name*>, <xref:System.Security.Permissions.PermissionSetAttribute.File*>, and <xref:System.Security.Permissions.PermissionSetAttribute.XML*> are mutually exclusive, meaning that a permission set can have as its source only one of the following: a named permission set, a file containing an XML representation of a permission set, or a string containing an XML representation of a permission set.
-
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used. A <xref:System.Security.Permissions.SecurityAction> performed on a <xref:System.Security.PermissionSet> is the equivalent of performing that action on each of the permissions within the set.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.PermissionSet" />
@@ -134,14 +128,7 @@
       <Docs>
         <summary>This method is not used.</summary>
         <returns>A null reference (<see langword="nothing" /> in Visual Basic) in all cases.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is not used; it is included only to support inheritance from <xref:System.Security.Permissions.SecurityAttribute>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreatePermissionSet">
@@ -178,16 +165,7 @@
       <Docs>
         <summary>Creates and returns a new permission set based on this permission set attribute object.</summary>
         <returns>A new permission set.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should be called only by the security system, never by application code.
-
- Attributes are used at compile time to convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission object that this method returns, which corresponds to this attribute instance.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="File">
@@ -223,14 +201,7 @@
       <Docs>
         <summary>Gets or sets a file containing the XML representation of a custom permission set to be declared.</summary>
         <value>The physical path to the file containing the XML representation of the permission set.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If the file specified is Unicode, set the <xref:System.Security.Permissions.PermissionSetAttribute.UnicodeEncoded> property to `true`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Hex">
@@ -301,14 +272,7 @@
       <Docs>
         <summary>Gets or sets the name of the permission set.</summary>
         <value>The name of an immutable <see cref="T:System.Security.NamedPermissionSet" /> (one of several permission sets that are contained in the default policy and cannot be altered).</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Because named permission sets can vary from computer to computer, the use of named permission sets for declarative security is restricted to the immutable named permission sets included as part of the default policy. This ensures that the permissions contained in the permission set referenced will be the same wherever the code is run. A compiler error will be thrown if a mutable or unrecognized named permission set is used.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnicodeEncoded">
@@ -345,16 +309,7 @@
         <summary>Gets or sets a value indicating whether the file specified by <see cref="P:System.Security.Permissions.PermissionSetAttribute.File" /> is Unicode or ASCII encoded.</summary>
         <value>
           <see langword="true" /> if the file is Unicode encoded; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If this property is not set, the file is assumed to be ASCII.
-
- If <xref:System.Security.Permissions.PermissionSetAttribute.File*> is `null` this property is not used.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="XML">

--- a/xml/System.Security.Permissions/PermissionState.xml
+++ b/xml/System.Security.Permissions/PermissionState.xml
@@ -70,18 +70,12 @@
   <Docs>
     <summary>Specifies whether a permission should have all or no access to resources at creation.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Permissions can be created in either a totally restrictive or totally unrestrictive state. A totally restrictive state allows no access to resources; a totally unrestricted state allows all access to a particular resource. For example, the file permission constructor could create an object representing either no access to any files or all access to all files.  
-  
- Each type of permission clearly defines extreme states representing either all or none of the permissions expressible within the type. Thus, it is possible to create a generic permission in a completely restricted or unrestricted state without knowledge of the particular permission; however, intermediate states can only be set according to the specific permission semantics.  
-  
- All code access permissions implemented in .NET Framework can take a <xref:System.Security.Permissions.PermissionState> value as an argument to their constructor.  
-  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Security.Permissions/PrincipalPermission.xml
+++ b/xml/System.Security.Permissions/PrincipalPermission.xml
@@ -57,17 +57,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- By passing identity information (user name and role) to the constructor, <xref:System.Security.Permissions.PrincipalPermission> can be used to demand that the identity of the active principal matches this information.
-
- To match the active <xref:System.Security.Principal.IPrincipal> and associated <xref:System.Security.Principal.IIdentity>, both the specified identity and role must match. If `null` identity string is used, it is interpreted as a request to match any identity. Use of `null` role string will match any role. By implication, passing `null` parameter for `name` or `role` to <xref:System.Security.Permissions.PrincipalPermission> will match the identity and roles in any <xref:System.Security.Principal.IPrincipal>. It is also possible to construct a <xref:System.Security.Permissions.PrincipalPermission> that only determines whether the <xref:System.Security.Principal.IIdentity> represents an authenticated or unauthenticated entity. In this case, `name` and `role` are ignored.
-
- Unlike most other permissions, <xref:System.Security.Permissions.PrincipalPermission> does not extend <xref:System.Security.CodeAccessPermission>. It does, however, implement the <xref:System.Security.IPermission> interface. This is because <xref:System.Security.Permissions.PrincipalPermission> is not a code access permission; that is, it is not granted based on the identity of the executing assembly. Instead, it allows code to perform actions (<xref:System.Security.Permissions.PrincipalPermission.Demand*>, <xref:System.Security.Permissions.PrincipalPermission.Union*>, <xref:System.Security.Permissions.PrincipalPermission.Intersect*>, and so on) against the current user identity in a manner consistent with the way those actions are performed for code access and code identity permissions.
-
-> [!IMPORTANT]
-> Prior to a demand for principal permission it is necessary to set the current application domain's principal policy to the enumeration value <xref:System.Security.Principal.PrincipalPolicy.WindowsPrincipal>. By default, the principal policy is set to <xref:System.Security.Principal.PrincipalPolicy.UnauthenticatedPrincipal>. If you do not set the principal policy to <xref:System.Security.Principal.PrincipalPolicy.WindowsPrincipal>, a demand for principal permission will fail. The following code should be executed before the principal permission is demanded:
->
-> `AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal).`
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.PrincipalPermissionAttribute" />
@@ -116,17 +105,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.PrincipalPermission" /> class with the specified <see cref="T:System.Security.Permissions.PermissionState" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- `None` matches only the unauthenticated principal (<xref:System.Security.Permissions.PrincipalPermissionAttribute.Name*> is the empty string (""), no <xref:System.Security.Permissions.PrincipalPermissionAttribute.Role*>, <xref:System.Security.Permissions.PrincipalPermissionAttribute.Authenticated*> is `false`). `Unrestricted` matches all principals (<xref:System.Security.Permissions.PrincipalPermissionAttribute.Name*> is `null`, <xref:System.Security.Permissions.PrincipalPermissionAttribute.Role*> is `null`).
-
-> [!NOTE]
->  This constructor is included for consistency with the design of other permissions, but is not useful in practice.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -165,14 +144,7 @@
         <param name="name">The name of the <see cref="T:System.Security.Principal.IPrincipal" /> object's user.</param>
         <param name="role">The role of the <see cref="T:System.Security.Principal.IPrincipal" /> object's user (for example, Administrator).</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.PrincipalPermission" /> class for the specified <paramref name="name" /> and <paramref name="role" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Both the `name` parameter and the `role` parameter must match for this permission to match the active <xref:System.Security.Principal.IPrincipal> and associated <xref:System.Security.Principal.IIdentity>. Set `name` to `null` to check for any user in a role.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -213,14 +185,7 @@
         <param name="isAuthenticated">
           <see langword="true" /> to signify that the user is authenticated; otherwise, <see langword="false" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.PrincipalPermission" /> class for the specified <paramref name="name" />, <paramref name="role" />, and authentication status.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Both the `name` parameter and the `role` parameter must match for this permission to match the active <xref:System.Security.Principal.IPrincipal> and associated <xref:System.Security.Principal.IIdentity>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Copy">
@@ -260,14 +225,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of the permission represents the same principal and identity as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Demand">
@@ -306,21 +264,7 @@
       <Parameters />
       <Docs>
         <summary>Determines at run time whether the current principal matches the principal specified by the current permission.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If no <xref:System.Security.SecurityException> is raised, <xref:System.Security.Permissions.PrincipalPermission.Demand*> succeeds.
-
- This method acts against the principal attached to the calling thread.
-
-> [!IMPORTANT]
->  Prior to calling the <xref:System.Security.Permissions.PrincipalPermission.Demand*> method, it is necessary to set the current application domain's principal policy to the enumeration value <xref:System.Security.Principal.PrincipalPolicy.WindowsPrincipal>. By default the principal policy is set to <xref:System.Security.Principal.PrincipalPolicy.UnauthenticatedPrincipal>. If you do not set the principal policy to <xref:System.Security.Principal.PrincipalPolicy.WindowsPrincipal>, a demand for principal permission will fail. The following code should be executed before the demand for principal permission occurs:
->
->  `AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal).`
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.SecurityException">The current principal does not pass the security check for the principal specified by the current permission.
 
  -or-
@@ -372,14 +316,7 @@
         <summary>Determines whether the specified <see cref="T:System.Security.Permissions.PrincipalPermission" /> object is equal to the current <see cref="T:System.Security.Permissions.PrincipalPermission" />.</summary>
         <returns>
           <see langword="true" /> if the specified <see cref="T:System.Security.Permissions.PrincipalPermission" /> is equal to the current <see cref="T:System.Security.Permissions.PrincipalPermission" /> object; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- For more information, see <xref:System.Object.Equals*>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -463,14 +400,7 @@
       <Docs>
         <summary>Gets a hash code for the <see cref="T:System.Security.Permissions.PrincipalPermission" /> object that is suitable for use in hashing algorithms and data structures such as a hash table.</summary>
         <returns>A hash code for the current <see cref="T:System.Security.Permissions.PrincipalPermission" /> object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The hash code for two instances of the same permission might be different, hence a hash code should not be used to compare two <xref:System.Security.Permissions.PrincipalPermission> objects.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Intersect">
@@ -558,14 +488,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if all demands that succeed for the current permission also succeed for the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is an object that is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -607,14 +530,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted <xref:System.Security.Permissions.PrincipalPermission> matches any principal.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">

--- a/xml/System.Security.Permissions/PrincipalPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/PrincipalPermissionAttribute.xml
@@ -51,15 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- <xref:System.Security.Permissions.PrincipalPermissionAttribute> can be used to declaratively demand that users running your code belong to a specified role or have been authenticated. Use of <xref:System.Security.Permissions.PermissionState.Unrestricted> creates a <xref:System.Security.Permissions.PrincipalPermission> with <xref:System.Security.Permissions.PrincipalPermissionAttribute.Authenticated*> set to `true` and <xref:System.Security.Permissions.PrincipalPermissionAttribute.Name*> and <xref:System.Security.Permissions.PrincipalPermissionAttribute.Role*> set to `null`.
-
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used. <xref:System.Security.Permissions.PrincipalPermissionAttribute> cannot be applied at the assembly level.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.
-
-> [!IMPORTANT]
->  Before you use this class to demand principal permission, you must set the current application domain's principal policy to the enumeration value <xref:System.Security.Principal.PrincipalPolicy.WindowsPrincipal>. By default, the principal policy is set to <xref:System.Security.Principal.PrincipalPolicy.UnauthenticatedPrincipal>. If you do not set the principal policy to <xref:System.Security.Principal.PrincipalPolicy.WindowsPrincipal>, a demand for principal permission will fail. The following code should be executed before the principal permission is demanded: `AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal).`
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.PrincipalPermission" />
@@ -105,14 +96,7 @@
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.PrincipalPermissionAttribute" /> class with the specified <see cref="T:System.Security.Permissions.SecurityAction" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- `Demand`, `InheritanceDemand`, and `LinkDemand` are the only values of <xref:System.Security.Permissions.SecurityAction> that have meaning for this attribute. Other actions do not apply to permissions that are not code access permissions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Authenticated">
@@ -186,16 +170,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.PrincipalPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.PrincipalPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should only be called by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -231,14 +206,7 @@
       <Docs>
         <summary>Gets or sets the name of the identity associated with the current principal.</summary>
         <value>A name to match against that provided by the underlying role-based security provider.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If the authentication provider is Windows NT, <xref:System.Security.Permissions.PrincipalPermissionAttribute.Name*> is the same as the user's Windows NT login name (in the form "DomainName\UserName"). Check the documentation of your host to determine which authentication provider it uses and how it determines the identity of the current principal.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Role">
@@ -274,14 +242,7 @@
       <Docs>
         <summary>Gets or sets membership in a specified security role.</summary>
         <value>The name of a role from the underlying role-based security provider.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The available roles will differ based on the authentication provider in use by the host. If the authentication provider is Windows NT, roles are Windows NT user groups (in the form "DomainName\GroupName"). Check the documentation of your host to determine which authentication provider it uses and what roles users can belong to.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/PublisherIdentityPermission.xml
+++ b/xml/System.Security.Permissions/PublisherIdentityPermission.xml
@@ -47,16 +47,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
-> [!IMPORTANT]
->  Starting with the .NET Framework 4, identity permissions are not used.
->
->  In the .NET Framework versions 1.0 and 1.1, identity permissions cannot have an <xref:System.Security.Permissions.PermissionState.Unrestricted> permission state value. Starting with the .NET Framework version 2.0, identity permissions can have any permission state value. This means that in 2.0 and later versions, identity permissions have the same behavior as permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface. That is, a demand for an identity always succeeds, regardless of the identity of the assembly, if the assembly has been granted full trust.
->
->  In the .NET Framework versions 1.0 and 1.1, demands on the identity permissions are effective, even when the calling assembly is fully trusted. That is, although the calling assembly has full trust, a demand for an identity permission fails if the assembly does not meet the demanded criteria. Starting with the .NET Framework version 2.0, demands for identity permissions are ineffective if the calling assembly has full trust. This assures consistency for all permissions, eliminating the treatment of identity permissions as a special case.
-
-> [!NOTE]
->  By default, code access security does not check for <xref:System.Security.Policy.Publisher> evidence. Unless your computer has a custom code group based on the <xref:System.Security.Policy.PublisherMembershipCondition> class, you can improve performance by bypassing Authenticode signature verification. This is accomplished by configuring the runtime to not provide <xref:System.Security.Policy.Publisher> evidence for code access security. For more information about how to configure this option and which applications can use it, see the [&lt;generatePublisherEvidence&gt;](/dotnet/framework/configure-apps/file-schema/runtime/generatepublisherevidence-element) element.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.PublisherIdentityPermissionAttribute" />
@@ -107,14 +97,7 @@
       <Docs>
         <param name="certificate">An X.509 certificate representing the software publisher's identity.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.PublisherIdentityPermission" /> class with the specified Authenticode X.509v3 certificate.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The X.509 certificate defines the identity of the specified software publisher, as established by Authenticode code signing.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="certificate" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <paramref name="certificate" /> parameter is not a valid certificate.</exception>
       </Docs>
@@ -152,19 +135,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.PublisherIdentityPermission" /> class with the specified <see cref="T:System.Security.Permissions.PermissionState" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates either a fully restricted (`None`) or `Unrestricted` permission.
-
-> [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, identity permissions cannot have an <xref:System.Security.Permissions.PermissionState.Unrestricted> permission state value. Starting with the .NET Framework version 2.0, identity permissions can have any permission state value. This means that in 2.0 and later versions, identity permissions have the same behavior as permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface. That is, a demand for an identity always succeeds, regardless of the identity of the assembly, if the assembly has been granted full trust.
-
- In the .NET Framework versions 1.0 and 1.1, demands on the identity permissions are effective, even when the calling assembly is fully trusted. That is, although the calling assembly has full trust, a demand for an identity permission fails if the assembly does not meet the demanded criteria. Starting with the .NET Framework version 2.0, demands for identity permissions are ineffective if the calling assembly has full trust. This assures consistency for all permissions, eliminating the treatment of identity permissions as a special case.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -241,14 +212,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -333,16 +297,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- <xref:System.Security.Permissions.PublisherIdentityPermission> only supports set operations (<xref:System.Security.Permissions.PublisherIdentityPermission.IsSubsetOf*>, <xref:System.Security.Permissions.PublisherIdentityPermission.Intersect*>, and <xref:System.Security.Permissions.PublisherIdentityPermission.Union*>) when the current permission is equal to the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -384,16 +339,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the two permissions are equal. If this method returns `true`, the current permission represents the same access to the protected resource as the specified permission.
-
- <xref:System.Security.Permissions.PublisherIdentityPermission> supports set operations (<xref:System.Security.Permissions.PublisherIdentityPermission.IsSubsetOf*>, <xref:System.Security.Permissions.PublisherIdentityPermission.Intersect*>, and <xref:System.Security.Permissions.PublisherIdentityPermission.Union*>) only when the current permission is equal to the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -471,16 +417,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to the <xref:System.Security.Permissions.PublisherIdentityPermission.Union*> method is a permission that represents all the operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- The <xref:System.Security.Permissions.PublisherIdentityPermission> class only supports set operations (<xref:System.Security.Permissions.PublisherIdentityPermission.IsSubsetOf*>, <xref:System.Security.Permissions.PublisherIdentityPermission.Intersect*>, and <xref:System.Security.Permissions.PublisherIdentityPermission.Union*>) when the current permission is equal to the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.
 
  -or-

--- a/xml/System.Security.Permissions/PublisherIdentityPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/PublisherIdentityPermissionAttribute.xml
@@ -51,20 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.
-
- The properties <xref:System.Security.Permissions.PublisherIdentityPermissionAttribute.CertFile*>, <xref:System.Security.Permissions.PublisherIdentityPermissionAttribute.SignedFile*>, and <xref:System.Security.Permissions.PublisherIdentityPermissionAttribute.X509Certificate*> are mutually exclusive.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.
-
-> [!IMPORTANT]
->  Starting with the .NET Framework 4, identity permissions are not used.
->
->  In the .NET Framework versions 1.0 and 1.1, identity permissions cannot have an <xref:System.Security.Permissions.PermissionState.Unrestricted> permission state value. Starting with the .NET Framework version 2.0, identity permissions can have any permission state value. This means that in 2.0 and later versions, identity permissions have the same behavior as permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface.
-
-> [!NOTE]
->  By default, code access security does not check for <xref:System.Security.Policy.Publisher> evidence. Unless your computer has a custom code group based on the <xref:System.Security.Policy.PublisherMembershipCondition> class, you can improve performance by bypassing Authenticode signature verification. This is accomplished by configuring the runtime to not provide <xref:System.Security.Policy.Publisher> evidence for code access security. For more information about how to configure this option and which applications can use it, see the [&lt;generatePublisherEvidence&gt;](/dotnet/framework/configure-apps/file-schema/runtime/generatepublisherevidence-element) element.
-
  ]]></format>
     </remarks>
     <related type="Article" href="/dotnet/standard/attributes/">Extending Metadata Using Attributes</related>
@@ -139,14 +125,7 @@
       <Docs>
         <summary>Gets or sets a certification file containing an Authenticode X.509v3 certificate.</summary>
         <value>The file path of an X.509 certificate file (usually has the extension.cer).</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If <xref:System.Security.Permissions.PublisherIdentityPermissionAttribute.X509Certificate*> is set, this property is ignored.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreatePermission">
@@ -183,16 +162,7 @@
       <Docs>
         <summary>Creates and returns a new instance of <see cref="T:System.Security.Permissions.PublisherIdentityPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.PublisherIdentityPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should be called only by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SignedFile">
@@ -228,14 +198,7 @@
       <Docs>
         <summary>Gets or sets a signed file from which to extract an Authenticode X.509v3 certificate.</summary>
         <value>The file path of a file signed with the Authenticode signature.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If either <xref:System.Security.Permissions.PublisherIdentityPermissionAttribute.X509Certificate*> or <xref:System.Security.Permissions.PublisherIdentityPermissionAttribute.CertFile*> is set, this property is ignored.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="X509Certificate">
@@ -271,16 +234,7 @@
       <Docs>
         <summary>Gets or sets an Authenticode X.509v3 certificate that identifies the publisher of the calling code.</summary>
         <value>A hexadecimal representation of the X.509 certificate.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If this property is set, <xref:System.Security.Permissions.PublisherIdentityPermissionAttribute.CertFile*> and <xref:System.Security.Permissions.PublisherIdentityPermissionAttribute.SignedFile*> are ignored.
-
- You can obtain the hexadecimal representation by running the Strong Name tool (Sn.exe) with the token and public key options (**Sn** **-tp** *keyfile*`)` against a file that has an Authenticode signature. For more information, see [Sn.exe (Strong Name Tool)](/dotnet/framework/tools/sn-exe-strong-name-tool).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/ReflectionPermission.xml
+++ b/xml/System.Security.Permissions/ReflectionPermission.xml
@@ -51,15 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Without <xref:System.Security.Permissions.ReflectionPermission>, code can use reflection to access only the public members of objects. Code with <xref:System.Security.Permissions.ReflectionPermission> and the appropriate <xref:System.Security.Permissions.ReflectionPermissionFlag> flags can access the `protected` and `private` members of objects.
-
-> [!CAUTION]
->  Because <xref:System.Security.Permissions.ReflectionPermission> can provide access to non-public types and members, we recommend that you do not grant <xref:System.Security.Permissions.ReflectionPermission> to Internet code, except with the <xref:System.Security.Permissions.ReflectionPermissionFlag.RestrictedMemberAccess?displayProperty=nameWithType> flag. <xref:System.Security.Permissions.ReflectionPermissionFlag.RestrictedMemberAccess> allows access to non-public members, with the restriction that the grant set of the non-public members must be equal to, or a subset of, the grant set of the code that accesses the non-public members.
-
- Certain features of reflection emit, such as emitting debug symbols, require <xref:System.Security.Permissions.ReflectionPermission> with the <xref:System.Security.Permissions.ReflectionPermissionFlag.ReflectionEmit?displayProperty=nameWithType> flag.
-
- For more information, see the <xref:System.Security.Permissions.ReflectionPermissionFlag> enumeration.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.ReflectionPermissionFlag" />
@@ -111,14 +102,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.ReflectionPermission" /> class with either fully restricted or unrestricted permission as specified.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates either fully restricted (`None`) or `Unrestricted` access to metadata.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -193,14 +177,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Flags">
@@ -322,14 +299,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -371,14 +341,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, a permission that represents access to C:\example.txt is a subset of a permission that represents access to C:\\. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -420,14 +383,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission represents access to any and all resources protected by the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -504,14 +460,7 @@
         <param name="other">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.ReflectionPermission.Union*> is a permission that represents all the operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="other" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Permissions/ReflectionPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/ReflectionPermissionAttribute.xml
@@ -51,10 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.ReflectionPermission" />
@@ -134,16 +130,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.ReflectionPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.ReflectionPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should only be called by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Flags">
@@ -349,14 +336,7 @@
         <summary>Gets or sets a value that indicates whether reflection on members that are not visible is allowed.</summary>
         <value>
           <see langword="true" /> if reflection on members that are not visible is allowed; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property is now obsolete. Reflecting on the metadata of members that are not visible no longer requires <xref:System.Security.Permissions.ReflectionPermission>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/ReflectionPermissionFlag.xml
+++ b/xml/System.Security.Permissions/ReflectionPermissionFlag.xml
@@ -50,14 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This enumeration is used by the <xref:System.Security.Permissions.ReflectionPermission> and <xref:System.Security.Permissions.ReflectionPermissionAttribute> classes. If no <xref:System.Security.Permissions.ReflectionPermission> is granted, reflection is allowed on all types and members, but invocation operations are allowed only on visible types and members. For more information, see [Security Considerations for Reflection](/dotnet/framework/reflection-and-codedom/security-considerations-for-reflection).
-
-> [!CAUTION]
->  Because <xref:System.Security.Permissions.ReflectionPermission> can provide access to private class members, we recommend that you grant <xref:System.Security.Permissions.ReflectionPermission> to Internet code only with the `RestrictedMemberAccess` flag, and not with any other flags.
-
-> [!IMPORTANT]
-> `AllFlags` does not include the `RestrictedMemberAccess` flag. To get a mask that includes all flags in this enumeration, you must use the combination of `AllFlags` with `RestrictedMemberAccess`.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.ReflectionPermission" />
@@ -224,7 +216,7 @@
       </ReturnValue>
       <MemberValue>4</MemberValue>
       <Docs>
-        <summary>Emitting debug symbols is allowed. Beginning with .NET Framework 2.0 Service Pack 1, this flag is no longer required to emit code.</summary>
+        <summary>Emitting debug symbols is allowed.</summary>
       </Docs>
     </Member>
     <Member MemberName="RestrictedMemberAccess">

--- a/xml/System.Security.Permissions/RegistryPermission.xml
+++ b/xml/System.Security.Permissions/RegistryPermission.xml
@@ -51,15 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- <xref:System.Security.Permissions.RegistryPermission> describes protected operations on registry variables. Registry variables should not be stored in memory locations where code without <xref:System.Security.Permissions.RegistryPermission> can access them. If the registry object is passed to an untrusted caller it can be misused.
-
- The allowed registry access types are defined by <xref:System.Security.Permissions.RegistryPermissionAccess>. If more than one type of access is desired, they can be combined using the bitwise OR operation as shown in the code sample that follows.
-
- Registry permission is defined in terms of canonical absolute paths; checks should always be made with canonical pathnames. Key access implies access to all values it contains and all variables under it.
-
-> [!NOTE]
->  In versions of .NET Framework before .NET Framework 4, you could use the <xref:System.Security.CodeAccessPermission.Deny*?displayProperty=nameWithType> method to prevent inadvertent access to system resources by trusted code. <xref:System.Security.CodeAccessPermission.Deny*> is now obsolete, and access to resources is now determined solely by the granted permission set for an assembly. To limit access to files, you must run partially trusted code in a sandbox and assign it permissions only to resources that the code is allowed to access. For information about running an application in a sandbox, see [How to: Run Partially Trusted Code in a Sandbox](/dotnet/framework/misc/how-to-run-partially-trusted-code-in-a-sandbox).
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.RegistryPermissionAttribute" />
@@ -109,14 +100,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.RegistryPermission" /> class with either fully restricted or unrestricted permission as specified.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates either fully restricted (`None`) or `Unrestricted` access to registry variables.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -155,14 +139,7 @@
         <param name="access">One of the <see cref="T:System.Security.Permissions.RegistryPermissionAccess" /> values.</param>
         <param name="pathList">A list of registry variables (semicolon-separated) to which access is granted.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.RegistryPermission" /> class with the specified access to the specified registry variables.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor allows only one of the <xref:System.Security.Permissions.RegistryPermissionAccess> values to be specified. This access applies to all listed registry variables. Use <xref:System.Security.Permissions.RegistryPermission.AddPathList*> to define more complicated permissions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="access" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.RegistryPermissionAccess" />.
 
  -or-
@@ -206,19 +183,7 @@
         <param name="control">A bitwise combination of the <see cref="T:System.Security.AccessControl.AccessControlActions" /> values.</param>
         <param name="pathList">A list of registry variables (semicolon-separated) to which access is granted.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.RegistryPermission" /> class with the specified access to the specified registry variables and the specified access rights to registry control information.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor allows only one of the <xref:System.Security.Permissions.RegistryPermissionAccess> values to be specified. This access applies to all listed registry variables. Use <xref:System.Security.Permissions.RegistryPermission.AddPathList*> to define more complicated permissions.
-
- The `control` parameter specifies whether the access control list (ACL) for the registry keys specified by `pathList` can be changed, viewed, or cannot be accessed.
-
-> [!IMPORTANT]
->  An access control list (ACL) describes individuals or groups who have, or do not have, rights to specific actions on the specified registry keys.  The ability to change or view an ACL is an important permission and should be granted with caution.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="access" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.RegistryPermissionAccess" />.
 
  -or-
@@ -234,14 +199,7 @@
       </AssemblyInfo>
       <Docs>
         <summary>Adds access for the specified registry variables to the existing state of the permission.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to modify access to registry variables by adding the set of their paths to the state of the current permission object.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </MemberGroup>
     <Member MemberName="AddPathList">
@@ -282,14 +240,7 @@
         <param name="access">One of the <see cref="T:System.Security.Permissions.RegistryPermissionAccess" /> values.</param>
         <param name="pathList">A list of registry variables (semicolon-separated).</param>
         <summary>Adds access for the specified registry variables to the existing state of the permission.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to modify access to registry variables by adding to the state of the current permission object.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="access" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.RegistryPermissionAccess" />.
 
  -or-
@@ -336,19 +287,7 @@
         <param name="actions">One of the <see cref="T:System.Security.AccessControl.AccessControlActions" /> values.</param>
         <param name="pathList">A list of registry variables (separated by semicolons).</param>
         <summary>Adds access for the specified registry variables to the existing state of the permission, specifying registry permission access and access control actions.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to modify access to registry variables by adding the set of their paths to the state of the current permission object. This overload allows you to specify the access control action as will as the registry permission access.
-
- The `control` parameter specifies whether the access control list (ACL) for the registry keys specified by `pathList` can be changed, viewed, or cannot be accessed.
-
-> [!IMPORTANT]
->  An access control list (ACL) describes individuals or groups who have, or do not have, rights to specific actions on the specified registry keys.  The ability to change or view an ACL is an important permission and should be granted with caution.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="access" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.RegistryPermissionAccess" />.
 
  -or-
@@ -390,14 +329,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -482,17 +414,7 @@
         <param name="access">One of the <see cref="T:System.Security.Permissions.RegistryPermissionAccess" /> values that represents a single type of registry variable access.</param>
         <summary>Gets paths for all registry variables with the specified <see cref="T:System.Security.Permissions.RegistryPermissionAccess" />.</summary>
         <returns>A list of the registry variables (semicolon-separated) with the specified <see cref="T:System.Security.Permissions.RegistryPermissionAccess" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to get the state of the current permission. You must call this method separately for each type of access.
-
-> [!NOTE]
->  The `access` parameter is limited to the values of <xref:System.Security.Permissions.RegistryPermissionAccess>, which represent single types of registry variable access. Those values are <xref:System.Security.Permissions.RegistryPermissionAccess.Read>, <xref:System.Security.Permissions.RegistryPermissionAccess.Write>, and <xref:System.Security.Permissions.RegistryPermissionAccess.Create>. The values acceptable to `access` do not include <xref:System.Security.Permissions.RegistryPermissionAccess.NoAccess> and <xref:System.Security.Permissions.RegistryPermissionAccess.AllAccess>, which do not represent single types of registry variable access.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="access" /> is not a valid value of <see cref="T:System.Security.Permissions.RegistryPermissionAccess" />.
 
@@ -538,14 +460,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -587,14 +502,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, a permission that represents access to C:\example.txt is a subset of a permission that represents access to C:\\. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -636,14 +544,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission represents access to any and all resources protected by the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SetPathList">
@@ -684,14 +585,7 @@
         <param name="access">One of the <see cref="T:System.Security.Permissions.RegistryPermissionAccess" /> values.</param>
         <param name="pathList">A list of registry variables (semicolon-separated).</param>
         <summary>Sets new access for the specified registry variable names to the existing state of the permission.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The previous state of the current permission is overwritten.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="access" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.RegistryPermissionAccess" />.
 
  -or-
@@ -773,14 +667,7 @@
         <param name="other">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.RegistryPermission.Union*> is a permission that represents all the operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="other" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Permissions/RegistryPermissionAccess.xml
+++ b/xml/System.Security.Permissions/RegistryPermissionAccess.xml
@@ -50,11 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- <xref:System.Security.Permissions.RegistryPermissionAccess> values are independent; rights to one type of access do not imply rights to another. For instance, `Write` permission does not imply permission to `Read` or `Create`.
-
-> [!NOTE]
-> Although `NoAccess` and `AllAccess` appear in `RegistryPermissionAccess`, they are not valid for use as the parameter for <xref:System.Security.Permissions.RegistryPermission.GetPathList*?displayProperty=nameWithType> because they describe no registry variable access types or all registry variable access types, respectively, and <xref:System.Security.Permissions.RegistryPermission.GetPathList*> expects a single registry variable access type.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.RegistryPermission" />

--- a/xml/System.Security.Permissions/RegistryPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/RegistryPermissionAttribute.xml
@@ -51,10 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.RegistryPermission" />
@@ -142,14 +138,7 @@
       <Docs>
         <summary>Gets or sets full access for the specified registry keys.</summary>
         <value>A semicolon-separated list of registry key paths, for full access.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Key access implies access to all subkeys and all values.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.NotSupportedException">The get accessor is called; it is only provided for C# compiler compatibility.</exception>
       </Docs>
     </Member>
@@ -185,17 +174,7 @@
       <Docs>
         <summary>Gets or sets change access control for the specified registry keys.</summary>
         <value>A semicolon-separated list of registry key paths, for change access control. .</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Key access implies access to all values it contains and all variables under it.
-
-> [!IMPORTANT]
->  An access control list (ACL) describes individuals or groups who have, or do not have, rights to specific actions for the given registry keys.  The ability to change an ACL is an important permission and should be granted with caution.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Create">
@@ -231,14 +210,7 @@
       <Docs>
         <summary>Gets or sets create-level access for the specified registry keys.</summary>
         <value>A semicolon-separated list of registry key paths, for create-level access.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Key access implies access to all values it contains and all variables under it.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreatePermission">
@@ -275,16 +247,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.RegistryPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.RegistryPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should only be called by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Read">
@@ -320,14 +283,7 @@
       <Docs>
         <summary>Gets or sets read access for the specified registry keys.</summary>
         <value>A semicolon-separated list of registry key paths, for read access.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Key access implies access to all values it contains and all variables under it.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ViewAccessControl">
@@ -362,17 +318,7 @@
       <Docs>
         <summary>Gets or sets view access control for the specified registry keys.</summary>
         <value>A semicolon-separated list of registry key paths, for view access control.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Key access implies access to all values it contains and all variables under it.
-
-> [!IMPORTANT]
->  An access control list (ACL) describes individuals or groups who have, or do not have, rights to specific actions for the given registry keys.  The ability to view an ACL is an important permission and should be granted with caution.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ViewAndModify">
@@ -407,19 +353,7 @@
       <Docs>
         <summary>Gets or sets a specified set of registry keys that can be viewed and modified.</summary>
         <value>A semicolon-separated list of registry key paths, for create, read, and write access.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Key access implies access to all values it contains and all variables under it.
-
- This property specifies <xref:System.Security.Permissions.RegistryPermissionAttribute.Create*>, <xref:System.Security.Permissions.RegistryPermissionAttribute.Read*>, and <xref:System.Security.Permissions.RegistryPermissionAttribute.Write*> access rights for the specified keys and their values. The access rights are for registry data only; they do not include the access control rights <xref:System.Security.Permissions.RegistryPermissionAttribute.ChangeAccessControl*> or <xref:System.Security.Permissions.RegistryPermissionAttribute.ViewAccessControl*>.
-
-> [!NOTE]
->  The get accessor is provided for C# compiler compatibility. The C# compiler requires attribute properties to be read/write.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.NotSupportedException">The get accessor is called; it is only provided for C# compiler compatibility.</exception>
       </Docs>
     </Member>
@@ -456,14 +390,7 @@
       <Docs>
         <summary>Gets or sets write access for the specified registry keys.</summary>
         <value>A semicolon-separated list of registry key paths, for write access.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Key access implies access to all values it contains and all variables under it.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/ResourcePermissionBase.xml
+++ b/xml/System.Security.Permissions/ResourcePermissionBase.xml
@@ -50,9 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
-> [!NOTE]
-> The <xref:System.Security.Permissions.ResourcePermissionBase> class compares strings using ordinal sort rules and ignores the case of the strings being compared.
-
  ]]></format>
     </remarks>
     <block subset="none" type="overrides">
@@ -212,14 +209,7 @@
       </ReturnValue>
       <Docs>
         <summary>Specifies the character to be used to represent the any wildcard character.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The value of this field is "*".
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Clear">
@@ -290,14 +280,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission object.</summary>
         <returns>A copy of the current permission object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of the permission object represents the same access to resources as the original permission object.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -377,14 +360,7 @@
       <Docs>
         <summary>Returns an array of the <see cref="T:System.Security.Permissions.ResourcePermissionBaseEntry" /> objects added to this permission.</summary>
         <returns>An array of <see cref="T:System.Security.Permissions.ResourcePermissionBaseEntry" /> objects that were added to this permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use <xref:System.Security.Permissions.ResourcePermissionBase.AddPermissionAccess*> and <xref:System.Security.Permissions.ResourcePermissionBase.RemovePermissionAccess*> to add and remove permission entries to this permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="M:System.Security.Permissions.ResourcePermissionBase.AddPermissionAccess(System.Security.Permissions.ResourcePermissionBaseEntry)" />
         <altmember cref="M:System.Security.Permissions.ResourcePermissionBase.RemovePermissionAccess(System.Security.Permissions.ResourcePermissionBaseEntry)" />
         <altmember cref="T:System.Security.Permissions.ResourcePermissionBaseEntry" />
@@ -426,14 +402,7 @@
         <param name="target">A permission object of the same type as the current permission object.</param>
         <summary>Creates and returns a permission object that is the intersection of the current permission object and a target permission object.</summary>
         <returns>A new permission object that represents the intersection of the current object and the specified target. This object is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permission objects is a permission that describes the set of operations they both hold in common. Specifically, it represents the minimum permissions required for a demand to pass both permissions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The target permission object is not of the same type as the current permission object.</exception>
       </Docs>
     </Member>
@@ -474,16 +443,7 @@
         <summary>Determines whether the current permission object is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission object is a subset of the specified permission object; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission object is a subset of the specified permission object if the current permission object specifies a set of operations that is wholly contained by the specified permission object. For example, a permission that represents access to C:\Example.txt is a subset of a permission that represents access to C:\\. If this method returns `true`, the current permission object represents no more access to the protected resource than does the specified permission object.
-
- This method always returns `false` when the specified permission object is of a different type than that of the current permission object.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsUnrestricted">
@@ -523,14 +483,7 @@
         <summary>Gets a value indicating whether the permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission object represents access to any and all resources protected by the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Local">
@@ -564,14 +517,7 @@
       </ReturnValue>
       <Docs>
         <summary>Specifies the character to be used to represent a local reference.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The value of this field is ".".
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PermissionAccessType">
@@ -771,14 +717,7 @@
         <param name="target">A permission object to combine with the current permission object. It must be of the same type as the current permission object.</param>
         <summary>Creates a permission object that combines the current permission object and the target permission object.</summary>
         <returns>A new permission object that represents the union of the current permission object and the specified permission object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.ResourcePermissionBase.Union*> is a permission that represents all the operations represented by both the current permission object and the specified permission object. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> permission object is not of the same type as the current permission object.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Permissions/ResourcePermissionBaseEntry.xml
+++ b/xml/System.Security.Permissions/ResourcePermissionBaseEntry.xml
@@ -87,14 +87,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.ResourcePermissionBaseEntry" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.ResourcePermissionBaseEntry.PermissionAccess> property is set to zero.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -202,14 +195,7 @@
       <Docs>
         <summary>Gets an array of strings that identify the resource you are protecting.</summary>
         <value>An array of strings that identify the resource you are protecting.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Diagnostics.PerformanceCounterPermissionEntry> has two properties, <xref:System.Diagnostics.PerformanceCounterPermissionEntry.CategoryName*> and <xref:System.Diagnostics.PerformanceCounterPermissionEntry.MachineName*>. The <xref:System.Security.Permissions.ResourcePermissionBaseEntry.PermissionAccessPath*> for <xref:System.Diagnostics.PerformanceCounterPermissionEntry> returns <xref:System.Diagnostics.PerformanceCounterPermissionEntry.MachineName*> + "\\\\" + <xref:System.Diagnostics.PerformanceCounterPermissionEntry.CategoryName*>. For example, "myMachine\\\myCategory".
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/SecurityAction.xml
+++ b/xml/System.Security.Permissions/SecurityAction.xml
@@ -86,27 +86,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The following table describes the time that each security action takes place and the targets that it supports.
-
-> [!IMPORTANT]
->  In .NET Framework 4, runtime support has been removed for enforcing the Deny, RequestMinimum, RequestOptional, and RequestRefuse permission requests. These requests should not be used in code that is based on .NET Framework 4 or later. For more information about this and other changes, see [Security Changes](/dotnet/framework/security/security-changes).
-
- You should not use `LinkDemand` in .NET Framework 4. Instead, use the <xref:System.Security.SecurityCriticalAttribute> to restrict usage to fully trusted applications, or use `Demand` to restrict partially trusted callers.
-
-| Declaration of security action                   | Time of action           | Targets supported |
-|--------------------------------------------------|--------------------------|-------------------|
-| `LinkDemand` (do not use in .NET Framework 4+)   | Just-in-time compilation | Class, method     |
-| `InheritanceDemand`                              | Load time                | Class, method     |
-| `Demand`                                         | Run time                 | Class, method     |
-| `Assert`                                         | Run time                 | Class, method     |
-| `Deny` (obsolete in .NET Framework 4)            | Run time                 | Class, method     |
-| `PermitOnly`                                     | Run time                 | Class, method     |
-| `RequestMinimum` (obsolete in .NET Framework 4)  | Grant time               | Assembly          |
-| `RequestOptional` (obsolete in .NET Framework 4) | Grant time               | Assembly          |
-| `RequestRefuse` (obsolete in .NET Framework 4)   | Grant time               | Assembly          |
-
- For additional information about attribute targets, see <xref:System.Attribute>.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -373,7 +352,7 @@
       </ReturnValue>
       <MemberValue>6</MemberValue>
       <Docs>
-        <summary>The immediate caller is required to have been granted the specified permission. Do not use in the .NET Framework 4. For full trust, use <see cref="T:System.Security.SecurityCriticalAttribute" /> instead; for partial trust, use <see cref="F:System.Security.Permissions.SecurityAction.Demand" />.</summary>
+        <summary>The immediate caller is required to have been granted the specified permission.</summary>
       </Docs>
     </Member>
     <Member MemberName="PermitOnly">

--- a/xml/System.Security.Permissions/SecurityAttribute.xml
+++ b/xml/System.Security.Permissions/SecurityAttribute.xml
@@ -148,14 +148,7 @@
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</param>
         <summary>Initializes a new instance of <see cref="T:System.Security.Permissions.SecurityAttribute" /> with the specified <see cref="T:System.Security.Permissions.SecurityAction" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- You cannot create an instance of this class. You must inherit from this class to make use of its functionality. The value of `action` is used to set the <xref:System.Security.Permissions.SecurityAttribute.Action> property.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Action">
@@ -207,14 +200,7 @@
       <Docs>
         <summary>Gets or sets a security action.</summary>
         <value>One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property is inherited by all classes implementing custom attributes for declarative security.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreatePermission">
@@ -268,14 +254,7 @@
       <Docs>
         <summary>When overridden in a derived class, creates a permission object that can then be serialized into binary form and persistently stored along with the <see cref="T:System.Security.Permissions.SecurityAction" /> in an assembly's metadata.</summary>
         <returns>A serializable permission object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Unrestricted">
@@ -328,14 +307,7 @@
         <summary>Gets or sets a value indicating whether full (unrestricted) permission to the resource protected by the attribute is declared.</summary>
         <value>
           <see langword="true" /> if full permission to the protected resource is declared; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property is inherited by all classes implementing custom attributes for declarative security.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/SecurityPermission.xml
+++ b/xml/System.Security.Permissions/SecurityPermission.xml
@@ -51,8 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This permission uses the <xref:System.Security.Permissions.SecurityPermissionFlag> enumeration. The values for this enumeration can be found in its documentation.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.SecurityPermissionAttribute" />
@@ -102,14 +100,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.SecurityPermission" /> class with either restricted or unrestricted permission as specified.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates either fully restricted (`None`) or `Unrestricted` access to all security permissions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -184,14 +175,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Flags">
@@ -227,14 +211,7 @@
       <Docs>
         <summary>Gets or sets the security permission flags.</summary>
         <value>The state of the current permission, represented by a bitwise OR combination of any permission bits defined by <see cref="T:System.Security.Permissions.SecurityPermissionFlag" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Individual permission bits can be determined by performing an AND operation against this value and checking for nonzero.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">An attempt is made to set this property to an invalid value. See <see cref="T:System.Security.Permissions.SecurityPermissionFlag" /> for the valid values.</exception>
       </Docs>
     </Member>
@@ -320,14 +297,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission object that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the state that they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -369,14 +339,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, a permission that represents access to C:\example.txt is a subset of a permission that represents access to C:\\. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -418,14 +381,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission represents access to any and all resources protected by the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -502,14 +458,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.SecurityPermission.Union*> is a permission that represents all the operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Permissions/SecurityPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/SecurityPermissionAttribute.xml
@@ -91,15 +91,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.
-
- When you use the <xref:System.Security.Permissions.SecurityPermissionAttribute> class, follow the security action with the permission(s) that are being requested. Each security permission that can be requested, as defined in the <xref:System.Security.Permissions.SecurityPermissionFlag> enumeration, has a corresponding property in the <xref:System.Security.Permissions.SecurityPermissionAttribute> class. For example, to demand the ability to access unmanaged code, follow the demand statement with the property setting that is being requested, as follows: `SecurityPermissionAttribute(SecurityAction.Demand, UnmanagedCode=true)`.
-
-> [!NOTE]
->  An exception to the equivalence between the <xref:System.Security.Permissions.SecurityPermissionFlag> enumeration and the <xref:System.Security.Permissions.SecurityPermissionAttribute> properties is that the <xref:System.Security.Permissions.SecurityPermissionFlag.AllFlags> enumeration value is represented by the <xref:System.Security.Permissions.SecurityAttribute.Unrestricted> property (inherited from the <xref:System.Security.Permissions.SecurityAttribute> class). To demand all security permissions, specify `Unrestricted=true`.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.SecurityPermission" />
@@ -261,14 +252,7 @@
         <summary>Gets or sets a value that indicates whether code has permission to perform binding redirection in the application configuration file.</summary>
         <value>
           <see langword="true" /> if code can perform binding redirects; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This permission allows redirection of .NET Framework assemblies that have been unified, as well as other assemblies found outside the .NET Framework.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ControlAppDomain">
@@ -586,14 +570,7 @@
         <summary>Gets or sets a value indicating whether permission to manipulate threads is declared.</summary>
         <value>
           <see langword="true" /> if permission to manipulate threads is declared; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- For more information, see <xref:System.Threading.Thread>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreatePermission">
@@ -647,16 +624,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.SecurityPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.SecurityPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should only be called by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Execution">
@@ -709,14 +677,7 @@
         <summary>Gets or sets a value indicating whether permission to execute code is declared.</summary>
         <value>
           <see langword="true" /> if permission to execute code is declared; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A demand for <xref:System.Security.Permissions.SecurityPermissionFlag.Execution> permission at the assembly level is ignored. If an assembly has the right to execute, <xref:System.Security.Permissions.SecurityPermissionFlag.Execution> permission is automatically granted, and setting the <xref:System.Security.Permissions.SecurityPermissionAttribute.Execution> property to either `true` or `false` has no effect.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Flags">
@@ -981,16 +942,7 @@
         <summary>Gets or sets a value indicating whether permission to bypass code verification is declared.</summary>
         <value>
           <see langword="true" /> if permission to bypass code verification is declared; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!CAUTION]
->  This is a powerful permission that should be granted only to highly trusted code.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="UnmanagedCode">

--- a/xml/System.Security.Permissions/SecurityPermissionFlag.xml
+++ b/xml/System.Security.Permissions/SecurityPermissionFlag.xml
@@ -90,11 +90,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This enumeration is used by <xref:System.Security.Permissions.SecurityPermission>.
-
-> [!CAUTION]
-> Many of these flags are powerful and should only be granted to highly trusted code.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.SecurityPermission" />

--- a/xml/System.Security.Permissions/SiteIdentityPermission.xml
+++ b/xml/System.Security.Permissions/SiteIdentityPermission.xml
@@ -47,21 +47,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Using this class, it is possible to ensure that callers are from a specific Web site. Site identity is only defined for code from URLs with the protocols of HTTP, HTTPS, and FTP. A site is the string between the "//" after the protocol of a URL and the following "/", if present, for example, `www.fourthcoffee.com` in the URL `http://www.fourthcoffee.com/process/grind.htm`. This excludes port numbers. If a given URL is `http://www.fourthcoffee.com:8000/`, the site is `www.fourthcoffee.com`, not `www.fourthcoffee.com:8000`.
-
- Sites can be matched exactly, or by a wildcard ("\*") prefix at the dot delimiter. For example, the site name string `*.fourthcoffee.com` matches `fourthcoffee.com` as well as `www.fourthcoffee.com`. Without a wildcard, the site name must be a precise match. The site name string \* will match any site, but will not match code that has no site evidence.
-
-> [!IMPORTANT]
->  Starting with the .NET Framework 4, identity permissions are not used.
->
->  In the .NET Framework versions 1.0 and 1.1, demands on the identity permissions are effective, even when the calling assembly is fully trusted. That is, although the calling assembly has full trust, a demand for an identity permission fails if the assembly does not meet the demanded criteria. Starting with the .NET Framework version 2.0, demands for identity permissions are ineffective if the calling assembly has full trust. This assures consistency for all permissions, eliminating the treatment of identity permissions as a special case.
-
-> [!NOTE]
->  In versions of the .NET Framework before the .NET Framework 4, you could use the <xref:System.Security.CodeAccessPermission.Deny*?displayProperty=nameWithType> method to prevent inadvertent access to system resources by trusted code. <xref:System.Security.CodeAccessPermission.Deny*> is now obsolete, and access to resources is now determined solely by the granted permission set for an assembly. To limit access to files, you must run partially trusted code in a sandbox and assign it permissions only to resources that the code is allowed to access. For information about running an application in a sandbox, see [How to: Run Partially Trusted Code in a Sandbox](/dotnet/framework/misc/how-to-run-partially-trusted-code-in-a-sandbox).
-
-> [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, identity permissions cannot have an <xref:System.Security.Permissions.PermissionState.Unrestricted> permission state value. Starting with the .NET Framework version 2.0, identity permissions can have any permission state value. This means that in 2.0 and later versions, identity permissions have the same behavior as permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.SiteIdentityPermissionAttribute" />
@@ -112,19 +97,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.SiteIdentityPermission" /> class with the specified <see cref="T:System.Security.Permissions.PermissionState" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The fully restricted state of <xref:System.Security.Permissions.SiteIdentityPermission> matches no sites. This constructor is included for consistency with the design of other permissions, but is not useful in practice.
-
-> [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, identity permissions cannot have an <xref:System.Security.Permissions.PermissionState.Unrestricted> permission state value. Starting with the .NET Framework version 2.0, identity permissions can have any permission state value. This means that in 2.0 and later versions, identity permissions have the same behavior as permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface. That is, a demand for an identity always succeeds, regardless of the identity of the assembly, if the assembly has been granted full trust.
-
- In the .NET Framework versions 1.0 and 1.1, demands on the identity permissions are effective, even when the calling assembly is fully trusted. That is, although the calling assembly has full trust, a demand for an identity permission fails if the assembly does not meet the demanded criteria. Starting with the .NET Framework version 2.0, demands for identity permissions are ineffective if the calling assembly has full trust. This assures consistency for all permissions, eliminating the treatment of identity permissions as a special case.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -161,16 +134,7 @@
       <Docs>
         <param name="site">The site name or wildcard expression.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.SiteIdentityPermission" /> class to represent the specified site identity.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Site identity is only defined for code from URLs with the protocols of HTTP, HTTPS, and FTP. A site is the string between the "//" after the protocol of a URL and the following "/", if present, for example, `www.fourthcoffee.com` in the URL `http://www.fourthcoffee.com/process/grind.htm/`. This excludes port numbers. If a given URL is `http://www.fourthcoffee.com:8000/`, the site is `www.fourthcoffee.com`, not `www.fourthcoffee.com:8000`.
-
- Sites can be matched exactly, or by a wildcard ("\*") prefix at the dot delimiter. For example, the site name string `*.fourthcoffee.com` matches `fourthcoffee.com` as well as `www.fourthcoffee.com`. Without a wildcard, the site name must be a precise match.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="site" /> parameter is not a valid string, or does not match a valid wildcard site name.</exception>
       </Docs>
     </Member>
@@ -208,14 +172,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of the permission represents the same access to resources or the same site identity as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -300,16 +257,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the sites they both describe in common. Only a demand that passes both original permissions will pass the intersection. For example, the intersection of a permission that represents access to `www.fourthcoffee.com` and one that represents access to `*.fourthcoffee.com` is a permission that represents access to `www.fourthcoffee.com`.
-
- The intersection of two identical site identity permissions is the same permission. The intersection of two different (not wildcard) expressions is an empty permission. The intersection of a wildcard expression and a matching site is the site. The intersection of two wildcard expressions that match is the longer, more specific of the two expressions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -351,28 +299,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a site that is wholly contained by the specified permission.
-
- The following table shows the value of <xref:System.Security.Permissions.SiteIdentityPermission.IsSubsetOf*> for a range of values of the current permission and the specified permission.
-
-|Current Permission|Specified Permission|IsSubsetOf|
-|------------------------|--------------------------|----------------|
-|`www.fourthcoffee.com`|`www.fourthcoffee.com`|`true`|
-|`www.fourthcoffee.com`|`www.tailspintoys.com`|`false`|
-|`www.fourthcoffee.com`|`*.fourthcoffee.com`|`true`|
-|`www.fourthcoffee.com`|`*.com`|`true`|
-|`*.fourthcoffee.com`|`www.fourthcoffee.com`|`false`|
-|`*.fourthcoffee.com`|`*.fourthcoffee.com`|`true`|
-|`*.fourthcoffee.com`|`*.com`|`true`|
-|Anything except `None`|`*`|`true`|
-|`None`|Anything|`true`|
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -409,16 +336,7 @@
       <Docs>
         <summary>Gets or sets the current site.</summary>
         <value>The current site.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Site identity is only defined for code from URLs with the protocols of HTTP, HTTPS, and FTP. A site is the string between the "//" after the protocol of a URL and the following "/", if present, for example, `www.fourthcoffee.com` in the URL `http://www.fourthcoffee.com/process/grind.htm/`. This excludes port numbers. If a given URL is `http://www.fourthcoffee.com:8000/`, the site is `www.fourthcoffee.com`, not `www.fourthcoffee.com:8000`.
-
- Sites can be matched exactly, or by a wildcard ("\*") prefix at the dot delimiter. For example, the site name string `*.fourthcoffee.com` matches `fourthcoffee.com` as well as `www.fourthcoffee.com`. Without a wildcard, the site name must be a precise match. The site name string \* will match any site, but will not match code that has no site evidence.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.NotSupportedException">The site identity cannot be retrieved because it has an ambiguous identity.</exception>
       </Docs>
     </Member>
@@ -496,16 +414,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.SiteIdentityPermission.Union*> is a permission that represents all the sites represented by both the current permission and the specified permission. Any demand that passes either permission passes their union. For example, the union of a permission that represents access to `www.fourthcoffee.com` and one that represents access to `*.fourthcoffee.com` is a permission that represents access to `*.fourthcoffee.com`.
-
- The union of a permission and `null` is the permission that is not `null`. The union of a permission and a subset of that permission is the permission that contains the subset. Any other combination results in an <xref:System.ArgumentException> being thrown. For example, the union of the site identity `www.fourthcoffee.com` and the site identity `www.tailspintoys.com` results in an exception because neither is a subset of the other.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.
 
  -or-

--- a/xml/System.Security.Permissions/SiteIdentityPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/SiteIdentityPermissionAttribute.xml
@@ -45,25 +45,12 @@
   <Docs>
     <summary>Allows security actions for <see cref="T:System.Security.Permissions.SiteIdentityPermission" /> to be applied to code using declarative security. This class cannot be inherited.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Site identity is only defined for code from URLs with the protocols of HTTP, HTTPS, and FTP. A site is the string between the "//" after the protocol of a URL and the following "/", if present, for example, `www.fourthcoffee.com` in the URL `http://www.fourthcoffee.com/process/grind.htm`. This excludes port numbers. If a given URL is `http://www.fourthcoffee.com:8000/`, the site is `www.fourthcoffee.com`, not `www.fourthcoffee.com:8000`.  
-  
- Sites can be matched exactly, or by a wildcard ("\*") prefix at the dot delimiter. For example, the site name string `*.fourthcoffee.com` matches `fourthcoffee.com` as well as `www.fourthcoffee.com`. Without a wildcard, the site name must be a precise match. The site name string \* will match any site, but will not match code that has no site evidence.  
-  
-> [!IMPORTANT]
->  Starting with the .NET Framework 4, identity permissions are not used.  
->   
->  In the .NET Framework versions 1.0 and 1.1, demands on the identity permissions are effective even when the calling assembly is fully trusted. That is, although the calling assembly has full trust, a demand for an identity permission fails if the assembly does not meet the demanded criteria. In the .NET Framework version 2.0, demands for identity permissions are ineffective if the calling assembly has full trust. This assures consistency for all permissions, eliminating the treatment of identity permissions as a special case.  
-  
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.  
-  
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.SiteIdentityPermission" />
@@ -142,16 +129,7 @@
       <Docs>
         <summary>Creates and returns a new instance of <see cref="T:System.Security.Permissions.SiteIdentityPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.SiteIdentityPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method should only be called by the security system, never by application code.  
-  
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Site">
@@ -187,16 +165,7 @@
       <Docs>
         <summary>Gets or sets the site name of the calling code.</summary>
         <value>The site name to compare against the site name specified by the security provider.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Site identity is only defined for code from URLs with the protocols of HTTP, HTTPS, and FTP. A site is the string between the "//" after the protocol of a URL and the following "/", if present, for example, `www.fourthcoffee.com` in the URL `http://www.fourthcoffee.com/process/grind.htm`. This excludes port numbers. If a given URL is `http://www.fourthcoffee.com:8000/`, the site is `www.fourthcoffee.com`, not `www.fourthcoffee.com:8000`.  
-  
- Sites can be matched exactly, or by a wildcard ("\*") prefix at the dot delimiter. For example, the site name string `*.fourthcoffee.com` matches `fourthcoffee.com` as well as `www.fourthcoffee.com`. Without a wildcard, the site name must be a precise match.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/StorePermission.xml
+++ b/xml/System.Security.Permissions/StorePermission.xml
@@ -49,8 +49,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- <xref:System.Security.Permissions.StorePermission> controls the access that code is granted to X.509 stores. The permission is based on flags representing the access levels that apply to every store.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.StorePermissionAttribute" />
@@ -97,14 +95,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.StorePermission" /> class with either fully restricted or unrestricted permission state.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The permission object provides either fully restricted (`None`) or `Unrestricted` access to X.509 stores. If fully restricted (`None`), the <xref:System.Security.Permissions.StorePermission.Flags> property can then be set to specify the type of access allowed.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="state" /> is not a valid <see cref="T:System.Security.Permissions.PermissionState" /> value.</exception>
       </Docs>
@@ -140,14 +131,7 @@
       <Docs>
         <param name="flag">A bitwise combination of the <see cref="T:System.Security.Permissions.StorePermissionFlags" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.StorePermission" /> class with the specified access.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The `flag` parameter specifies the permitted access to X.509 stores. The specified permitted access applies to all stores. It is not possible to specify access to an individual store.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="flag" /> is not a valid combination of <see cref="T:System.Security.Permissions.StorePermissionFlags" /> values.</exception>
       </Docs>
@@ -184,14 +168,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Flags">
@@ -225,14 +202,7 @@
       <Docs>
         <summary>Gets or sets the type of <see cref="T:System.Security.Cryptography.X509Certificates.X509Store" /> access allowed by the current permission.</summary>
         <value>A bitwise combination of the <see cref="T:System.Security.Permissions.StorePermissionFlags" /> values.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.StorePermission.Flags> property specifies the permitted access to X.509 stores. X.509 stores are physical stores used to persist and manage X.509 certificates.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">An attempt is made to set this property to an invalid value. See <see cref="T:System.Security.Permissions.StorePermissionFlags" /> for the valid values.</exception>
       </Docs>
     </Member>
@@ -270,14 +240,7 @@
       <Docs>
         <param name="securityElement">A <see cref="T:System.Security.SecurityElement" /> that contains the XML encoding to use to reconstruct the permission.</param>
         <summary>Reconstructs a permission with a specified state from an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.StorePermission.FromXml*> method reconstructs a <xref:System.Security.Permissions.StorePermission> object from an XML encoding defined by the <xref:System.Security.SecurityElement> class. Use the <xref:System.Security.Permissions.StorePermission.ToXml*> method to XML-encode the <xref:System.Security.Permissions.StorePermission>, including state information.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="securityElement" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">
@@ -323,14 +286,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations that both permissions describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> s not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
@@ -371,14 +327,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, a permission that represents access to C:\example.txt is a subset of a permission that represents access to C:\\. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
@@ -419,14 +368,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission represents access to all resources protected by the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -461,14 +403,7 @@
       <Docs>
         <summary>Creates an XML encoding of the permission and its current state.</summary>
         <returns>A <see cref="T:System.Security.SecurityElement" /> that contains an XML encoding of the permission, including any state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use the <xref:System.Security.Permissions.StorePermission.FromXml*> method to restore the state information from a <xref:System.Security.SecurityElement>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -506,14 +441,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.StorePermission.Union*> is a permission that represents all operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="target" /> is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>

--- a/xml/System.Security.Permissions/StorePermissionAttribute.xml
+++ b/xml/System.Security.Permissions/StorePermissionAttribute.xml
@@ -49,10 +49,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> value that is used.
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. The <xref:System.Security.Permissions.StorePermissionAttribute> attribute is used only for declarative security. For imperative security, use the <xref:System.Security.Permissions.StorePermission> class.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.StorePermission" />
@@ -126,14 +122,7 @@
         <summary>Gets or sets a value indicating whether the code is permitted to add to a store.</summary>
         <value>
           <see langword="true" /> if the ability to add to a store is allowed; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- For security reasons, this ability should be granted only to highly trusted code.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreatePermission">
@@ -168,16 +157,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.StorePermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.StorePermission" /> that corresponds to the attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should be called only by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. The metadata is created from the permission object that this method returns.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateStore">
@@ -212,14 +192,7 @@
         <summary>Gets or sets a value indicating whether the code is permitted to create a store.</summary>
         <value>
           <see langword="true" /> if the ability to create a store is allowed; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- New stores are created by calling the <xref:System.Security.Cryptography.X509Certificates.X509Store.Open*?displayProperty=nameWithType> method.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="DeleteStore">
@@ -254,14 +227,7 @@
         <summary>Gets or sets a value indicating whether the code is permitted to delete a store.</summary>
         <value>
           <see langword="true" /> if the ability to delete a store is allowed; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This functionality is not exposed by the <xref:System.Security.Cryptography.X509Certificates.X509Store> class.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EnumerateCertificates">
@@ -296,14 +262,7 @@
         <summary>Gets or sets a value indicating whether the code is permitted to enumerate the certificates in a store.</summary>
         <value>
           <see langword="true" /> if the ability to enumerate certificates is allowed; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- For privacy reasons, this ability should be granted only to fully trusted code.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="EnumerateStores">
@@ -338,14 +297,7 @@
         <summary>Gets or sets a value indicating whether the code is permitted to enumerate stores.</summary>
         <value>
           <see langword="true" /> if the ability to enumerate stores is allowed; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This functionality is not exposed by the <xref:System.Security.Cryptography.X509Certificates.X509Store> class.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Flags">
@@ -379,18 +331,7 @@
       <Docs>
         <summary>Gets or sets the store permissions.</summary>
         <value>A bitwise combination of the <see cref="T:System.Security.Permissions.StorePermissionFlags" /> values. The default is <see cref="F:System.Security.Permissions.StorePermissionFlags.NoFlags" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!CAUTION]
->  Many of these flags are powerful and permit access to stores that should be granted only to highly trusted code.
-
- The most powerful of the flags are <xref:System.Security.Permissions.StorePermissionFlags.AddToStore>, <xref:System.Security.Permissions.StorePermissionFlags.CreateStore>, <xref:System.Security.Permissions.StorePermissionFlags.DeleteStore>, and <xref:System.Security.Permissions.StorePermissionFlags.AllFlags>. For specific threats posed by the use of these flags, see individual flag descriptions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OpenStore">
@@ -425,14 +366,7 @@
         <summary>Gets or sets a value indicating whether the code is permitted to open a store.</summary>
         <value>
           <see langword="true" /> if the ability to open a store is allowed; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The ability to open a store does not include the ability to enumerate certificates (which raises privacy concerns) or to add or remove certificates (which raises security concerns).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemoveFromStore">
@@ -467,14 +401,7 @@
         <summary>Gets or sets a value indicating whether the code is permitted to remove a certificate from a store.</summary>
         <value>
           <see langword="true" /> if the ability to remove a certificate from a store is allowed; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This ability should be granted only to highly trusted code because removing a certificate can result in a denial of service.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/StorePermissionFlags.xml
+++ b/xml/System.Security.Permissions/StorePermissionFlags.xml
@@ -48,8 +48,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
-Many of these access permissions pose potential security and privacy threats. Great care should be taken in granting access to stores. A brief description of the type of threat exposed by an access can be found in the summary for the individual enumeration member.  
-
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Security.Permissions/StrongNameIdentityPermission.xml
+++ b/xml/System.Security.Permissions/StrongNameIdentityPermission.xml
@@ -47,23 +47,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
-> [!IMPORTANT]
->  Starting with the .NET Framework 4, identity permissions are not used.
->
->  In the .NET Framework versions 1.0 and 1.1, identity permissions cannot have an <xref:System.Security.Permissions.PermissionState.Unrestricted> permission state value. In the .NET Framework version 2.0 and later, identity permissions can have any permission state value.  This means that in version 2.0 and later versions, identity permissions have the same behavior as permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface. That is, a demand for an identity always succeeds, regardless of the identity of the assembly, if the assembly has been granted full trust.
-
- Use <xref:System.Security.Permissions.StrongNameIdentityPermission> to confirm that the calling code is in a particular strong-named code assembly. Full demands for <xref:System.Security.Permissions.StrongNameIdentityPermission> succeed only if all the assemblies in the stack have the correct evidence to satisfy the demand. Link demands that use the <xref:System.Security.Permissions.StrongNameIdentityPermissionAttribute> attribute succeed only if the immediate caller has the correct evidence.
-
- A strong name identity is based on a cryptographic public key called a binary large object (BLOB), which is optionally combined with the name and version of a specific assembly. The key defines a unique namespace and provides strong verification that the name is genuine, because the definition of the name must be in an assembly that is signed by the corresponding private key.
-
- Note that the validity of the strong name key is not dependent on a trust relationship or on any certificate necessarily being issued for the key.
-
- In the .NET Framework versions 1.0 and 1.1, demands on the identity permissions are effective even when the calling assembly is fully trusted. That is, even if the calling assembly has full trust, a demand for an identity permission fails if the assembly does not meet the demanded criteria. In the .NET Framework version 2.0 and later, demands for identity permissions are ineffective if the calling assembly has full trust. This ensures consistency for all permissions and eliminates the treatment of identity permissions as a special case.
-
- For a complete description of strong names, see the <xref:System.Security.Policy.StrongName> reference page. For more information about strong-named assemblies, see [Strong-named assemblies](/dotnet/standard/assembly/strong-named).
-
- The <xref:System.Security.Permissions.StrongNameIdentityPermission> class is used to define strong-name requirements for accessing the public members of a type. The <xref:System.Security.Permissions.StrongNameIdentityPermissionAttribute> attribute can be used to define strong-name requirements at the assembly level. In the .NET Framework version 2.0 and later, you can also use the <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> attribute to specify that all nonpublic types in that assembly are visible to another assembly. For more information, see [Friend assemblies](/dotnet/standard/assembly/friend).
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.StrongNameIdentityPermission" />
@@ -117,21 +100,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.StrongNameIdentityPermission" /> class with the specified <see cref="T:System.Security.Permissions.PermissionState" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates either a fully restricted (`None`) or `Unrestricted` permission.
-
-> [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, identity permissions cannot have an <xref:System.Security.Permissions.PermissionState.Unrestricted> permission state value. In the .NET Framework version 2.0 and later, identity permissions can have any permission state value.  This means that in version 2.0 and later versions, identity permissions have the same behavior as permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface. That is, a demand for an identity always succeeds, regardless of the identity of the assembly, if the assembly has been granted full trust.
-
- In the .NET Framework versions 1.0 and 1.1, demands on the identity permissions are effective, even when the calling assembly is fully trusted. That is, although the calling assembly has full trust, a demand for an identity permission fails if the assembly does not meet the demanded criteria. In the .NET Framework version 2.0 and later, demands for identity permissions are ineffective if the calling assembly has full trust. This assures consistency for all permissions, eliminating the treatment of identity permissions as a special case.
-
- Use this constructor with a permission state value of <xref:System.Security.Permissions.PermissionState.None> to create an identity permission that matches no strong names. If you subsequently set the <xref:System.Security.Permissions.StrongNameIdentityPermission.Name*> and <xref:System.Security.Permissions.StrongNameIdentityPermission.Version*> properties, a specific strong name identity can be represented by the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -172,16 +141,7 @@
         <param name="name">The simple name part of the strong name identity. This corresponds to the name of the assembly.</param>
         <param name="version">The version number of the identity.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.StrongNameIdentityPermission" /> class for the specified strong name identity.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The `name` and `version` parameters can be `null` only when the public key is used to identify the assembly. An empty string ("") should not be used in place of `null`. If `name` is an empty string, an <xref:System.ArgumentException> is thrown.
-
- For more information on names and version numbers of assemblies, see [Strong-named assemblies](/dotnet/standard/assembly/strong-named).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="blob" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <paramref name="name" /> parameter is an empty string ("").</exception>
       </Docs>
@@ -220,14 +180,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -266,14 +219,7 @@
       <Docs>
         <param name="e">The XML encoding to use to reconstruct the permission.</param>
         <summary>Reconstructs a permission with a specified state from an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is not used by application code.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="e" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <paramref name="e" /> parameter is not a valid permission element.
 
@@ -319,16 +265,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission, or <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- The intersection of two identical strong name identity permissions is the same permission. The intersection of two different (not wildcard) expressions is an empty permission. The intersection of a wildcard expression and a matching strong name is the strong name. The intersection of two wildcard expressions that match is the longer, more specific of the two expressions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -370,14 +307,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, the other properties being equal, an identity with the <xref:System.Security.Permissions.StrongNameIdentityPermission.Name> property containing the wildcard expression MyCompany.MyDepartment.* is identified as a subset of an identity with the <xref:System.Security.Permissions.StrongNameIdentityPermission.Name> property MyCompany.MyDepartment.MyFile.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -414,14 +344,7 @@
       <Docs>
         <summary>Gets or sets the simple name portion of the strong name identity.</summary>
         <value>The simple name of the identity.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The value of the <xref:System.Security.Permissions.StrongNameIdentityPermission.Name> property can be an exact name or can be modified by a wildcard character in the final position; for example, both MyCompany.MyDepartment.MyFile and MyCompany.MyDepartment.* are valid names. If you attempt to set the <xref:System.Security.Permissions.StrongNameIdentityPermission.Name> property to an empty string (""), an <xref:System.ArgumentException> is thrown.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The value is an empty string ("").</exception>
         <exception cref="T:System.NotSupportedException">The property value cannot be retrieved because it contains an ambiguous identity.</exception>
       </Docs>
@@ -498,14 +421,7 @@
       <Docs>
         <summary>Creates an XML encoding of the permission and its current state.</summary>
         <returns>An XML encoding of the permission, including any state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method is not typically used by application code.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -545,16 +461,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.StrongNameIdentityPermission.Union*> is a permission that represents all the operations represented by both the current permission and the specified permission. Any demand that passes either permission passes their union.
-
- The union of a permission and `null` is the permission that is not `null`. The union of a permission and a subset of that permission is the permission that contains the other. Any other combination results in an <xref:System.ArgumentException> exception being thrown.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.
 
  -or-

--- a/xml/System.Security.Permissions/StrongNameIdentityPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/StrongNameIdentityPermissionAttribute.xml
@@ -51,15 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
-> [!IMPORTANT]
-> Starting with .NET Framework 4, identity permissions are not used.
-
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used. You can obtain the key string for this attribute by running the Strong Name tool (Sn.exe) with the token and public key options (**Sn** **-tp** *keyfile*`)` against a file that has an Authenticode signature. For more information, see [Sn.exe (Strong Name Tool)](/dotnet/framework/tools/sn-exe-strong-name-tool).
-
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.
-
- The <xref:System.Security.Permissions.StrongNameIdentityPermissionAttribute> attribute can be used to define strong-name requirements for access to public members at the assembly level. In the .NET Framework version 2.0 and later, you can also use the <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> attribute to specify that all nonpublic types in that assembly are visible to another assembly. For more information, see [Friend assemblies](/dotnet/standard/assembly/friend).
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.StrongNameIdentityPermission" />
@@ -140,16 +131,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.StrongNameIdentityPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.StrongNameIdentityPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method should be called only by the security system, never by application code.
-
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The method failed because the key is <see langword="null" />.</exception>
       </Docs>
     </Member>
@@ -186,14 +168,7 @@
       <Docs>
         <summary>Gets or sets the name of the strong name identity.</summary>
         <value>A name to compare against the name specified by the security provider.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A strong-named assembly contains a public key, a name, and a version. The name portion of the strong name is the simple name of the assembly; that is, the name of the assembly without the file extension. For example, to reference mylibrary.dll, set the <xref:System.Security.Permissions.StrongNameIdentityPermissionAttribute.Name> property to "mylibrary".
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PublicKey">

--- a/xml/System.Security.Permissions/StrongNamePublicKeyBlob.xml
+++ b/xml/System.Security.Permissions/StrongNamePublicKeyBlob.xml
@@ -41,16 +41,12 @@
   <Docs>
     <summary>Represents the public key information (called a blob) for a strong name. This class cannot be inherited.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This class facilitates the use of strong names for identification purposes.  
-  
- For a complete description of strong names, see <xref:System.Security.Policy.StrongName>.  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.StrongNameIdentityPermission" />
@@ -171,14 +167,7 @@
       <Docs>
         <summary>Returns a hash code based on the public key.</summary>
         <returns>The hash code based on the public key.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Hash functions map binary strings of an arbitrary length to small binary strings of a fixed length, known as hash values.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">

--- a/xml/System.Security.Permissions/TypeDescriptorPermission.xml
+++ b/xml/System.Security.Permissions/TypeDescriptorPermission.xml
@@ -49,16 +49,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The <xref:System.Security.Permissions.TypeDescriptorPermission> class defines access to the following methods on the <xref:System.ComponentModel.TypeDescriptor> class.
-
-- <xref:System.ComponentModel.TypeDescriptor.AddProviderTransparent(System.ComponentModel.TypeDescriptionProvider,System.Object)>
-
-- <xref:System.ComponentModel.TypeDescriptor.AddProviderTransparent(System.ComponentModel.TypeDescriptionProvider,System.Type)>
-
-- <xref:System.ComponentModel.TypeDescriptor.RemoveProviderTransparent(System.ComponentModel.TypeDescriptionProvider,System.Object)>
-
-- <xref:System.ComponentModel.TypeDescriptor.RemoveProviderTransparent(System.ComponentModel.TypeDescriptionProvider,System.Type)>
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.ComponentModel.TypeDescriptor" />

--- a/xml/System.Security.Permissions/UIPermission.xml
+++ b/xml/System.Security.Permissions/UIPermission.xml
@@ -51,12 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Drawing and user input events in windows are user interfaces.
-
- The permission to use windows can be one of the following: unrestricted, limited to <xref:System.Security.Permissions.UIPermissionWindow.SafeTopLevelWindows>, only <xref:System.Security.Permissions.UIPermissionWindow.SafeSubWindows>, or no window drawing or user input event access allowed. <xref:System.Security.Permissions.UIPermissionWindow.SafeTopLevelWindows> and <xref:System.Security.Permissions.UIPermissionWindow.SafeSubWindows> are restricted in title and size to prevent possible spoofing by potentially harmful code.
-
- The permission to use the Clipboard can be one of the following: unrestricted, write-only, or no Clipboard access allowed. The paste limitation prevents potentially harmful applications from taking data from the Clipboard without the user's consent, while still allowing the cut, copy, and paste operations when initiated by the user through keyboard commands.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.UIPermissionAttribute" />
@@ -107,14 +101,7 @@
       <Docs>
         <param name="state">One of the enumeration values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.UIPermission" /> class with either fully restricted or unrestricted access, as specified.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor creates either the fully restricted (`None`) or the `Unrestricted` form of the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -151,14 +138,7 @@
       <Docs>
         <param name="clipboardFlag">One of the enumeration values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.UIPermission" /> class with the permissions for the Clipboard, and no access to windows.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- To set both the Clipboard and window permissions, use the constructor that takes parameters for both.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="clipboardFlag" /> parameter is not a valid <see cref="T:System.Security.Permissions.UIPermissionClipboard" /> value.</exception>
       </Docs>
     </Member>
@@ -195,14 +175,7 @@
       <Docs>
         <param name="windowFlag">One of the enumeration values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.UIPermission" /> class with the permissions for windows, and no access to the Clipboard.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- To set both the Clipboard and window permissions, use the constructor that takes parameters for both.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="windowFlag" /> parameter is not a valid <see cref="T:System.Security.Permissions.UIPermissionWindow" /> value.</exception>
       </Docs>
     </Member>
@@ -319,14 +292,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of the permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -411,14 +377,7 @@
         <param name="target">A permission to intersect with the current permission. It must be the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Specifically, it represents the least permissive values of <xref:System.Security.Permissions.UIPermissionWindow> and <xref:System.Security.Permissions.UIPermissionClipboard> from those in the current permission and the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -460,14 +419,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if all demands that succeed for the current permission also succeed for the specified permission. That is, the specified permission contains at least the permissions contained in the subset. For <xref:System.Security.Permissions.UIPermission.IsSubsetOf*> to return `true`, both the <xref:System.Security.Permissions.UIPermissionWindow> and <xref:System.Security.Permissions.UIPermissionClipboard> values of the current permission must be equal to or less permissive than the values of the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -509,14 +461,7 @@
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the current permission is unrestricted; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- An unrestricted permission represents access to any and all resources protected by the permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -593,14 +538,7 @@
         <param name="target">A permission to combine with the current permission. It must be the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.UIPermission.Union*> is a permission that represents all the operations represented by the current permission as well as all the operations represented by the specified permission. Specifically, it represents the most permissive values of <xref:System.Security.Permissions.UIPermissionWindow> and <xref:System.Security.Permissions.UIPermissionClipboard> from those in the current permission and the specified permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Permissions/UIPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/UIPermissionAttribute.xml
@@ -45,16 +45,12 @@
   <Docs>
     <summary>Allows security actions for <see cref="T:System.Security.Permissions.UIPermission" /> to be applied to code using declarative security. This class cannot be inherited.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.  
-  
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.UIPermission" />
@@ -169,16 +165,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.UIPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.UIPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method should only be called by the security system, never by application code.  
-  
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Window">

--- a/xml/System.Security.Permissions/UIPermissionClipboard.xml
+++ b/xml/System.Security.Permissions/UIPermissionClipboard.xml
@@ -40,14 +40,12 @@
   <Docs>
     <summary>Specifies the type of clipboard access that is allowed to the calling code.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This enumeration is used by <xref:System.Security.Permissions.UIPermission>.  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.UIPermission" />

--- a/xml/System.Security.Permissions/UIPermissionWindow.xml
+++ b/xml/System.Security.Permissions/UIPermissionWindow.xml
@@ -46,44 +46,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
-This enumeration is used by <xref:System.Security.Permissions.UIPermission>.
-
-When an application runs under the `SafeTopLevelWindows` permission, it:
-
-- Shows the DNS name or IP address of the Web site from which the application was loaded in its title bar.
-
-- Displays Balloon tooltip when it first displays, informing the user that it is running under a restricted trust level.
-
-- Must display its title bar at all times.
-
-- Must display window controls on its forms.
-
-- Cannot minimize its main window on startup.
-
-- Cannot move its windows off-screen.
-
-- Cannot use the <xref:System.Windows.Forms.Form.Opacity?displayProperty=nameWithType> property to make its windows less than 50% transparent.
-
-- Must use only rectangular windows, and must include the window frame. Windows Forms will not honor setting <xref:System.Windows.Forms.Form.FormBorderStyle*?displayProperty=nameWithType> to <xref:System.Windows.Forms.FormBorderStyle.None?displayProperty=nameWithType>.
-
-- Cannot make windows invisible. Any attempt by the application to set the <xref:System.Windows.Forms.Control.Visible?displayProperty=nameWithType> property to `False` will be ignored.
-
-- Must have an entry in the Task Bar.
-
-- Has its controls prohibited from accessing the <xref:System.Windows.Forms.Control.Parent> property. By implication, controls will also be barred from accessing siblings - that is, other controls at the same level of nesting.
-
-- Cannot control focus using the <xref:System.Windows.Forms.Control.Focus*?displayProperty=nameWithType> method.
-
-- Has restricted keyboard input access, so that a form or control can only access keyboard events for itself and its children.
-
-- Has restricted mouse coordinate access, so that a form or control can only read mouse coordinates if the mouse is over its visible area.
-
-- Cannot set the <xref:System.Windows.Forms.Form.TopMost?displayProperty=nameWithType> property.
-
-- Cannot control the z-order of controls on the form using the <xref:System.Windows.Forms.Control.BringToFront*?displayProperty=nameWithType> and <xref:System.Windows.Forms.Control.SendToBack*?displayProperty=nameWithType> methods.
-
- These restrictions help prevent potentially harmful code from spoofing attacks, such as imitating trusted system dialogs.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.UIPermission" />
@@ -229,12 +191,7 @@ When an application runs under the `SafeTopLevelWindows` permission, it:
       <MemberValue>2</MemberValue>
       <Docs>
         <summary>Users can only use <see cref="F:System.Security.Permissions.UIPermissionWindow.SafeTopLevelWindows" /> and <see cref="F:System.Security.Permissions.UIPermissionWindow.SafeSubWindows" /> for drawing, and can only use user input events for the user interface within those top-level windows and subwindows. See the Remarks section for more information.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/UrlIdentityPermission.xml
+++ b/xml/System.Security.Permissions/UrlIdentityPermission.xml
@@ -47,21 +47,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The complete URL is considered, including the protocol (HTTP, HTTPS, FTP) and the file. For example, `http://www.fourthcoffee.com/process/grind.htm` is a complete URL.
-
- URLs can be matched exactly or by a wildcard in the final position, for example: `http://www.fourthcoffee.com/process/*`. URLs can also contain a wildcard ("\*") prefix at the dot delimiter. For example, the URL name string `http://www.fourthcoffee.com/process/grind.htm/` is a subset of `http://*.fourthcoffee.com/process/grind.htm/` and `http://*.com/process/grind.htm/`.
-
-> [!IMPORTANT]
->  Starting with the .NET Framework 4, identity permissions are not used.
->
->  In the .NET Framework versions 1.0 and 1.1, demands on the identity permissions are effective even when the calling assembly is fully trusted. That is, although the calling assembly has full trust, a demand for an identity permission fails if the assembly does not meet the demanded criteria. Starting with the .NET Framework version 2.0, demands for identity permissions are ineffective if the calling assembly has full trust. That is, a demand for an identity always succeeds, regardless of the identity of the assembly, if the assembly has been granted full trust. This assures consistency for all permissions, eliminating the treatment of identity permissions as a special case.
-
-> [!NOTE]
->  In versions of the .NET Framework before the .NET Framework 4, you could use the <xref:System.Security.CodeAccessPermission.Deny*?displayProperty=nameWithType> method to prevent inadvertent access to system resources by trusted code. <xref:System.Security.CodeAccessPermission.Deny*> is now obsolete, and access to resources is now determined solely by the granted permission set for an assembly. To limit access to files, you must run partially trusted code in a sandbox and assign it permissions only to resources that the code is allowed to access. For information about running an application in a sandbox, see [How to: Run Partially Trusted Code in a Sandbox](/dotnet/framework/misc/how-to-run-partially-trusted-code-in-a-sandbox).
-
-> [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, identity permissions cannot have an <xref:System.Security.Permissions.PermissionState.Unrestricted> permission state value. Starting with the .NET Framework version 2.0, identity permissions can have any permission state value. This means that in 2.0 and later versions, identity permissions have the same behavior as permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.UrlIdentityPermissionAttribute" />
@@ -112,19 +97,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.UrlIdentityPermission" /> class with the specified <see cref="T:System.Security.Permissions.PermissionState" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates either a fully restricted (`None`) or `Unrestricted` permission.
-
-> [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, identity permissions cannot have an <xref:System.Security.Permissions.PermissionState.Unrestricted> permission state value. Starting with the .NET Framework version 2.0, identity permissions can have any permission state value. This means that in 2.0 and later versions, identity permissions have the same behavior as permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface. That is, a demand for an identity always succeeds, regardless of the identity of the assembly, if the assembly has been granted full trust.
-
- In the .NET Framework versions 1.0 and 1.1, demands on the identity permissions are effective, even when the calling assembly is fully trusted. That is, although the calling assembly has full trust, a demand for an identity permission fails if the assembly does not meet the demanded criteria. Starting with the .NET Framework version 2.0, demands for identity permissions are ineffective if the calling assembly has full trust. This assures consistency for all permissions, eliminating the treatment of identity permissions as a special case.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -161,19 +134,7 @@
       <Docs>
         <param name="site">A URL or wildcard expression.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.UrlIdentityPermission" /> class to represent the URL identity described by <paramref name="site" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The complete URL is considered, including the protocol (HTTP, HTTPS, FTP) and the file, for example: `http://www.fourthcoffee.com/process/grind.htm/`.
-
- URLs can be matched exactly or by a wildcard in the final position, for example: `http://www.fourthcoffee.com/process/*`. URLs can also contain a wildcard ("\*") prefix at the dot delimiter. For example, the URL name string `http://www.fourthcoffee.com/process/grind.htm/` is a subset of `http://*.fourthcoffee.com/process/grind.htm/` and `http://*.com/process/grind.htm/`.
-
-> [!NOTE]
->  Starting with the .NET Framework version 2.0, for performance reasons, an invalid URL does not cause an argument exception at the time the new class instance is created.  The argument exception will occur when one of the set operations (Union, Intersect, or IsSubsetOf) is executed.  A demand on the permission causes <xref:System.Security.Permissions.UrlIdentityPermission.IsSubsetOf*> to be called by the security infrastructure. The demand will fail because of the argument exception, resulting in a <xref:System.Security.SecurityException> being thrown. In this case, the original <xref:System.ArgumentException> exception will not be seen.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="site" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.FormatException">The length of the <paramref name="site" /> parameter is zero.</exception>
         <exception cref="T:System.ArgumentException">The URL, directory, or site portion of the <paramref name="site" /> parameter is not valid.</exception>
@@ -213,14 +174,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -305,16 +259,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes access to the URLs they both describe in common. Only a demand that passes both original permissions will pass the intersection. For example, the intersection of a permission that represents access to `http://www.fourthcoffee.com/process/grind.htm` and a permission that represents access to `http://www.fourthcoffee.com/*` is a permission that represents access to `http://www.fourthcoffee.com/process/grind.htm`.
-
- <xref:System.Security.Permissions.UrlIdentityPermission> supports set operations (<xref:System.Security.Permissions.UrlIdentityPermission.IsSubsetOf*>, <xref:System.Security.Permissions.UrlIdentityPermission.Intersect*>, and <xref:System.Security.Permissions.UrlIdentityPermission.Union*>) only when the current permission is equal to the specified permission object or when one of the permissions uses the wildcard operator ("\*").
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.
 
  -or-
@@ -360,16 +305,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the current permission identifies access to a URL that is wholly contained by the specified permission. For example, a permission that represents access to `http://www.fourthcoffee.com/process/grind.htm` is a subset of a permission that represents access to `http://www.fourthcoffee.com/*`. If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
- <xref:System.Security.Permissions.UrlIdentityPermission> supports set operations (<xref:System.Security.Permissions.UrlIdentityPermission.IsSubsetOf*>, <xref:System.Security.Permissions.UrlIdentityPermission.Intersect*>, and <xref:System.Security.Permissions.UrlIdentityPermission.Union*>) only when the current permission is equal to the specified permission or when one of the permissions uses the wildcard operator ("\*").
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.
 
  -or-
@@ -451,16 +387,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to the <xref:System.Security.Permissions.UrlIdentityPermission.Union*> method is a permission that represents access to the URL as represented by the current permission, as well as access to the URL as represented by the specified permission.
-
- The <xref:System.Security.Permissions.UrlIdentityPermission> class supports set operations <xref:System.Security.Permissions.UrlIdentityPermission.IsSubsetOf*>, <xref:System.Security.Permissions.UrlIdentityPermission.Intersect*>, and <xref:System.Security.Permissions.UrlIdentityPermission.Union*>) only when the current permission is equal to the specified permission, or when one of the permissions uses the wildcard operator ("\*") and one is a subset of the other.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.
 
  -or-
@@ -506,16 +433,7 @@
       <Docs>
         <summary>Gets or sets a URL representing the identity of Internet code.</summary>
         <value>A URL representing the identity of Internet code.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The complete URL is considered, including the protocol (HTTP, HTTPS, FTP) and the file, for example: `http://www.fourthcoffee.com/process/grind.htm/`.
-
- URLs can be matched exactly or by a wildcard in the final position, for example: `http://www.fourthcoffee.com/process/*`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.NotSupportedException">The URL cannot be retrieved because it has an ambiguous identity.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Permissions/UrlIdentityPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/UrlIdentityPermissionAttribute.xml
@@ -45,21 +45,12 @@
   <Docs>
     <summary>Allows security actions for <see cref="T:System.Security.Permissions.UrlIdentityPermission" /> to be applied to code using declarative security. This class cannot be inherited.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The complete URL is considered, including the protocol (HTTP, HTTPS, FTP) and the file. For example, `http://www.fourthcoffee.com/process/grind.htm` is a complete URL.  
-  
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.  
-  
-> [!IMPORTANT]
-> Starting with .NET Framework 4, identity permissions are not used.
-  
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.UrlIdentityPermission" />
@@ -138,16 +129,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.UrlIdentityPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.UrlIdentityPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method should only be called by the security system, never by application code.  
-  
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Url">
@@ -183,16 +165,7 @@
       <Docs>
         <summary>Gets or sets the full URL of the calling code.</summary>
         <value>The URL to match with the URL specified by the host.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The complete URL is considered, including the protocol (HTTP, HTTPS, FTP) and the file, for example: `http://www.fourthcoffee.com/process/grind.htm/`.  
-  
- URLs can be matched exactly or by a wildcard in the final position, for example: `http://www.fourthcoffee.com/process/*`.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/WebBrowserPermission.xml
+++ b/xml/System.Security.Permissions/WebBrowserPermission.xml
@@ -52,11 +52,9 @@
     <summary>The <see cref="T:System.Security.Permissions.WebBrowserPermission" /> object controls the ability to create the WebBrowser control.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[
+
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
-In Windows Presentation Foundation (WPF), the Web browser control enables frames to navigate HTML. This permission uses the values of the <xref:System.Security.Permissions.WebBrowserPermission> enumerations.
-
-This class is not typically used in XAML.
       ]]></format>
     </remarks>
   </Docs>
@@ -97,14 +95,7 @@ This class is not typically used in XAML.
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.WebBrowserPermission" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- By default, the value of the <xref:System.Security.Permissions.WebBrowserPermission.Level> property is set to <xref:System.Security.Permissions.WebBrowserPermissionLevel.Safe>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -138,14 +129,7 @@ This class is not typically used in XAML.
       <Docs>
         <param name="state">An enumerated value of <see cref="T:System.Security.Permissions.PermissionState" />.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.WebBrowserPermission" /> class by specifying a permission state.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If `state` is set to <xref:System.Security.Permissions.PermissionState.Unrestricted>, the value of the <xref:System.Security.Permissions.WebBrowserPermission.Level> property is set to <xref:System.Security.Permissions.WebBrowserPermissionLevel.Unrestricted>. If `state` is set to <xref:System.Security.Permissions.PermissionState.None>, the value of the <xref:System.Security.Permissions.WebBrowserPermission.Level> property is set to <xref:System.Security.Permissions.WebBrowserPermissionLevel.None>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -214,7 +198,7 @@ This class is not typically used in XAML.
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>A copy of a permission represents the same access to resources as the original permission. Members of this class are either not typically used in XAML, or cannot be used in XAML.</remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -251,13 +235,7 @@ This class is not typically used in XAML.
       <Docs>
         <param name="securityElement">The XML encoding to use to reconstruct the permission.</param>
         <summary>Reconstructs a permission with a specified state from an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-Members of this class are either not typically used in XAML, or cannot be used in XAML.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Intersect">
@@ -295,13 +273,7 @@ Members of this class are either not typically used in XAML, or cannot be used i
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>The intersection of two permissions is a permission that describes the state that they both describe in common. Only a demand that passes both original permissions will be valid for the intersected permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-Members of this class are either not typically used in XAML, or cannot be used in XAML.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSubsetOf">
@@ -340,19 +312,7 @@ Members of this class are either not typically used in XAML, or cannot be used i
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-The current permission is a subset of the specified permission if the current permission specifies a set of operations that is wholly contained by the specified permission. For example, a permission that represents access to C:\example.txt is a subset of a permission that represents access to C:\\.
-
-If this method returns `true`, the current permission represents no more access to the protected resource than does the specified permission.
-
-Members of this class are either not typically used in XAML, or cannot be used in XAML.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsUnrestricted">
@@ -391,17 +351,7 @@ Members of this class are either not typically used in XAML, or cannot be used i
         <summary>Returns a value indicating whether the current permission is unrestricted.</summary>
         <returns>
           <see langword="true" /> if the <see cref="P:System.Security.Permissions.WebBrowserPermission.Level" /> property is set to <see cref="F:System.Security.Permissions.WebBrowserPermissionLevel.Unrestricted" />; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-An unrestricted permission represents access to any and all resources protected by the permission.
-
-Members of this class are either not typically used in XAML, or cannot be used in XAML.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Level">
@@ -470,13 +420,7 @@ Members of this class are either not typically used in XAML, or cannot be used i
       <Docs>
         <summary>Creates an XML encoding of the permission and its current state.</summary>
         <returns>An XML encoding of the permission, including any state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-Members of this class are either not typically used in XAML, or cannot be used in XAML.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Union">
@@ -514,13 +458,7 @@ Members of this class are either not typically used in XAML, or cannot be used i
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-Members of this class are either not typically used in XAML, or cannot be used in XAML.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Permissions/WebBrowserPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/WebBrowserPermissionAttribute.xml
@@ -52,13 +52,8 @@
     <summary>Allows security actions for <see cref="T:System.Security.Permissions.WebBrowserPermission" /> to be applied to code using declarative security.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[
+
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
-
-<xref:System.Security.Permissions.WebBrowserPermissionAttribute> controls the ability of a Web browser control to run in a Windows Presentation Foundation (WPF) application. The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.
-
-The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class, <xref:System.Security.Permissions.WebBrowserPermission>.
-
-This class is not typically used in XAML.
 
       ]]></format>
     </remarks>
@@ -96,7 +91,7 @@ This class is not typically used in XAML.
       <Docs>
         <param name="action">One of the <see cref="T:System.Security.Permissions.SecurityAction" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.WebBrowserPermissionAttribute" /> class with the specified <see cref="T:System.Security.Permissions.SecurityAction" />.</summary>
-        <remarks>Members of this class are either not typically used in XAML, or cannot be used in XAML.</remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreatePermission">
@@ -131,19 +126,7 @@ This class is not typically used in XAML.
       <Docs>
         <summary>Creates and returns a new instance of the <see cref="T:System.Security.Permissions.WebBrowserPermission" /> class.</summary>
         <returns>A <see cref="T:System.Security.Permissions.WebBrowserPermission" /> corresponding to the security declaration.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-The <xref:System.Security.Permissions.WebBrowserPermissionAttribute.CreatePermission*> method is called by the security system, not by application code.
-
-The security information described by <xref:System.Security.Permissions.WebBrowserPermissionAttribute> is stored in the metadata of the attribute target, which is the class to which <xref:System.Security.Permissions.WebBrowserPermissionAttribute> is applied. The system accesses the information at run time. The system uses the <xref:System.Security.Permissions.WebBrowserPermission> returned by <xref:System.Security.Permissions.WebBrowserPermissionAttribute.CreatePermission*> to convert the security information of the attribute target to a serializable form stored in metadata.
-
-Members of this class are either not typically used in XAML, or cannot be used in XAML.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Level">

--- a/xml/System.Security.Permissions/WebBrowserPermissionLevel.xml
+++ b/xml/System.Security.Permissions/WebBrowserPermissionLevel.xml
@@ -52,14 +52,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Use this enumeration to set the <xref:System.Security.Permissions.WebBrowserPermission.Level> property of the <xref:System.Security.Permissions.WebBrowserPermission> class.
-
- The Safe permission level restricts the following Web browser operations.
-
-- A pop-up window cannot be created over the Web browser control.
-- The Web browser control can only be navigated to its site of origin.
-- The security settings of the Web browser control are reduced.
-
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Security.Permissions/ZoneIdentityPermission.xml
+++ b/xml/System.Security.Permissions/ZoneIdentityPermission.xml
@@ -47,21 +47,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This permission can determine whether calling code is from a certain zone. Zones are configured according to the Internet options, and are mapped from URL by IInternetSecurityManager and related APIs. Only exact zone matches are defined for the permission; a URL can only belong to one zone.
-
-- Local intranet zone: The Local intranet zone is used for content located on a company's intranet. Because the servers are within a company's firewall, content on the intranet is assigned a higher level of trust.
-
-- Trusted sites zone: The Trusted sites zone is used for content located on Web sites that are considered more reputable or trustworthy than other sites on the Internet. Users can use this zone to assign a higher level of trust to specific Internet sites. The URLs of these trusted Web sites need to be mapped into this zone by the user. By default, sites in the Trusted sites zone receive no higher trust than those in the Internet zone. A user or company needs to change the level of trust granted to this zone if they want the sites it contains to be given a higher level of trust.
-
-- Internet zone: The Internet zone is used for the Web sites on the Internet that do not belong to another zone. The default settings allow code downloaded from these sites only minimal access to resources on the user's computer. Web sites that are not mapped into other zones automatically fall into this zone.
-
-- Restricted sites zone: The Restricted sites zone is used for Web sites that contain content that could cause, or could have previously caused, problems when downloaded. This zone could be used to prevent code downloaded from these sites from running on the user's computer. The URLs of these untrusted Web sites need to be mapped into this zone by the user.
-
-- Local Machine zone: The Local Machine zone is an implicit zone that is used for content that exists on the user's computer. The content found on the user's computer, except for content cached by Internet Explorer on the local system, is treated with a very high level of trust.
-
-> [!IMPORTANT]
-> Starting with .NET Framework 4, identity permissions are not used.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.ZoneIdentityPermissionAttribute" />
@@ -112,19 +97,7 @@
       <Docs>
         <param name="state">One of the <see cref="T:System.Security.Permissions.PermissionState" /> values.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Permissions.ZoneIdentityPermission" /> class with the specified <see cref="T:System.Security.Permissions.PermissionState" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Creates either a fully restricted (`None`) or `Unrestricted` permission.
-
-> [!NOTE]
->  In the .NET Framework versions 1.0 and 1.1, identity permissions cannot have an <xref:System.Security.Permissions.PermissionState.Unrestricted> permission state value. Starting with the .NET Framework version 2.0, identity permissions can have any permission state value. This means that in 2.0 and later versions, identity permissions have the same behavior as permissions that implement the <xref:System.Security.Permissions.IUnrestrictedPermission> interface. That is, a demand for an identity always succeeds, regardless of the identity of the assembly, if the assembly has been granted full trust.
-
- In the .NET Framework versions 1.0 and 1.1, demands on the identity permissions are effective, even when the calling assembly is fully trusted. That is, although the calling assembly has full trust, a demand for an identity permission fails if the assembly does not meet the demanded criteria. Starting with the .NET Framework version 2.0, demands for identity permissions are ineffective if the calling assembly has full trust. This assures consistency for all permissions, eliminating the treatment of identity permissions as a special case.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="state" /> parameter is not a valid value of <see cref="T:System.Security.Permissions.PermissionState" />.</exception>
       </Docs>
     </Member>
@@ -198,14 +171,7 @@
       <Docs>
         <summary>Creates and returns an identical copy of the current permission.</summary>
         <returns>A copy of the current permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A copy of a permission represents the same access to resources as the original permission.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FromXml">
@@ -290,16 +256,7 @@
         <param name="target">A permission to intersect with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates and returns a permission that is the intersection of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the intersection of the current permission and the specified permission. This new permission is <see langword="null" /> if the intersection is empty.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The intersection of two permissions is a permission that describes the set of operations they both describe in common. Only a demand that passes both original permissions will pass the intersection.
-
- The intersection of two identical <xref:System.Security.Permissions.ZoneIdentityPermission> objects is the same permission. Any other combination results in a permission that is `null`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.</exception>
       </Docs>
     </Member>
@@ -341,14 +298,7 @@
         <summary>Determines whether the current permission is a subset of the specified permission.</summary>
         <returns>
           <see langword="true" /> if the current permission is a subset of the specified permission; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The current permission is a subset of the specified permission if the two permissions are equal or if the current permission represents the <xref:System.Security.SecurityZone.NoZone> security zone.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" />, this permission does not represent the <see cref="F:System.Security.SecurityZone.NoZone" /> security zone, and the specified permission is not equal to the current permission.</exception>
       </Docs>
     </Member>
@@ -463,16 +413,7 @@
         <param name="target">A permission to combine with the current permission. It must be of the same type as the current permission.</param>
         <summary>Creates a permission that is the union of the current permission and the specified permission.</summary>
         <returns>A new permission that represents the union of the current permission and the specified permission.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The result of a call to <xref:System.Security.Permissions.ZoneIdentityPermission.Union*> is a permission that represents the security zone represented by both the current permission and the specified permission. Any demand that passes either permission passes their union. The union of two identical <xref:System.Security.Permissions.ZoneIdentityPermission> objects is the same permission. The union of a null permission and a <xref:System.Security.Permissions.ZoneIdentityPermission> permission is the permission that is not null.
-
- Note that a <xref:System.Security.Permissions.ZoneIdentityPermission> object representing a <xref:System.Security.SecurityZone.NoZone> security zone is treated as a null permission and handled as a special case. The union of a <xref:System.Security.Permissions.ZoneIdentityPermission> object representing the <xref:System.Security.SecurityZone.NoZone> security zone and a null permission is null. The union of two different zone identity permissions results in an <xref:System.ArgumentException> exception being thrown when neither of the two permissions represents the <xref:System.Security.SecurityZone.NoZone> security zone.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="target" /> parameter is not <see langword="null" /> and is not of the same type as the current permission.
 
  -or-

--- a/xml/System.Security.Permissions/ZoneIdentityPermissionAttribute.xml
+++ b/xml/System.Security.Permissions/ZoneIdentityPermissionAttribute.xml
@@ -45,19 +45,12 @@
   <Docs>
     <summary>Allows security actions for <see cref="T:System.Security.Permissions.ZoneIdentityPermission" /> to be applied to code using declarative security. This class cannot be inherited.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The scope of the declaration that is allowed depends on the <xref:System.Security.Permissions.SecurityAction> that is used.  
-  
-> [!IMPORTANT]
-> Starting with .NET Framework 4, identity permissions are not used.
-  
- The security information declared by a security attribute is stored in the metadata of the attribute target and is accessed by the system at run time. Security attributes are used only for declarative security. For imperative security, use the corresponding permission class.  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Permissions.ZoneIdentityPermission" />
@@ -136,16 +129,7 @@
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Security.Permissions.ZoneIdentityPermission" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.ZoneIdentityPermission" /> that corresponds to this attribute.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method should only be called by the security system, never by application code.  
-  
- At compile time, attributes convert security declarations to a serialized form in metadata. Declarative security data in metadata is created from the permission that this method returns that corresponds to this attribute.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Zone">


### PR DESCRIPTION
.NET Framework API ref has moved to its own repo (https://github.com/dotnet/dotnetfw-api-docs), so we can clean up .NET Framework remarks, exceptions, and code examples out of this repo. Contributes to #12513.

Removes remarks and examples related to:

- .NET Framework versions
- Code-access security
- Configuring apps via app.config file
- App domains

Also removes *all* remarks from obsolete APIs.

*Hide whitespace changes*