### PR TITLE
Remove .NET Framework remarks (System.Security.Policy)

### DIFF
--- a/xml/System.Security.Policy/ApplicationDirectory.xml
+++ b/xml/System.Security.Policy/ApplicationDirectory.xml
@@ -34,14 +34,7 @@
   <Interfaces />
   <Docs>
     <summary>Provides the application directory as evidence for policy evaluation. This class cannot be inherited.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The domain host can associate a file directory with an application domain. The evidence for policy evaluation is provided only when the application domain is associated with a file directory.  
-  
- ]]></format>
-    </remarks>
+    <remarks>The domain host can associate a file directory with an application domain. The evidence for policy evaluation is provided only when the application domain is associated with a file directory.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -78,11 +71,11 @@
         <param name="name">The path of the application directory.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Policy.ApplicationDirectory" /> class.</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Application code does not need to create instances of this class.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ Application code does not need to create instances of this class.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="name" /> parameter is <see langword="null" />.</exception>
@@ -200,11 +193,11 @@
         <returns>
           <see langword="true" /> if the two instances are equivalent; otherwise, <see langword="false" />.</returns>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The directory values of the two instances must match exactly. Equivalent noncanonical paths are not resolved. For example, C:\app and C:\temp\\...\app are not equal directory values.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ The directory values of the two instances must match exactly. Equivalent noncanonical paths are not resolved. For example, C:\app and C:\temp\\...\app are not equal directory values.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -281,11 +274,11 @@
         <summary>Gets a string representation of the state of the <see cref="T:System.Security.Policy.ApplicationDirectory" /> evidence object.</summary>
         <returns>A representation of the state of the <see cref="T:System.Security.Policy.ApplicationDirectory" /> evidence object.</returns>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method is useful during debugging to get an easy-to-read representation of the object.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ This method is useful during debugging to get an easy-to-read representation of the object.
+
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Security.Policy/ApplicationTrust.xml
+++ b/xml/System.Security.Policy/ApplicationTrust.xml
@@ -183,8 +183,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- `fullTrustAssemblies` identifies strong-named assemblies within the <xref:System.AppDomain> that are to be granted full trust. This constructor is called by the <xref:System.AppDomain.CreateDomain*?displayProperty=nameWithType> method to create an <xref:System.AppDomain> that will be used as a sandbox. For more information about running an application in a sandbox, see [How to: Run Partially Trusted Code in a Sandbox](/dotnet/framework/misc/how-to-run-partially-trusted-code-in-a-sandbox).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -413,8 +411,6 @@ The <xref:System.Security.ISecurityPolicyEncodable.ToXml*> and <xref:System.Secu
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
-
- The list identifies assemblies that are to be granted full trust within the <xref:System.AppDomain> that is associated with this <xref:System.Security.Policy.ApplicationTrust> instance. The assemblies are identified by their strong names.
 
  ]]></format>
         </remarks>

