### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/labeler-cache-retention.yml
+++ b/.github/workflows/labeler-cache-retention.yml
@@ -20,6 +20,10 @@ on:
         required: true
         default: "ACTIVE"
 
+
+permissions:
+  contents: read
+
 env:
   CACHE_KEY: ${{ inputs.cache_key || 'ACTIVE' }}
 


### PR DESCRIPTION
This PR adds a workflow-level `permissions: contents: read` to 1 workflow(s) that currently have no `permissions:` block (and therefore get the default broad read-write token). Each affected workflow was inspected and only reads repository contents; no publish/release/push/comment paths, so the change is non-functional in steady state and just shrinks the blast radius.

GitHub's documented Actions security recommendation. Happy to split per-file or adjust naming if preferred.