### PR TITLE
Fix spacing typo in IEnumerable<T> remarks ("property .You" -> "property. You")

### DIFF
--- a/xml/System.Collections.Generic/IEnumerable`1.xml
+++ b/xml/System.Collections.Generic/IEnumerable`1.xml
@@ -140,7 +140,7 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- The returned <xref:System.Collections.Generic.IEnumerator`1> provides the ability to iterate through the collection by exposing a <xref:System.Collections.Generic.IEnumerator`1.Current> property .You can use enumerators to read the data in a collection, but not to modify the collection.
+ The returned <xref:System.Collections.Generic.IEnumerator`1> provides the ability to iterate through the collection by exposing a <xref:System.Collections.Generic.IEnumerator`1.Current> property. You can use enumerators to read the data in a collection, but not to modify the collection.
 
  Initially, the enumerator is positioned before the first element in the collection. At this position, <xref:System.Collections.Generic.IEnumerator`1.Current*> is undefined. Therefore, you must call the <xref:System.Collections.IEnumerator.MoveNext*> method to advance the enumerator to the first element of the collection before reading the value of <xref:System.Collections.Generic.IEnumerator`1.Current*>.
 


### PR DESCRIPTION
Fixes #12726.

The `GetEnumerator` remarks in `xml/System.Collections.Generic/IEnumerable`1.xml` had a misplaced space around a sentence boundary: a space before the period and no space after it. The text read `...exposing a ...Current property .You can use enumerators...`.

This corrects it to `...exposing a ...Current property. You can use enumerators...` (space removed before the period, space added after it).

This is a single-line, content-only change — no markup, whitespace, or line-ending changes elsewhere in the file.