--- a/xml/System.Security.Policy/CodeGroup.xml
+++ b/xml/System.Security.Policy/CodeGroup.xml
@@ -34,16 +34,7 @@
   <Interfaces />
   <Docs>
     <summary>Represents the abstract base class from which all implementations of code groups must derive.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[
-
-## Remarks
- Code groups are the building blocks of code access security policy. Each policy level consists of a root code group that can have child code groups. Each child code group can have their own child code groups; this behavior extends to any number of levels, forming a tree. Each code group has a membership condition that determines if a given assembly belongs to it based on the evidence for that assembly.
-
- Only those code groups whose membership conditions match a given assembly's evidence will be applied. If a matching code group has child code groups, then those children whose membership conditions also match the supplied evidence will likewise be applied.
-
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -81,14 +72,7 @@
         <param name="membershipCondition">A membership condition that tests evidence to determine whether this code group applies policy.</param>
         <param name="policy">The policy statement for the code group in the form of a permission set and attributes to grant code that matches the membership condition.</param>
         <summary>Initializes a new instance of <see cref="T:System.Security.Policy.CodeGroup" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor creates a basic code group and should be called from the constructors of custom code groups. You can add child code groups using the <xref:System.Security.Policy.CodeGroup.AddChild*> method.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="membershipCondition" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The type of the <paramref name="membershipCondition" /> parameter is not valid.
 
@@ -171,14 +155,7 @@
       <Docs>
         <summary>Gets a string representation of the attributes of the policy statement for the code group.</summary>
         <value>A string representation of the attributes of the policy statement for the code group.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The string representation is not localized.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Children">
@@ -214,17 +191,7 @@
       <Docs>
         <summary>Gets or sets an ordered list of the child code groups of a code group.</summary>
         <value>A list of child code groups.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The order of child code groups is significant for certain code groups.
-
-> [!NOTE]
->  The return value is a copy of the child code list. Do not use the returned list to add a child code group; instead, use the <xref:System.Security.Policy.CodeGroup.AddChild*> method.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">An attempt is made to set this property to <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">An attempt is made to set this property with a list of children that are not <see cref="T:System.Security.Policy.CodeGroup" /> objects.</exception>
       </Docs>
@@ -263,14 +230,7 @@
       <Docs>
         <summary>When overridden in a derived class, makes a deep copy of the current code group.</summary>
         <returns>An equivalent copy of the current code group, including its membership conditions and child code groups.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method makes a deep copy of the code group, so that copies of all objects the code group contains are also made.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateXml">
@@ -311,16 +271,7 @@
         <param name="element">The XML encoding to which to add the serialization.</param>
         <param name="level">The policy level within which the code group exists.</param>
         <summary>When overridden in a derived class, serializes properties and internal state specific to a derived code group and adds the serialization to the specified <see cref="T:System.Security.SecurityElement" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.Policy.CodeGroup.ToXml*> cannot be overridden. If you need to serialize members specific to a particular implementation of <xref:System.Security.Policy.CodeGroup>, you must override <xref:System.Security.Policy.CodeGroup.CreateXml*> and serialize your members there. When the code group is serialized, <xref:System.Security.Policy.CodeGroup.ToXml*> calls <xref:System.Security.Policy.CodeGroup.CreateXml*> and adds your serialization to the <xref:System.Security.SecurityElement> created by <xref:System.Security.Policy.CodeGroup.ToXml*>.
-
- The XML created using this method is deserialized by the <xref:System.Security.Policy.CodeGroup.ParseXml*> method.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <block subset="none" type="overrides">
           <para>If you implement this method, you must implement the <see cref="M:System.Security.Policy.CodeGroup.ParseXml(System.Security.SecurityElement,System.Security.Policy.PolicyLevel)" /> method as well.</para>
         </block>
@@ -411,16 +362,7 @@
         <summary>Determines whether the specified code group is equivalent to the current code group.</summary>
         <returns>
           <see langword="true" /> if the specified code group is equivalent to the current code group; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Two code groups are equivalent if they have the same <xref:System.Security.Policy.CodeGroup.Name*>, <xref:System.Security.Policy.CodeGroup.Description*>, and <xref:System.Security.Policy.CodeGroup.MembershipCondition*>.
-
- This method tests the top-level code group only, not its child code groups.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -464,16 +406,7 @@
         <summary>Determines whether the specified code group is equivalent to the current code group, checking the child code groups as well, if specified.</summary>
         <returns>
           <see langword="true" /> if the specified code group is equivalent to the current code group; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Two code groups are equivalent if they have the same <xref:System.Security.Policy.CodeGroup.Name*>, <xref:System.Security.Policy.CodeGroup.Description*>, and <xref:System.Security.Policy.CodeGroup.MembershipCondition*>.
-
- If the `compareChildren` parameter is `true`, this method will only return `true` if the current code group and all its child code groups are equivalent to the specified code group and all its child code groups.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <MemberGroup MemberName="FromXml">
@@ -568,14 +501,7 @@
         <param name="e">The XML encoding to use to reconstruct the security object.</param>
         <param name="level">The policy level within which the code group exists.</param>
         <summary>Reconstructs a security object with a given state and policy level from an XML encoding.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The policy level context is provided for resolution of named permission sets.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="e" /> parameter is <see langword="null" />.</exception>
         <block subset="none" type="overrides">
           <para>
@@ -653,14 +579,7 @@
       <Docs>
         <summary>Gets or sets the code group's membership condition.</summary>
         <value>The membership condition that determines to which evidence the code group is applicable.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A membership condition tests evidence and returns a Boolean value that tells whether there is a match.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">An attempt is made to set this parameter to <see langword="null" />.</exception>
       </Docs>
     </Member>
@@ -777,16 +696,7 @@
         <param name="e">The XML encoding to use to reconstruct the security object.</param>
         <param name="level">The policy level within which the code group exists.</param>
         <summary>When overridden in a derived class, reconstructs properties and internal state specific to a derived code group from the specified <see cref="T:System.Security.SecurityElement" />.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.Policy.CodeGroup.FromXml*> cannot be overridden. If you need to deserialize members specific to a particular implementation of <xref:System.Security.Policy.CodeGroup>, you must override <xref:System.Security.Policy.CodeGroup.ParseXml*> and deserialize your members there. When the code group is deserialized, <xref:System.Security.Policy.CodeGroup.FromXml*> calls <xref:System.Security.Policy.CodeGroup.ParseXml*> and reconstructs your members from the <xref:System.Security.SecurityElement>.
-
- This method deserializes XML created using <xref:System.Security.Policy.CodeGroup.CreateXml*>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <block subset="none" type="overrides">
           <para>If you implement this method, you must implement the <see cref="M:System.Security.Policy.CodeGroup.CreateXml(System.Security.SecurityElement,System.Security.Policy.PolicyLevel)" /> method as well.</para>
         </block>
@@ -826,14 +736,7 @@
       <Docs>
         <summary>Gets the name of the named permission set for the code group.</summary>
         <value>The name of a named permission set of the policy level.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This property can be `null` if the code group contains an unnamed permission set.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PolicyStatement">
@@ -869,25 +772,7 @@
       <Docs>
         <summary>Gets or sets the policy statement associated with the code group.</summary>
         <value>The policy statement for the code group.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The policy statement applies to code in assemblies when evidence matches the membership condition.
-
- This property can also be set by passing a policy statement to the constructor.
-
-
-
-## Examples
- The following example sets the <xref:System.Security.Policy.PolicyStatement> for a code group.
-
- :::code language="cpp" source="~/snippets/cpp/VS_Snippets_CLR_Classic/classic CodeGroup.PolicyStatement Example/CPP/source.cpp" id="Snippet1":::
- :::code language="csharp" source="~/snippets/csharp/System.Security.Policy/CodeGroup/PolicyStatement/source.cs" id="Snippet1":::
- :::code language="vb" source="~/snippets/visualbasic/System.Security.Policy/CodeGroup/PolicyStatement/source.vb" id="Snippet1":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemoveChild">
@@ -926,14 +811,7 @@
       <Docs>
         <param name="group">The code group to be removed as a child.</param>
         <summary>Removes the specified child code group.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Only immediate child code groups can be removed with this method.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="group" /> parameter is not an immediate child code group of the current code group.</exception>
       </Docs>
     </Member>
@@ -974,18 +852,7 @@
         <param name="evidence">The evidence for the assembly.</param>
         <summary>When overridden in a derived class, resolves policy for the code group and its descendants for a set of evidence.</summary>
         <returns>A policy statement that consists of the permissions granted by the code group with optional attributes, or <see langword="null" /> if the code group does not apply (the membership condition does not match the specified evidence).</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Given evidence for an assembly to be loaded, this method evaluates the code group by checking the membership condition against the specified evidence. If there is a match, this method returns a policy statement for the code group, including evaluation of child code groups.
-
- For a <xref:System.Security.Policy.UnionCodeGroup>, all child code groups whose membership condition match the specified evidence are also resolved, and all resulting policy statements are combined with the policy statement of the parent union code group. Each child code group type determines how all child groups under it are applied, depending on how the <xref:System.Security.Policy.CodeGroup.Resolve*> methods of these child groups work.
-
- The .NET Framework security system uses <xref:System.Security.Policy.CodeGroup.Resolve*> on the policy levels to determine which permissions to grant to loaded code from the resulting policy statements and the code request on the assembly.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ResolveMatchingCodeGroups">
@@ -1025,14 +892,7 @@
         <param name="evidence">The evidence for the assembly.</param>
         <summary>When overridden in a derived class, resolves matching code groups.</summary>
         <returns>A <see cref="T:System.Security.Policy.CodeGroup" /> that is the root of the tree of matching code groups.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method has the same evaluation characteristics as <xref:System.Security.Policy.CodeGroup.Resolve*>. The code group that is returned contains child code groups, which in turn can have child code groups as necessary to reflect the complete set of code groups that were matched by the evidence provided.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <MemberGroup MemberName="ToXml">
@@ -1123,14 +983,7 @@
         <param name="level">The policy level within which the code group exists.</param>
         <summary>Creates an XML encoding of the security object, its current state, and the policy level within which the code exists.</summary>
         <returns>An XML encoding of the security object, including any state information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The policy level context is provided for resolution of named permission sets.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <block subset="none" type="overrides">
           <para>
             <see cref="M:System.Security.Policy.CodeGroup.FromXml(System.Security.SecurityElement)" /> and <see cref="M:System.Security.Policy.CodeGroup.ToXml" /> cannot be overridden. If you need to change the way in which your code group implementation handles XML, override the <see cref="M:System.Security.Policy.CodeGroup.ParseXml(System.Security.SecurityElement,System.Security.Policy.PolicyLevel)" /> and <see cref="M:System.Security.Policy.CodeGroup.CreateXml(System.Security.SecurityElement,System.Security.Policy.PolicyLevel)" /> methods.</para>

--- a/xml/System.Security.Policy/EvidenceBase.xml
+++ b/xml/System.Security.Policy/EvidenceBase.xml
@@ -44,17 +44,12 @@
   <Docs>
     <summary>Provides a base class from which all objects to be used as evidence must derive.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Before the .NET Framework 4, almost any object could be used as an evidence object if the hosting code wanted to apply it as evidence. For example, some .NET Framework code recognized <xref:System.Uri?displayProperty=nameWithType> objects as evidence. The common language runtime (CLR) considered evidence objects as <xref:System.Object?displayProperty=nameWithType> references, and did not apply any type safety to them.  
-  
- This presented a problem because there were implicit restrictions on which types could be used as evidence objects. Specifically, any object used as evidence had to be serializable and could not be `null`. If these requirements were not met, the CLR threw an exception whenever an operation that required one of these assumptions was performed.  
-  
- The <xref:System.Security.Policy.EvidenceBase> class, which all evidence objects must derive from, was introduced in the .NET Framework 4 to enable constraints on the types of objects that can be used as evidence and to provide the ability to add new features and requirements to all evidence objects. The <xref:System.Security.Policy.EvidenceBase> class ensures, upon instantiation, that the evidence object is serializable. In addition, it enables new evidence requirements to be created by adding new default implementations to the base class.  
-  
- All the types used by the CLR as evidence objects have been updated in the .NET Framework 4 to derive from <xref:System.Security.Policy.EvidenceBase>.  
-  
+      <format type="text/markdown"><![CDATA[
+
+## Remarks
+
+The <xref:System.Security.Policy.EvidenceBase> class, which all evidence objects must derive from, enables constraints on the types of objects that can be used as evidence and to provide the ability to add new features and requirements to all evidence objects. The <xref:System.Security.Policy.EvidenceBase> class ensures, upon instantiation, that the evidence object is serializable. In addition, it enables new evidence requirements to be created by adding new default implementations to the base class.
+
  ]]></format>
     </remarks>
   </Docs>
@@ -91,11 +86,11 @@
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Policy.EvidenceBase" /> class.</summary>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- All objects to be used as evidence must be serializable. You must mark any derived types as serializable, because the serializable attribute does not propagate to derived classes.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ All objects to be used as evidence must be serializable. You must mark any derived types as serializable, because the serializable attribute does not propagate to derived classes.
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">An object to be used as evidence is not serializable.</exception>
@@ -139,11 +134,11 @@
         <summary>Creates a new object that is a complete copy of the current instance.</summary>
         <returns>A duplicate copy of this evidence object.</returns>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The duplicate copy is a complete copy that includes all the evidence objects in the collection.  
-  
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+ The duplicate copy is a complete copy that includes all the evidence objects in the collection.
+
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Security.Policy/EvidenceBase.xml
+++ b/xml/System.Security.Policy/EvidenceBase.xml
@@ -48,7 +48,7 @@
 
 ## Remarks
 
-The <xref:System.Security.Policy.EvidenceBase> class, which all evidence objects must derive from, enables constraints on the types of objects that can be used as evidence and to provide the ability to add new features and requirements to all evidence objects. The <xref:System.Security.Policy.EvidenceBase> class ensures, upon instantiation, that the evidence object is serializable. In addition, it enables new evidence requirements to be created by adding new default implementations to the base class.
+The <xref:System.Security.Policy.EvidenceBase> class, which all evidence objects must derive from, enables constraints on the types of objects that can be used as evidence, and provides the ability to add new features and requirements to all evidence objects. The <xref:System.Security.Policy.EvidenceBase> class ensures, upon instantiation, that the evidence object is serializable. In addition, it enables new evidence requirements to be created by adding new default implementations to the base class.
 
  ]]></format>
     </remarks>

--- a/xml/System.Security.Policy/FileCodeGroup.xml
+++ b/xml/System.Security.Policy/FileCodeGroup.xml
@@ -47,12 +47,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Code groups are the building blocks of code access security policy. Each policy level consists of a root code group that can have child code groups. Each child code group can have their own child code groups; this behavior extends to any number of levels, forming a tree. Each code group has a membership condition that determines if a given assembly belongs to it based on the evidence for that assembly. Only code groups whose membership conditions match a given assembly and their child code groups apply policy.
-
- <xref:System.Security.Policy.FileCodeGroup> has the same child matching semantics as <xref:System.Security.Policy.UnionCodeGroup>. However, <xref:System.Security.Policy.FileCodeGroup> returns a permission set containing a dynamically-calculated <xref:System.Security.Permissions.FileIOPermission> that grants file access to the directory from which the code is run; <xref:System.Security.Policy.UnionCodeGroup> only returns a static permission set. The type of file access granted is passed as a parameter to the constructor.
-
- This code group only matches assemblies run over a file protocol, that is, assemblies that have URLs that point to a file or UNC path.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -92,16 +86,7 @@
         <param name="membershipCondition">A membership condition that tests evidence to determine whether this code group applies policy.</param>
         <param name="access">One of the <see cref="T:System.Security.Permissions.FileIOPermissionAccess" /> values. This value is used to construct the <see cref="T:System.Security.Permissions.FileIOPermission" /> that is granted.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Policy.FileCodeGroup" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor creates a basic code group. Child code groups can be added with the <xref:System.Security.Policy.CodeGroup.AddChild*> method.
