### PR TITLE
Clarify ConcurrentStack range exception docs

### DIFF
--- a/xml/System.Collections.Concurrent/ConcurrentStack`1.xml
+++ b/xml/System.Collections.Concurrent/ConcurrentStack`1.xml
@@ -605,7 +605,7 @@
         <exception cref="T:System.ArgumentNullException">
           <paramref name="items" /> is a null reference (Nothing in Visual Basic).</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
-          <paramref name="startIndex" /> or <paramref name="count" /> is negative. Or <paramref name="startIndex" /> is greater than or equal to the length of <paramref name="items" />.</exception>
+          <paramref name="startIndex" /> or <paramref name="count" /> is negative. Or <paramref name="startIndex" /> is greater than the length of <paramref name="items" />.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="startIndex" /> + <paramref name="count" /> is greater than the length of <paramref name="items" />.</exception>
         <related type="Article" href="/dotnet/standard/collections/thread-safe/">Thread-Safe Collections</related>
@@ -1221,7 +1221,7 @@ This member is an explicit interface member implementation. It can be used only 
         <exception cref="T:System.ArgumentNullException">
           <paramref name="items" /> is a null reference (Nothing in Visual Basic).</exception>
         <exception cref="T:System.ArgumentOutOfRangeException">
-          <paramref name="startIndex" /> or <paramref name="count" /> is negative. Or <paramref name="startIndex" /> is greater than or equal to the length of <paramref name="items" />.</exception>
+          <paramref name="startIndex" /> or <paramref name="count" /> is negative. Or <paramref name="startIndex" /> is greater than the length of <paramref name="items" />.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="startIndex" /> + <paramref name="count" /> is greater than the length of <paramref name="items" />.</exception>
         <related type="Article" href="/dotnet/standard/collections/thread-safe/">Thread-Safe Collections</related>


### PR DESCRIPTION
Fixes #10508.

Updates ConcurrentStack<T>.PushRange and TryPopRange exception documentation so startIndex equal to items.Length is not documented as ArgumentOutOfRangeException. The existing ArgumentException documentation still covers startIndex + count beyond the array length.

Validation:
- git diff --check
- XML parsed successfully with PowerShell [xml]