### PR TITLE
Remove opinions from Rfc2898DeriveBytes docs

### DIFF
--- a/snippets/csharp/System.Security.Cryptography/Rfc2898DeriveBytes/Overview/rfc28981.cs
+++ b/snippets/csharp/System.Security.Cryptography/Rfc2898DeriveBytes/Overview/rfc28981.cs
@@ -35,7 +35,7 @@ public class rfc2898test
             //data1 can be a string or contents of a file.
             string data1 = "Some test data";
             //<SNIPPET3>
-            //The default iteration count is 1000 so the two methods use the same iteration count.
+            //The legacy default iteration count is 1000 so the two methods use the same iteration count.
             int myIterations = 1000;
             //</SNIPPET6>		
             //<SNIPPET2>

--- a/snippets/visualbasic/System.Security.Cryptography/Rfc2898DeriveBytes/Overview/rfc28981.vb
+++ b/snippets/visualbasic/System.Security.Cryptography/Rfc2898DeriveBytes/Overview/rfc28981.vb
@@ -28,7 +28,7 @@ Public Class rfc2898test
             'data1 can be a string or contents of a file.
             Dim data1 As String = "Some test data"
             '<SNIPPET3>
-            'The default iteration count is 1000 so the two methods use the same iteration count.
+            'The legacy default iteration count is 1000 so the two methods use the same iteration count.
             Dim myIterations As Integer = 1000
             '</SNIPPET6>		
             '<SNIPPET2>

--- a/xml/System.Security.Cryptography/Rfc2898DeriveBytes.xml
+++ b/xml/System.Security.Cryptography/Rfc2898DeriveBytes.xml
@@ -321,7 +321,7 @@ For more information about PBKDF2, see [RFC 2898](https://www.rfc-editor.org/inf
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The salt size must be 8 bytes or larger and the iteration count must be greater than zero. The minimum recommended number of iterations is 1000.
+ The salt size must be 8 bytes or larger and the iteration count must be greater than zero.
 
  RFC 2898 includes methods for creating a key and initialization vector (IV) from a password and salt. You can use PBKDF2, a password-based key derivation function, to derive keys using a pseudo-random function that allows keys of virtually unlimited length to be generated. The <xref:System.Security.Cryptography.Rfc2898DeriveBytes> class can be used to produce a derived key from a base key and other parameters. In a password-based key derivation function, the base key is a password and the other parameters are a salt value and an iteration count.
 
@@ -398,7 +398,7 @@ For more information about PBKDF2, see [RFC 2898](https://www.rfc-editor.org/inf
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The salt size must be 8 bytes or larger and the iteration count must be greater than zero. The minimum recommended number of iterations is 1000.
+ The salt size must be 8 bytes or larger and the iteration count must be greater than zero.
 
  RFC 2898 includes methods for creating a key and initialization vector (IV) from a password and salt. You can use PBKDF2, a password-based key derivation function, to derive keys using a pseudo-random function that allows keys of virtually unlimited length to be generated. The <xref:System.Security.Cryptography.Rfc2898DeriveBytes> class can be used to produce a derived key from a base key and other parameters. In a password-based key derivation function, the base key is a password and the other parameters are a salt value and an iteration count.
 
@@ -482,7 +482,7 @@ For more information about PBKDF2, see [RFC 2898](https://www.rfc-editor.org/inf
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The salt size must be 8 bytes or larger and the iteration count must be greater than zero. The minimum recommended number of iterations is 1000.
+ The salt size must be 8 bytes or larger and the iteration count must be greater than zero.
 
  RFC 2898 includes methods for creating a key and initialization vector (IV) from a password and salt. You can use PBKDF2, a password-based key derivation function, to derive keys using a pseudo-random function that allows keys of virtually unlimited length to be generated. The <xref:System.Security.Cryptography.Rfc2898DeriveBytes> class can be used to produce a derived key from a base key and other parameters. In a password-based key derivation function, the base key is a password and the other parameters are a salt value and an iteration count.
 
@@ -965,12 +965,6 @@ For more information about PBKDF2, see [RFC 2898](https://www.rfc-editor.org/inf
         <value>The number of iterations for the operation.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[
-
-## Remarks
- Iteration count is the number of times an operation is performed. For this method, the count should be greater than zero. The minimum recommended number of iterations is 1000.
-
-
-
 ## Examples
  The following example shows how to use the <xref:System.Security.Cryptography.Rfc2898DeriveBytes.IterationCount> property to display the number of iterations used in the generation of the key. This code example is part of a larger example provided for the <xref:System.Security.Cryptography.Rfc2898DeriveBytes> class.
 


### PR DESCRIPTION
* Remove the "recommended minimum" from the API documentation.  The correct answer is too complicated for API docs.
* In the sample that references the "default" value (which is from an Obsolete constructor) call it instead the "legacy default".