-
- <xref:System.Security.Policy.FileCodeGroup> returns a permission set containing a dynamically-calculated <xref:System.Security.Permissions.FileIOPermission> that grants file access to the directory from which the code is run. The type of access granted is determined by the `access` parameter.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="membershipCondition" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The type of the <paramref name="membershipCondition" /> parameter is not valid.
 
@@ -143,14 +128,7 @@
       <Docs>
         <summary>Gets a string representation of the attributes of the policy statement for the code group.</summary>
         <value>Always <see langword="null" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.Policy.FileCodeGroup> does not use <xref:System.Security.Policy.FileCodeGroup.AttributeString*>, so this property is always `null`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Copy">
@@ -187,14 +165,7 @@
       <Docs>
         <summary>Makes a deep copy of the current code group.</summary>
         <returns>An equivalent copy of the current code group, including its membership conditions and child code groups.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method makes a deep copy of the code group, so that copies of all objects the code group contains are also made.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateXml">
@@ -466,18 +437,7 @@
         <param name="evidence">The evidence for the assembly.</param>
         <summary>Resolves policy for the code group and its descendants for a set of evidence.</summary>
         <returns>A policy statement consisting of the permissions granted by the code group with optional attributes, or <see langword="null" /> if the code group does not apply (the membership condition does not match the specified evidence).</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Given evidence for an assembly to be loaded, this method evaluates the code group by first checking the membership condition against the specified evidence. If there is a match, this method returns a policy statement for the code group, including evaluation of child code groups.
-
- The .NET Framework security system uses <xref:System.Security.Policy.FileCodeGroup.Resolve*> on the policy levels to determine which permissions to grant to loaded code from the resulting policy statements and the code request on the assembly.
-
- <xref:System.Security.Policy.FileCodeGroup> uses union semantics and forms a permission set based on the <xref:System.Security.Policy.Url> specified by `evidence`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="evidence" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Security.Policy.PolicyException">The current policy is <see langword="null" />.
 
@@ -523,16 +483,7 @@
         <param name="evidence">The evidence for the assembly.</param>
         <summary>Resolves matching code groups.</summary>
         <returns>A <see cref="T:System.Security.Policy.CodeGroup" /> that is the root of the tree of matching code groups.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Given evidence for an assembly to be loaded, this method evaluates the code group by first checking the membership condition against the specified evidence. If there is a match, this method returns a root code group. The code group that is returned contains child code groups, which in turn can have child code groups as necessary to reflect the complete set of code groups that were matched by the evidence provided.
-
- <xref:System.Security.Policy.FileCodeGroup> uses union semantics and forms a permission set based on the <xref:System.Security.Policy.Url> specified by `evidence`.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="evidence" /> parameter is <see langword="null" />.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Policy/FirstMatchCodeGroup.xml
+++ b/xml/System.Security.Policy/FirstMatchCodeGroup.xml
@@ -47,12 +47,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Code groups are the building blocks of code access security policy. Each policy level consists of a root code group that can have child code groups. Each child code group can have their own child code groups; this behavior extends to any number of levels, forming a tree. Each code group has a membership condition that determines if a given assembly belongs to it based on the evidence for that assembly. Only code groups whose membership conditions match a given assembly and their child code groups apply policy.
-
- Like any code group, <xref:System.Security.Policy.FirstMatchCodeGroup> only applies when its membership condition matches evidence for an assembly. If there is a match, it tests the membership condition of each child in order, stopping when the first match occurs. The result of <xref:System.Security.Policy.FirstMatchCodeGroup> is the union of the policy statement of the root code group and the policy statement of the first child group of that code group that matches.
-
- <xref:System.Security.Policy.FirstMatchCodeGroup> is intended for programmatic use by application domain hosts to set domain policy.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -92,14 +86,7 @@
         <param name="membershipCondition">A membership condition that tests evidence to determine whether this code group applies policy.</param>
         <param name="policy">The policy statement for the code group in the form of a permission set and attributes to grant code that matches the membership condition.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Policy.FirstMatchCodeGroup" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor creates a basic code group and should be called from the constructors of custom code groups. Child code groups can be added using the <xref:System.Security.Policy.CodeGroup.AddChild*> method.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The type of the <paramref name="membershipCondition" /> parameter is not valid.
 
  -or-
@@ -141,14 +128,7 @@
       <Docs>
         <summary>Makes a deep copy of the code group.</summary>
         <returns>An equivalent copy of the code group, including its membership conditions and child code groups.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method makes a deep copy of the code group, meaning that copies of all objects it contains are made, as well.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MergeLogic">
@@ -224,22 +204,7 @@
         <param name="evidence">The evidence for the assembly.</param>
         <summary>Resolves policy for the code group and its descendants for a set of evidence.</summary>
         <returns>A policy statement consisting of the permissions granted by the code group with optional attributes, or <see langword="null" /> if the code group does not apply (the membership condition does not match the specified evidence).</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Given evidence for an assembly to be loaded, this method evaluates the code group by first checking the membership condition against the specified evidence. If there is a match, this method returns a policy statement for the code group, including evaluation of child code groups.
-
- For first-match code groups, each child code group's membership condition is tested against the evidence in the order in which they were added; only the first match is resolved with the evidence set. If there are no matches, the policy statement of the parent first-match code group applies. The matching child code group type determines how all child groups under it are applied, depending on how the <xref:System.Security.Policy.CodeGroup.Resolve*> methods of these child groups work.
-
- The .NET Framework security system uses <xref:System.Security.Policy.CodeGroup.Resolve*> on the policy levels to determine which permissions to grant to loaded code from the resulting policy statements and the code request on the assembly.
-
- This operation of this method is as follows:
-
- If the membership condition does not match the specified evidence, return `null`; otherwise, set the permission set to be returned (P) equal to the code group's policy statement and continue. For each child code group, resolve the code group with the same evidence; if the result is not `null`, return that policy statement. If no child code group matched, return P (the parent's policy statement).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="evidence" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Security.Policy.PolicyException">More than one code group (including the parent code group and any child code groups) is marked <see cref="F:System.Security.Policy.PolicyStatementAttribute.Exclusive" />.</exception>
       </Docs>
@@ -281,16 +246,7 @@
         <param name="evidence">The evidence for the assembly.</param>
         <summary>Resolves matching code groups.</summary>
         <returns>A <see cref="T:System.Security.Policy.CodeGroup" /> that is the root of the tree of matching code groups.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Given evidence for an assembly to be loaded, this method evaluates the code group by first checking the membership condition against the specified evidence. If there is a match, this method returns a root code group. The code group that is returned contains child code groups, which in turn can have child code groups as necessary to reflect the complete set of code groups that were matched by the evidence provided.
-
- For first-match code groups, each child code group's membership condition is tested against the evidence in the order in which they were added; only the first match is resolved with the evidence set. If there are no matches, the policy statement of the parent first-match code group applies. The matching child code group type determines how all child groups under it are applied, depending on how the <xref:System.Security.Policy.CodeGroup.ResolveMatchingCodeGroups*> methods of these child groups work.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="evidence" /> parameter is <see langword="null" />.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Policy/GacInstalled.xml
+++ b/xml/System.Security.Policy/GacInstalled.xml
@@ -50,8 +50,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The presence of <xref:System.Security.Policy.GacInstalled> evidence produces a <xref:System.Security.Permissions.GacIdentityPermission> in the grant set. If there is a <xref:System.Security.CodeAccessPermission.Demand*> for <xref:System.Security.Permissions.GacIdentityPermission>, the <xref:System.Security.Permissions.GacIdentityPermission> that corresponds to the <xref:System.Security.Policy.GacInstalled> evidence is compared with the demanded permission.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -84,14 +82,7 @@
       <Parameters />
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Policy.GacInstalled" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The constructor sets no property values because a <xref:System.Security.Policy.GacInstalled> object has no properties.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Copy">
@@ -169,14 +160,7 @@
         <param name="evidence">The <see cref="T:System.Security.Policy.Evidence" /> from which to construct the identity permission.</param>
         <summary>Creates a new identity permission that corresponds to the current object.</summary>
         <returns>A new identity permission that corresponds to the current object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Permissions.GacIdentityPermission> can be used to determine whether the calling code is in the global assembly cache.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -216,14 +200,7 @@
         <summary>Indicates whether the current object is equivalent to the specified object.</summary>
         <returns>
           <see langword="true" /> if <paramref name="o" /> is a <see cref="T:System.Security.Policy.GacInstalled" /> object; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.Policy.GacInstalled> objects have no properties to distinguish one from another, so all <xref:System.Security.Policy.GacInstalled> objects are equal.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -259,14 +236,7 @@
       <Docs>
         <summary>Returns a hash code for the current object.</summary>
         <returns>A hash code for the current object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Policy.GacInstalled.GetHashCode*> method returns 0 (zero) because <xref:System.Security.Policy.GacInstalled> objects have no properties to distinguish one from another.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -302,14 +272,7 @@
       <Docs>
         <summary>Returns a string representation of the current  object.</summary>
         <returns>A string representation of the current object.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Returns the XML encoding for the current object.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Policy/IIdentityPermissionFactory.xml
+++ b/xml/System.Security.Policy/IIdentityPermissionFactory.xml
@@ -45,8 +45,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Some types of evidence have a corresponding identity permission that is granted to assemblies with that evidence. This allows other code to make identity demands, so that only code with a specific piece of evidence will pass. For example, you can demand that your callers have a specific strong name; only callers with that strong name will pass the demand. By implementing <xref:System.Security.Policy.IIdentityPermissionFactory> for an evidence object, you provide an implementation of <xref:System.Security.Policy.IIdentityPermissionFactory.CreateIdentityPermission*> that the .NET Framework security system can call to get an identity permission that represents that piece of evidence. During policy resolution, the security system will call that method on all evidence objects that implement <xref:System.Security.Policy.IIdentityPermissionFactory> and grant the resulting identity permissions to the appropriate assembly.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Policy.Evidence" />

--- a/xml/System.Security.Policy/NetCodeGroup.xml
+++ b/xml/System.Security.Policy/NetCodeGroup.xml
@@ -34,37 +34,7 @@
   <Interfaces />
   <Docs>
     <summary>Grants Web permission to the site from which the assembly was downloaded. This class cannot be inherited.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[
-
-## Remarks
- Code groups are the building blocks of code access security policy. Each policy level consists of a root code group that can have one or more child code groups. Each child code group can have its own child code groups; this behavior extends to any number of levels, forming a tree. Each code group has a membership condition that determines if a given assembly belongs to the group, based on the evidence for that assembly. Only code groups whose membership conditions match a given assembly, along with their child code groups, apply code access security policy.
-
- <xref:System.Security.Policy.NetCodeGroup> has the same merge semantics as that of <xref:System.Security.Policy.UnionCodeGroup>; it forms the union of the <xref:System.Security.Policy.PolicyStatement> objects of all matching child code groups and the <xref:System.Security.Policy.PolicyStatement> it generates from the input <xref:System.Security.Policy.Url> evidence. However, <xref:System.Security.Policy.NetCodeGroup> returns a permission containing a dynamically calculated <xref:System.Net.WebPermission> that grants connect access to the site from which the code is run; <xref:System.Security.Policy.UnionCodeGroup> simply returns a static permission set.
-
- When a <xref:System.Security.Policy.NetCodeGroup> is created, it contains the default connection access rules shown in the following table.
-
-|URI Scheme|Rule|
-|----------------|----------|
-|file|No connection access to the origin server is permitted.|
-|http|HTTP and HTTPS access is permitted using the origin port.|
-|https|HTTPS access is permitted using the origin port.|
-
- You can control the scheme and port that code is permitted to use when connecting back to its site of origin by passing a <xref:System.Security.Policy.CodeConnectAccess> object with the appropriate <xref:System.Security.Policy.CodeConnectAccess.Scheme*> and <xref:System.Security.Policy.CodeConnectAccess.Port> property values to the <xref:System.Security.Policy.NetCodeGroup.AddConnectAccess*> method. You can create a connection access rule that applies when the origin scheme is not present in the evidence or is not recognized by specifying <xref:System.Security.Policy.NetCodeGroup.AbsentOriginScheme> ("") as the scheme. You can also create a connection access rule that applies when there is no connection access rule with a matching scheme by specifying <xref:System.Security.Policy.NetCodeGroup.AnyOtherOriginScheme> ("*") as the scheme.
-
-> [!NOTE]
->  If code does not submit the URI scheme as evidence, access is permitted using any scheme back to the origin site.
-
-
-
-## Examples
- The following code example demonstrates creating a <xref:System.Security.Policy.NetCodeGroup> and adding <xref:System.Security.Policy.CodeConnectAccess> objects for code downloaded using the HTTP scheme.
-
- :::code language="cpp" source="~/snippets/cpp/VS_Snippets_Remoting/NclCodeGroup/cpp/sample.cpp" id="Snippet3":::
- :::code language="csharp" source="~/snippets/csharp/System.Security.Policy/CodeConnectAccess/Overview/sample.cs" id="Snippet3":::
-
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -100,28 +70,7 @@
       <Docs>
         <param name="membershipCondition">A membership condition that tests evidence to determine whether this code group applies code access security policy.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Policy.NetCodeGroup" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- When a <xref:System.Security.Policy.NetCodeGroup> is created, it contains the default connection access rules shown in the following table.
-
-|Scheme|Rule|
-|------------|----------|
-|file|No connection access to the origin server is permitted.|
-|http|HTTP and HTTPS access is permitted using the origin port.|
-|https|HTTPS access is permitted using the origin port.|
-
-
-
-## Examples
- The following code example demonstrates creating a <xref:System.Security.Policy.NetCodeGroup> and adding <xref:System.Security.Policy.CodeConnectAccess> objects for code downloaded using the HTTP scheme.
-
- :::code language="cpp" source="~/snippets/cpp/VS_Snippets_Remoting/NclCodeGroup/cpp/sample.cpp" id="Snippet3":::
- :::code language="csharp" source="~/snippets/csharp/System.Security.Policy/CodeConnectAccess/Overview/sample.cs" id="Snippet3":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="membershipCondition" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The type of the <paramref name="membershipCondition" /> parameter is not valid.</exception>
       </Docs>
@@ -157,18 +106,7 @@
       </ReturnValue>
       <Docs>
         <summary>Contains a value used to specify connection access for code with an unknown or unrecognized origin scheme.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- When calling the <xref:System.Security.Policy.NetCodeGroup.AddConnectAccess*> method, you specify a scheme and an associated <xref:System.Security.Policy.CodeConnectAccess> object. Any <xref:System.Security.Policy.CodeConnectAccess> objects that you add to the <xref:System.Security.Policy.NetCodeGroup> using <xref:System.Security.Policy.NetCodeGroup.AbsentOriginScheme> as the origin scheme are applied when the code's origin scheme is not present in its evidence, or is not a scheme recognized by the <xref:System.Security.Policy.NetCodeGroup> object.
-
- To specify the <xref:System.Security.Policy.CodeConnectAccess> objects to use when the code's origin scheme does not match any of the schemes contained in the set of origin schemes added to the current <xref:System.Security.Policy.NetCodeGroup> object, use the <xref:System.Security.Policy.NetCodeGroup.AnyOtherOriginScheme> value.
-
- The value of the <xref:System.Security.Policy.NetCodeGroup.AbsentOriginScheme> field is an empty string ("").
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AddConnectAccess">
@@ -208,22 +146,7 @@
         <param name="originScheme">A <see cref="T:System.String" /> containing the scheme to match against the code's scheme.</param>
         <param name="connectAccess">A <see cref="T:System.Security.Policy.CodeConnectAccess" /> that specifies the scheme and port code can use to connect back to its origin server.</param>
         <summary>Adds the specified connection access to the current code group.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- You can add multiple <xref:System.Security.Policy.CodeConnectAccess> objects for the same `origin scheme`. If an `origin scheme` already has one or more associated <xref:System.Security.Policy.CodeConnectAccess> objects, specifying `null` for `connectAccess` has no effect. If the origin scheme does not have associated <xref:System.Security.Policy.CodeConnectAccess> objects, specifying `null` for `connectAccess` prevents code with an origin scheme that matches `originScheme` from accessing its origin server.
-
-
-
-## Examples
- The following code example demonstrates creating and adding <xref:System.Security.Policy.CodeConnectAccess> objects to a <xref:System.Security.Policy.NetCodeGroup>.
-
- :::code language="cpp" source="~/snippets/cpp/VS_Snippets_Remoting/NclCodeGroup/cpp/sample.cpp" id="Snippet3":::
- :::code language="csharp" source="~/snippets/csharp/System.Security.Policy/CodeConnectAccess/Overview/sample.cs" id="Snippet3":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="originScheme" /> is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
@@ -265,20 +188,7 @@
       </ReturnValue>
       <Docs>
         <summary>Contains a value used to specify any other unspecified origin scheme.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- When calling the <xref:System.Security.Policy.NetCodeGroup.AddConnectAccess*> method, you specify a scheme and an associated <xref:System.Security.Policy.CodeConnectAccess> object. You can use the value of the <xref:System.Security.Policy.NetCodeGroup.AnyOtherOriginScheme> field to specify the <xref:System.Security.Policy.CodeConnectAccess> objects that should be used for any scheme that is not explicitly contained in the set of origin schemes added to the current <xref:System.Security.Policy.NetCodeGroup> object.
-
- The <xref:System.Security.Policy.CodeConnectAccess> objects specified with the <xref:System.Security.Policy.NetCodeGroup.AnyOtherOriginScheme> field are only used if the code's origin scheme does not match any of the schemes contained in the set of origin schemes added to the current <xref:System.Security.Policy.NetCodeGroup> object.
-
- To specify the <xref:System.Security.Policy.CodeConnectAccess> objects to apply when the code's origin scheme is not available in its evidence or is not recognized, use the <xref:System.Security.Policy.NetCodeGroup.AbsentOriginScheme> value.
-
- The value of the <xref:System.Security.Policy.NetCodeGroup.AnyOtherOriginScheme> field is "*".
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="AttributeString">
@@ -438,20 +348,7 @@
         <summary>Determines whether the specified code group is equivalent to the current code group.</summary>
         <returns>
           <see langword="true" /> if the specified code group is equivalent to the current code group; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The following data are used to determine the equality of two <xref:System.Security.Policy.NetCodeGroup> objects:
-
-- The <xref:System.Security.Policy.CodeGroup.Name*> and <xref:System.Security.Policy.CodeGroup.Description*> properties.
-
-- The <xref:System.Security.Policy.CodeGroup.MembershipCondition> property.
-
-- The set of origin schemes and the associated <xref:System.Security.Policy.CodeConnectAccess> objects.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetConnectAccessRules">
@@ -487,22 +384,7 @@
       <Docs>
         <summary>Gets the connection access information for the current code group.</summary>
         <returns>A <see cref="T:System.Collections.DictionaryEntry" /> array containing connection access information.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- In each dictionary entry, the <xref:System.Collections.DictionaryEntry.Key> property value is the origin scheme, and the <xref:System.Collections.DictionaryEntry.Value> property value is the array of associated <xref:System.Security.Policy.CodeConnectAccess> objects. If there are no associated <xref:System.Security.Policy.CodeConnectAccess> objects, <xref:System.Collections.DictionaryEntry.Value*?displayProperty=nameWithType> returns an empty array.
-
-
-
-## Examples
- The following code example demonstrates displaying the connection access rules for a <xref:System.Security.Policy.NetCodeGroup> object.
-
- :::code language="cpp" source="~/snippets/cpp/VS_Snippets_Remoting/NclCodeGroup/cpp/sample.cpp" id="Snippet8":::
- :::code language="csharp" source="~/snippets/csharp/System.Security.Policy/CodeConnectAccess/Overview/sample.cs" id="Snippet8":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -686,30 +568,7 @@
       <Parameters />
       <Docs>
         <summary>Removes all connection access information for the current code group.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Use this method to remove the system-supplied default connection access rules.
-
- The default rules are shown in the following table.
-
-|Scheme|Rule|
-|------------|----------|
-|file|No connection access to the origin server is permitted.|
-|http|HTTP and HTTPS access is permitted using the origin port.|
-|https|HTTPS access is permitted using the origin port.|
-
-
-
-## Examples
- The following code example demonstrates calling this method to remove the default code access connection rules.
-
- :::code language="cpp" source="~/snippets/cpp/VS_Snippets_Remoting/NclCodeGroup/cpp/sample.cpp" id="Snippet3":::
- :::code language="csharp" source="~/snippets/csharp/System.Security.Policy/CodeConnectAccess/Overview/sample.cs" id="Snippet3":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Resolve">
@@ -749,18 +608,7 @@
         <param name="evidence">The <see cref="T:System.Security.Policy.Evidence" /> for the assembly.</param>
         <summary>Resolves policy for the code group and its descendants for a set of evidence.</summary>
         <returns>A <see cref="T:System.Security.Policy.PolicyStatement" /> that consists of the permissions granted by the code group with optional attributes, or <see langword="null" /> if the code group does not apply (the membership condition does not match the specified evidence).</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Given evidence for an assembly to be loaded, this method evaluates the code group by first checking the membership condition against the specified evidence. If there is a match, this method returns a policy statement for the code group, including evaluation of child code groups.
-
- The operation of this method is as follows:
-
- If the membership condition does not match the specified evidence, return `null`; otherwise, set the permission set to be returned (P) equal to the code group's policy statement and continue. For each child code group, resolve the code group with the same evidence; if the result is not `null`, return that policy statement. If no child code group matched, return P (the parent's policy statement).
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="evidence" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Security.Policy.PolicyException">More than one code group (including the parent code group and any child code groups) is marked <see cref="F:System.Security.Policy.PolicyStatementAttribute.Exclusive" />.</exception>
       </Docs>
@@ -802,14 +650,7 @@
         <param name="evidence">The evidence for the assembly.</param>
         <summary>Resolves matching code groups.</summary>
         <returns>The complete set of code groups that were matched by the evidence.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Given evidence for an assembly to be loaded, this method evaluates the code group by first checking the membership condition against the specified evidence. If there is a match, this method returns a root code group. The code group that is returned may contain child code groups, which, in turn, may also have child code groups, so the return value reflects the complete set of code groups that were matched by the evidence provided.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="evidence" /> parameter is <see langword="null" />.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Policy/PermissionRequestEvidence.xml
+++ b/xml/System.Security.Policy/PermissionRequestEvidence.xml
@@ -41,14 +41,12 @@
   <Docs>
     <summary>Defines evidence that represents permission requests. This class cannot be inherited.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Permission requests include the minimum permissions the code requires to run, permissions the code can use if they are granted, but are not required, and permissions the code explicitly asks not to be granted.  
-  
  ]]></format>
     </remarks>
   </Docs>
@@ -90,14 +88,7 @@
         <param name="optional">The permissions the code can use if they are granted, but that are not required.</param>
         <param name="denied">The permissions the code explicitly asks not to be granted.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Policy.PermissionRequestEvidence" /> class with the permission request of a code assembly.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The .NET Framework security policy system uses the requested permissions along with a code assembly's <xref:System.Security.Policy.Evidence> to determine which permissions the code should be granted.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Copy">
@@ -279,14 +270,7 @@
       <Docs>
         <summary>Gets a string representation of the state of the <see cref="T:System.Security.Policy.PermissionRequestEvidence" />.</summary>
         <returns>A representation of the state of the <see cref="T:System.Security.Policy.PermissionRequestEvidence" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method is useful during debugging to get an easy-to-read representation of the <xref:System.Security.Policy.PermissionRequestEvidence>.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Security.Policy/PolicyLevel.xml
+++ b/xml/System.Security.Policy/PolicyLevel.xml
@@ -34,27 +34,7 @@
   <Interfaces />
   <Docs>
     <summary>Represents the security policy levels for the common language runtime. This class cannot be inherited.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[
-
-## Remarks
-
-> [!IMPORTANT]
-> We recommend that you use [Windows Software Restriction Policies (SRP) or AppLocker as a replacement for CLR security policy. The information in this topic applies to the .NET Framework version 3.5 and earlier; it does not apply to the .NET Framework 4 and later. For more information about this and other changes, see [Security Changes](/dotnet/framework/security/security-changes).
-
- The highest level of security policy is enterprise-wide. Successive lower levels of hierarchy represent further policy restrictions, but can never grant more permissions than allowed by higher levels. The following policy levels are implemented:
-
-1. Enterprise: Security policy for all managed code in an enterprise.
-2. Machine: Security policy for all managed code run on the computer.
-3. User: Security policy for all managed code run by the user.
-4. Application domain: Security policy for all managed code in an application.
-
- A policy level consists of a set of code groups organized into a single rooted tree (see <xref:System.Security.Policy.CodeGroup>), a set of named permission sets that are referenced by the code groups to specify permissions to be granted to code belonging to the code group, and a list of fully-trusted assemblies.
-
- Use <xref:System.Security.SecurityManager.PolicyHierarchy*?displayProperty=nameWithType> to enumerate the policy levels.
-
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <MemberGroup MemberName="AddFullTrustAssembly">
@@ -113,17 +93,9 @@
       <Docs>
         <param name="sn">The <see cref="T:System.Security.Policy.StrongName" /> used to create the <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> to add to the list of <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> objects used to determine whether an assembly is a member of the group of assemblies that should not be evaluated.</param>
         <summary>Adds a <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> corresponding to the specified <see cref="T:System.Security.Policy.StrongName" /> to the list of <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> objects used to determine whether an assembly is a member of the group of assemblies that should not be evaluated.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Policy.PolicyLevel.AddFullTrustAssembly*> method is not supported in version 2.0 or later of the .NET Framework because the list of full trust assemblies is not used in those versions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="sn" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <see cref="T:System.Security.Policy.StrongName" /> specified by the <paramref name="sn" /> parameter already has full trust.</exception>
-        <altmember cref="P:System.Security.Policy.PolicyLevel.FullTrustAssemblies" />
       </Docs>
     </Member>
     <Member MemberName="AddFullTrustAssembly">
@@ -172,17 +144,9 @@
       <Docs>
         <param name="snMC">The <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> to add to the list of <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> objects used to determine whether an assembly is a member of the group of assemblies that should not be evaluated.</param>
         <summary>Adds the specified <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> to the list of <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> objects used to determine whether an assembly is a member of the group of assemblies that should not be evaluated.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Policy.PolicyLevel.AddFullTrustAssembly*> method is not supported in version 2.0 or later of the .NET Framework because the list of full trust assemblies is not used in those versions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="snMC" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> specified by the <paramref name="snMC" /> parameter already has full trust.</exception>
-        <altmember cref="P:System.Security.Policy.PolicyLevel.FullTrustAssemblies" />
       </Docs>
     </Member>
     <Member MemberName="AddNamedPermissionSet">
@@ -233,8 +197,6 @@
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
-
- Named permission sets are scoped by policy level.
 
  ]]></format>
         </remarks>
@@ -355,8 +317,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- This method creates a new <xref:System.Security.Policy.PolicyLevel> with the <xref:System.Security.Policy.PolicyLevel.Label*> "AppDomain". The new <xref:System.Security.Policy.PolicyLevel> will initially contain the same <xref:System.Security.NamedPermissionSet> objects as in the default computer policy, and will have a single root code group that grants `FullTrust` to all code.
-
  ]]></format>
         </remarks>
       </Docs>
@@ -445,16 +405,7 @@
       <Docs>
         <summary>Gets a list of <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> objects used to determine whether an assembly is a member of the group of assemblies used to evaluate security policy.</summary>
         <value>A list of <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> objects used to determine whether an assembly is a member of the group of assemblies used to evaluate security policy. These assemblies are granted full trust during security policy evaluation of assemblies not in the list.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.Policy.PolicyLevel.FullTrustAssemblies*> are granted full trust during security policy evaluation of assemblies not in the list, but are not automatically granted full trust when directly evaluated by the security policy system.
-
- The <xref:System.Security.Policy.PolicyLevel.FullTrustAssemblies> property is not supported in version 2.0 or later of the .NET Framework because the list of full trust assemblies is not used in those versions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetNamedPermissionSet">
@@ -631,8 +582,6 @@
 ## Remarks
  This method does not make modifications to the current <xref:System.Security.Policy.PolicyLevel>. Instead, it updates the <xref:System.Security.Policy.PolicyLevel> object's file and the <xref:System.Security.Policy.PolicyLevel> that the security system uses to evaluate policy.
 
- This method is used by the caspol -recover option (see [Caspol.exe (Code Access Security Policy Tool)](/dotnet/framework/tools/caspol-exe-code-access-security-policy-tool)).
-
  ]]></format>
         </remarks>
         <exception cref="T:System.Security.Policy.PolicyException">The policy level does not have a valid configuration file.</exception>
@@ -694,14 +643,7 @@
       <Docs>
         <param name="sn">The <see cref="T:System.Security.Policy.StrongName" /> of the assembly to remove from the list of assemblies used to evaluate policy.</param>
         <summary>Removes an assembly with the specified <see cref="T:System.Security.Policy.StrongName" /> from the list of assemblies the policy level uses to evaluate policy.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Policy.PolicyLevel.RemoveFullTrustAssembly*> method is not supported in version 2.0 or later of the .NET Framework because the list of full trust assemblies is not used in those versions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="sn" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The assembly with the <see cref="T:System.Security.Policy.StrongName" /> specified by the <paramref name="sn" /> parameter does not have full trust.</exception>
       </Docs>
@@ -752,14 +694,7 @@
       <Docs>
         <param name="snMC">The <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> of the assembly to remove from the list of assemblies used to evaluate policy.</param>
         <summary>Removes an assembly with the specified <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> from the list of assemblies the policy level uses to evaluate policy.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The <xref:System.Security.Policy.PolicyLevel.RemoveFullTrustAssembly*> method is not supported in version 2.0 or later of the .NET Framework because the list of full trust assemblies is not used in those versions.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="snMC" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> specified by the <paramref name="snMC" /> parameter does not have full trust.</exception>
       </Docs>
@@ -971,25 +906,7 @@
         <param name="evidence">The <see cref="T:System.Security.Policy.Evidence" /> used to resolve the <see cref="T:System.Security.Policy.PolicyLevel" />.</param>
         <summary>Resolves policy based on evidence for the policy level, and returns the resulting <see cref="T:System.Security.Policy.PolicyStatement" />.</summary>
         <returns>The resulting <see cref="T:System.Security.Policy.PolicyStatement" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.Policy.PolicyLevel.Resolve*> is the basic policy evaluation operation for policy levels. Given a set of evidence as input, this method tests membership conditions of code groups starting at the root and working down as matched. The combination of permissions resulting from the matching code groups produces a <xref:System.Security.Policy.PolicyStatement> that is returned.
-
- In granting permissions to code, security policy uses the resolved policy statements for all applicable policy levels, together with the code request for permissions.
-
-
-
-## Examples
- The following code shows the use of the <xref:System.Security.Policy.PolicyLevel.Resolve*> method. This code example is part of a larger example provided for the <xref:System.Security.Policy.PolicyLevel> class.
-
- :::code language="cpp" source="~/snippets/cpp/VS_Snippets_CLR_System/system.Security.policy.policylevel/CPP/policylevel.cpp" id="Snippet13":::
- :::code language="csharp" source="~/snippets/csharp/System.Security.Policy/PolicyLevel/Resolve/policylevel.cs" id="Snippet13":::
- :::code language="vb" source="~/snippets/visualbasic/System.Security.Policy/PolicyLevel/Resolve/policylevel.vb" id="Snippet13":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.Security.Policy.PolicyException">The policy level contains multiple matching code groups marked as exclusive.</exception>
         <exception cref="T:System.ArgumentNullException">The <paramref name="evidence" /> parameter is <see langword="null" />.</exception>
       </Docs>
@@ -1122,18 +1039,7 @@
       <Docs>
         <summary>Gets the path where the policy file is stored.</summary>
         <value>The path where the policy file is stored, or <see langword="null" /> if the <see cref="T:System.Security.Policy.PolicyLevel" /> does not have a storage location.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Examples
- The following code shows how to display the store location for a policy level. This code example is part of a larger example provided for the <xref:System.Security.Policy.PolicyLevel> class.
-
- :::code language="cpp" source="~/snippets/cpp/VS_Snippets_CLR_System/system.Security.policy.policylevel/CPP/policylevel.cpp" id="Snippet15":::
- :::code language="csharp" source="~/snippets/csharp/System.Security.Policy/PolicyLevel/Resolve/policylevel.cs" id="Snippet15":::
- :::code language="vb" source="~/snippets/visualbasic/System.Security.Policy/PolicyLevel/Resolve/policylevel.vb" id="Snippet15":::
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToXml">
@@ -1205,24 +1111,7 @@
       <Docs>
         <summary>Gets the type of the policy level.</summary>
         <value>One of the <see cref="T:System.Security.PolicyLevelType" /> values.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The highest level of security policy is enterprise-wide. Successive lower levels of hierarchy represent further policy restrictions, but can never grant more permissions than allowed by higher levels. The policy levels in order are the following.
-
-1. Enterprise
-
-2. Machine
-
-3. User
-
-4. Application domain
-
- For more information, see <xref:System.Security.PolicyLevelType>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <altmember cref="T:System.Security.PolicyLevelType" />
       </Docs>
     </Member>

--- a/xml/System.Security.Policy/Publisher.xml
+++ b/xml/System.Security.Policy/Publisher.xml
@@ -51,12 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The presence of <xref:System.Security.Policy.Publisher> evidence produces a <xref:System.Security.Permissions.PublisherIdentityPermission> in the grant set. If there is a <xref:System.Security.CodeAccessPermission.Demand*> for <xref:System.Security.Permissions.PublisherIdentityPermission>, the <xref:System.Security.Permissions.PublisherIdentityPermission> that corresponds to the <xref:System.Security.Policy.Publisher> evidence will be compared with the demanded permission.
-
- Publisher evidence is based on Authenticode X.509v3 signatures.
-
- By default, code access security (CAS) does not check for <xref:System.Security.Policy.Publisher> evidence. Unless your computer has a custom code group based on the <xref:System.Security.Policy.PublisherMembershipCondition> class, you can improve performance by bypassing Authenticode signature verification. This is accomplished by configuring the runtime to not provide <xref:System.Security.Policy.Publisher> evidence for CAS. For more information about how to configure this option and which applications can use it, see the [\<generatePublisherEvidence>](/dotnet/framework/configure-apps/file-schema/runtime/generatepublisherevidence-element) element.
-
  ]]></format>
     </remarks>
     <altmember cref="T:System.Security.Cryptography.X509Certificates.X509Certificate" />
@@ -253,14 +247,7 @@
         <summary>Compares the current <see cref="T:System.Security.Policy.Publisher" /> to the specified object for equivalence.</summary>
         <returns>
           <see langword="true" /> if the two instances of the <see cref="T:System.Security.Policy.Publisher" /> class are equal; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.Policy.Publisher> objects are equal if they designate the same software publisher certificate.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="o" /> parameter is not a <see cref="T:System.Security.Policy.Publisher" /> object.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Policy/PublisherMembershipCondition.xml
+++ b/xml/System.Security.Policy/PublisherMembershipCondition.xml
@@ -44,16 +44,7 @@
   </Interfaces>
   <Docs>
     <summary>Determines whether an assembly belongs to a code group by testing its software publisher's Authenticode X.509v3 certificate. This class cannot be inherited.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- A code assembly satisfies a publisher membership condition if that code is signed by the specified software publisher.  
-  
- By default, code access security (CAS) does not check for <xref:System.Security.Policy.Publisher> evidence. Unless your computer has a custom code group based on the <xref:System.Security.Policy.PublisherMembershipCondition> class, you can improve performance by bypassing Authenticode signature verification. This is accomplished by configuring the runtime to not provide <xref:System.Security.Policy.Publisher> evidence for CAS. For more information about how to configure this option and which applications can use it, see the \<generatePublisherEvidence> element.  
-  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -89,14 +80,7 @@
       <Docs>
         <param name="certificate">An <see cref="T:System.Security.Cryptography.X509Certificates.X509Certificate" /> that contains the software publisher's public key.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Policy.PublisherMembershipCondition" /> class with the Authenticode X.509v3 certificate that determines membership.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Code satisfies the membership condition if it is signed by the software publisher with the private key that corresponds to the specified public key certificate.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="certificate" /> parameter is <see langword="null" />.</exception>
       </Docs>
     </Member>
@@ -178,14 +162,7 @@
         <summary>Determines whether the specified evidence satisfies the membership condition.</summary>
         <returns>
           <see langword="true" /> if the specified evidence satisfies the membership condition; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This membership condition tests only <xref:System.Security.Policy.Publisher> evidence.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <see cref="P:System.Security.Policy.PublisherMembershipCondition.Certificate" /> property is <see langword="null" />.</exception>
       </Docs>
     </Member>
@@ -271,14 +248,7 @@
         <summary>Determines whether the publisher certificate from the specified object is equivalent to the publisher certificate contained in the current <see cref="T:System.Security.Policy.PublisherMembershipCondition" />.</summary>
         <returns>
           <see langword="true" /> if the publisher certificate from the specified object is equivalent to the publisher certificate contained in the current <see cref="T:System.Security.Policy.PublisherMembershipCondition" />; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- If the two publisher certificates are equal, they represent the same <xref:System.Security.Policy.Publisher>.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <see cref="P:System.Security.Policy.PublisherMembershipCondition.Certificate" /> property is <see langword="null" />.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Policy/Site.xml
+++ b/xml/System.Security.Policy/Site.xml
@@ -51,10 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
-The presence of <xref:System.Security.Policy.Site> evidence produces a <xref:System.Security.Permissions.SiteIdentityPermission> in the grant set. If there is a <xref:System.Security.CodeAccessPermission.Demand*> for <xref:System.Security.Permissions.SiteIdentityPermission>, the <xref:System.Security.Permissions.SiteIdentityPermission> that corresponds to the <xref:System.Security.Policy.Site> evidence will be compared with the demanded permission.
-
-Site identity is defined for code from URLs with any protocol except FILE. A site is the string between the "//" after the protocol of a URL and the following "/", if present. For example, `www.fourthcoffee.com` is the site identity in the URL `http://www.fourthcoffee.com/process/grind.htm`. This excludes port numbers. If a given URL is `http://www.fourthcoffee.com:8000/`, the site is `www.fourthcoffee.com`, not `www.fourthcoffee.com:8000`.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -259,14 +255,7 @@ Site identity is defined for code from URLs with any protocol except FILE. A sit
         <summary>Compares the current <see cref="T:System.Security.Policy.Site" /> to the specified object for equivalence.</summary>
         <returns>
           <see langword="true" /> if the two instances of the <see cref="T:System.Security.Policy.Site" /> class are equal; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.Policy.Site> objects are equal if they designate the same website name.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">

--- a/xml/System.Security.Policy/StrongName.xml
+++ b/xml/System.Security.Policy/StrongName.xml
@@ -45,18 +45,12 @@
   <Docs>
     <summary>Provides the strong name of a code assembly as evidence for policy evaluation. This class cannot be inherited.</summary>
     <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
+      <format type="text/markdown"><![CDATA[
+
 ## Remarks
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The <xref:System.Security.Policy.StrongName> class represents evidence of a unique, cryptographically strong name of a code assembly. The strong name consists of a public key, a given name, and a version. The public key corresponds to the publisher's private key which is kept secret, and with which the assembly must be signed in order for the strong name to be valid.  
-  
- Strong names are typically assigned to assemblies using either <xref:System.Reflection.AssemblyKeyFileAttribute>, <xref:System.Reflection.AssemblyKeyNameAttribute> or <xref:System.Reflection.AssemblyDelaySignAttribute> in conjunction with the SN utility (see [Sn.exe (Strong Name Tool)](/dotnet/framework/tools/sn-exe-strong-name-tool)).  
-  
- <xref:System.Security.Permissions.StrongNameIdentityPermission> uses this class to confirm that calling code is in a particular strong-named code assembly.  
-  
  ]]></format>
     </remarks>
   </Docs>
@@ -98,24 +92,15 @@
         <param name="name">The simple name section of the strong name.</param>
         <param name="version">The <see cref="T:System.Version" /> of the strong name.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Policy.StrongName" /> class with the strong name public key blob, name, and version.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The `name` parameter can be `null`, but it cannot be an empty string ("").  
-  
- For more information about strong names, see <xref:System.Security.Permissions.StrongNameIdentityPermission> and <xref:System.Security.Permissions.StrongNamePublicKeyBlob>.  
-  
- ]]></format>
-        </remarks>
-        <exception cref="T:System.ArgumentNullException">The <paramref name="blob" /> parameter is <see langword="null" />.  
-  
- -or-  
-  
- The <paramref name="name" /> parameter is <see langword="null" />.  
-  
- -or-  
-  
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.ArgumentNullException">The <paramref name="blob" /> parameter is <see langword="null" />.
+
+ -or-
+
+ The <paramref name="name" /> parameter is <see langword="null" />.
+
+ -or-
+
  The <paramref name="version" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <paramref name="name" /> parameter is an empty string ("").</exception>
       </Docs>
@@ -197,14 +182,7 @@
         <param name="evidence">The <see cref="T:System.Security.Policy.Evidence" /> from which to construct the <see cref="T:System.Security.Permissions.StrongNameIdentityPermission" />.</param>
         <summary>Creates a <see cref="T:System.Security.Permissions.StrongNameIdentityPermission" /> that corresponds to the current <see cref="T:System.Security.Policy.StrongName" />.</summary>
         <returns>A <see cref="T:System.Security.Permissions.StrongNameIdentityPermission" /> for the specified <see cref="T:System.Security.Policy.StrongName" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The identity permission for a strong name can be used to determine whether calling code is in a particular strong named code assembly.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -354,16 +332,7 @@
       <Docs>
         <summary>Gets the <see cref="T:System.Security.Permissions.StrongNamePublicKeyBlob" /> of the current <see cref="T:System.Security.Policy.StrongName" />.</summary>
         <value>The <see cref="T:System.Security.Permissions.StrongNamePublicKeyBlob" /> of the current <see cref="T:System.Security.Policy.StrongName" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- A blob is cryptographic information that uniquely specifies the public key of the software publisher.  
-  
- Blobs differ from certificates in that the blob only has information about the public key; the certificate also includes information that associates the name of the holder with the key as well as information to verify the certificate.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -400,14 +369,7 @@
       <Docs>
         <summary>Creates a string representation of the current <see cref="T:System.Security.Policy.StrongName" />.</summary>
         <returns>A representation of the current <see cref="T:System.Security.Policy.StrongName" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method is useful during debugging to get an easy-to-read representation of the object.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Version">

--- a/xml/System.Security.Policy/StrongNameMembershipCondition.xml
+++ b/xml/System.Security.Policy/StrongNameMembershipCondition.xml
@@ -57,8 +57,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Strong names are well suited to specifying code assemblies to which you give a rich set of powerful permissions. Since strong names are cryptographically verified, attackers cannot impersonate rightful assemblies and use their permissions.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -100,16 +98,7 @@
         <param name="name">The simple name section of the strong name.</param>
         <param name="version">The version number of the strong name.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Policy.StrongNameMembershipCondition" /> class with the strong name public key blob, name, and version number that determine membership.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Strong names are well suited to specifying code assemblies to which you give a rich set of powerful permissions. Since strong names are cryptographically verified, attackers cannot impersonate rightful assemblies and use their permissions.
-
- The `name` and `version` parameters are optional. For example, you can create a <xref:System.Security.Policy.StrongNameMembershipCondition> that checks for <xref:System.Security.Policy.StrongNameMembershipCondition.PublicKey*> and <xref:System.Security.Policy.StrongNameMembershipCondition.Name*> (but not <xref:System.Security.Policy.StrongNameMembershipCondition.Version*>) by passing `null` into the `version` parameter. If `name` is an empty string (""), an <xref:System.ArgumentException> is thrown.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="blob" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.ArgumentException">The <paramref name="name" /> parameter is <see langword="null" />.
 
@@ -159,16 +148,7 @@
         <summary>Determines whether the specified evidence satisfies the membership condition.</summary>
         <returns>
           <see langword="true" /> if the specified evidence satisfies the membership condition; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This membership condition tests only the <xref:System.Security.Policy.StrongName> evidence object.
-
- The membership condition is satisfied if the specified evidence contains a <xref:System.Security.Policy.StrongName> with the same <xref:System.Security.Policy.StrongName> (public key, name, and version) as specified by the <xref:System.Security.Policy.StrongNameMembershipCondition>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Copy">
@@ -252,14 +232,7 @@
         <summary>Determines whether the <see cref="T:System.Security.Policy.StrongName" /> from the specified object is equivalent to the <see cref="T:System.Security.Policy.StrongName" /> contained in the current <see cref="T:System.Security.Policy.StrongNameMembershipCondition" />.</summary>
         <returns>
           <see langword="true" /> if the <see cref="T:System.Security.Policy.StrongName" /> from the specified object is equivalent to the <see cref="T:System.Security.Policy.StrongName" /> contained in the current <see cref="T:System.Security.Policy.StrongNameMembershipCondition" />; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- For two <xref:System.Security.Policy.StrongName> classes to be equal, their name, version, and public key blob must match exactly.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <see cref="P:System.Security.Policy.StrongNameMembershipCondition.PublicKey" /> property of the current object or the specified object is <see langword="null" />.</exception>
       </Docs>
     </Member>
@@ -432,14 +405,7 @@
       <Docs>
         <summary>Gets or sets the simple name of the <see cref="T:System.Security.Policy.StrongName" /> for which the membership condition tests.</summary>
         <value>The simple name of the <see cref="T:System.Security.Policy.StrongName" /> for which the membership condition tests.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- If you attempt to set the <xref:System.Security.Policy.StrongNameMembershipCondition.Name> property to an empty string (""), an <xref:System.ArgumentException> is thrown.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The value is <see langword="null" />.
 
  -or-
@@ -480,16 +446,7 @@
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Security.Permissions.StrongNamePublicKeyBlob" /> of the <see cref="T:System.Security.Policy.StrongName" /> for which the membership condition tests.</summary>
         <value>The <see cref="T:System.Security.Permissions.StrongNamePublicKeyBlob" /> of the <see cref="T:System.Security.Policy.StrongName" /> for which the membership condition tests.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- A blob is cryptographic information that uniquely specifies the public key of the software publisher.
-
- Blobs differ from certificates in that the blob only has information about the public key; the certificate also includes information that associates a name of the holder with the key, as well as information to verify the certificate.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">An attempt is made to set the <see cref="P:System.Security.Policy.StrongNameMembershipCondition.PublicKey" /> to <see langword="null" />.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Policy/UnionCodeGroup.xml
+++ b/xml/System.Security.Policy/UnionCodeGroup.xml
@@ -47,12 +47,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- Code groups are the building blocks of code access security policy. Each policy level consists of a root code group that can have child code groups (and so on), forming a tree. Each code group has a membership condition that determines if a given assembly belongs to it or not, based on the evidence for that assembly. Only code groups whose membership conditions match a given assembly and their child code groups apply policy.
-
- <xref:System.Security.Policy.UnionCodeGroup> is the most common type of code group; the policy statement of all matching child code groups (and by extension their child code groups) are combined with the permission set of the matching parent code group. Thus, if its membership condition matches, this code group forms the union of its policy statement and those of all its child code groups that also match the evidence.
-
- <xref:System.Security.Policy.UnionCodeGroup> code groups are the code groups created by the CASPOL utility (see [Caspol.exe (Code Access Security Policy Tool)](/dotnet/framework/tools/caspol-exe-code-access-security-policy-tool)).
-
  ]]></format>
     </remarks>
   </Docs>
@@ -92,14 +86,7 @@
         <param name="membershipCondition">A membership condition that tests evidence to determine whether this code group applies policy.</param>
         <param name="policy">The policy statement for the code group in the form of a permission set and attributes to grant code that matches the membership condition.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Security.Policy.UnionCodeGroup" /> class.</summary>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This constructor creates a basic code group and should be called from the constructors of custom code groups. You can add child code groups by using the <xref:System.Security.Policy.CodeGroup.AddChild*> method.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The type of the <paramref name="membershipCondition" /> parameter is not valid.
 
  -or-
@@ -141,14 +128,7 @@
       <Docs>
         <summary>Makes a deep copy of the current code group.</summary>
         <returns>An equivalent copy of the current code group, including its membership conditions and child code groups.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- This method makes a deep copy of the code group, so that copies of all objects the code group contains are also made.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="MergeLogic">
@@ -224,20 +204,7 @@
         <param name="evidence">The evidence for the assembly.</param>
         <summary>Resolves policy for the code group and its descendants for a set of evidence.</summary>
         <returns>A policy statement consisting of the permissions granted by the code group with optional attributes, or <see langword="null" /> if the code group does not apply (the membership condition does not match the specified evidence).</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Given evidence for an assembly to be loaded, this method evaluates the code group by first checking the membership condition against the specified evidence. If there is a match, this method returns a policy statement for the code group, including evaluation of child code groups.
-
- For union code groups, all child code groups whose membership condition match the evidence are also resolved, and all resulting policy statements form a union with the policy statement of the parent union code group. Each child code group type determines how its child groups are applied, depending on how their respective <xref:System.Security.Policy.UnionCodeGroup.Resolve*> methods work.
-
- The .NET Framework security system uses <xref:System.Security.Policy.UnionCodeGroup.Resolve*> on the policy levels to determine which permissions to grant to loaded code from the resulting policy statements and the code request on the assembly.
-
- If the membership condition does not match the specified evidence, this method returns `null`; otherwise, it sets the permission set to be returned (P) equal to the code group's policy statement, and then continues. For each child code group, the method resolves the code group with the same evidence; if the result is not `null`, it sets P equal to the union of P and the child code group's policy statement. It then returns P, which is now the union of the current code group's policy statement and all child group policy statements.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="evidence" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Security.Policy.PolicyException">More than one code group (including the parent code group and any child code groups) is marked <see cref="F:System.Security.Policy.PolicyStatementAttribute.Exclusive" />.</exception>
       </Docs>
@@ -279,14 +246,7 @@
         <param name="evidence">The evidence for the assembly.</param>
         <summary>Resolves matching code groups.</summary>
         <returns>The complete set of code groups that were matched by the evidence.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- Given evidence for an assembly to be loaded, this method evaluates the code group by first checking the membership condition against the specified evidence. If there is a match, this method returns a root code group. The code group that is returned may contain child code groups, which, in turn, may also contain child code groups, so the return value reflects the complete set of code groups that were matched by the evidence provided.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="evidence" /> parameter is <see langword="null" />.</exception>
       </Docs>
     </Member>

--- a/xml/System.Security.Policy/Url.xml
+++ b/xml/System.Security.Policy/Url.xml
@@ -51,12 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The presence of <xref:System.Security.Policy.Url> evidence produces a <xref:System.Security.Permissions.UrlIdentityPermission> in the grant set. If there is a <xref:System.Security.CodeAccessPermission.Demand*> for <xref:System.Security.Permissions.UrlIdentityPermission>, the <xref:System.Security.Permissions.UrlIdentityPermission> that corresponds to the <xref:System.Security.Policy.Url> evidence is compared to the demanded permission.
-
- The complete URL is considered, including the protocol (HTTP, HTTPS, FTP) and the file. For example, `http://www.fourthcoffee.com/process/grind.htm` is a complete URL.
-
- URLs can be matched exactly or by a wildcard in the final position. For example, `http://www.fourthcoffee.com/process/*` is a wildcard URL.
-
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Security.Policy/Zone.xml
+++ b/xml/System.Security.Policy/Zone.xml
@@ -51,10 +51,6 @@
 
 [!INCLUDE[cas-deprecated](~/includes/cas-deprecated.md)]
 
- The presence of <xref:System.Security.Policy.Zone> evidence produces a <xref:System.Security.Permissions.ZoneIdentityPermission> in the grant set. If there is a <xref:System.Security.CodeAccessPermission.Demand*> for <xref:System.Security.Permissions.ZoneIdentityPermission>, the <xref:System.Security.Permissions.ZoneIdentityPermission> that corresponds to the <xref:System.Security.Policy.Zone> evidence will be compared with the demanded permission.
-
- Zones are defined by the <xref:System.Security.SecurityZone> enumeration.
-
  ]]></format>
     </remarks>
   </Docs>
@@ -170,14 +166,7 @@
         <param name="url">The URL from which to create the zone.</param>
         <summary>Creates a new zone with the specified URL.</summary>
         <returns>A new zone with the specified URL.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- The zone determination for the specified URL is based on the zone mapping settings in Internet options and can therefore differ from computer to computer. The zone mapping settings are located on the Security tab of the Internet Properties dialog launched from the control panel.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="url" /> parameter is <see langword="null" />.</exception>
       </Docs>
     </Member>
@@ -262,14 +251,7 @@
         <summary>Compares the current <see cref="T:System.Security.Policy.Zone" /> evidence object to the specified object for equivalence.</summary>
         <returns>
           <see langword="true" /> if the two <see cref="T:System.Security.Policy.Zone" /> objects are equal; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[
-
-## Remarks
- <xref:System.Security.Policy.Zone> objects are equal if they designate the same <xref:System.Security.SecurityZone>.
-
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">The <paramref name="o" /> parameter is not a <see cref="T:System.Security.Policy.Zone" /> object.</exception>
       </Docs>
     </Member>


### PR DESCRIPTION
.NET Framework API ref has moved to its own repo (https://github.com/dotnet/dotnetfw-api-docs), so we can clean up .NET Framework remarks, exceptions, and code examples out of this repo. Contributes to #12513.

Removes remarks and examples related to:

- .NET Framework versions
- Code-access security
- Configuring apps via app.config file
- App domains

Also removes *all* remarks from obsolete APIs.

*Hide whitespace changes*