### PR TITLE
Clarify ValueTask consumption guidance

### DIFF
--- a/xml/System.Threading.Tasks/ValueTask.xml
+++ b/xml/System.Threading.Tasks/ValueTask.xml
@@ -74,9 +74,9 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
-A `ValueTask` instance may either be awaited or converted to a <xref:System.Threading.Tasks.Task> using <xref:System.Threading.Tasks.ValueTask.AsTask*>. A `ValueTask` instance may only be awaited once, and consumers may not call <xref:System.Threading.Tasks.ValueTask.GetAwaiter> until the instance has completed. If these limitations are unacceptable, convert the `ValueTask` to a <xref:System.Threading.Tasks.Task> by calling <xref:System.Threading.Tasks.ValueTask.AsTask*>.
+A `ValueTask` instance may either be awaited or converted to a <xref:System.Threading.Tasks.Task> using <xref:System.Threading.Tasks.ValueTask.AsTask*>. If the instance wraps a <xref:System.Threading.Tasks.Task> or a synchronous result, multiple awaits might succeed. However, a `ValueTask` instance can also be backed by a pooled <xref:System.Threading.Tasks.Sources.IValueTaskSource>, so consumers should treat an arbitrary `ValueTask` as single-consumption unless the provider explicitly documents support for multiple consumption. Consumers may not call <xref:System.Threading.Tasks.ValueTask.GetAwaiter> until the instance has completed. If these limitations are unacceptable, convert the `ValueTask` to a <xref:System.Threading.Tasks.Task> by calling <xref:System.Threading.Tasks.ValueTask.AsTask*>.
 
-The following operations should never be performed on a `ValueTask` instance:
+The following operations should not be performed on a `ValueTask` instance unless the provider explicitly documents that they are supported:
 
 - Awaiting the instance multiple times.
 - Calling <xref:System.Threading.Tasks.ValueTask.AsTask*> multiple times.

--- a/xml/System.Threading.Tasks/ValueTask`1.xml
+++ b/xml/System.Threading.Tasks/ValueTask`1.xml
@@ -90,9 +90,9 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
-A <xref:System.Threading.Tasks.ValueTask`1> instance may either be awaited or converted to a <xref:System.Threading.Tasks.Task`1> using <xref:System.Threading.Tasks.ValueTask`1.AsTask*>. A <xref:System.Threading.Tasks.ValueTask`1> instance may only be awaited once, and consumers may not read <xref:System.Threading.Tasks.ValueTask`1.Result> until the instance has completed. If these limitations are unacceptable, convert the <xref:System.Threading.Tasks.ValueTask`1> to a <xref:System.Threading.Tasks.Task`1> by calling <xref:System.Threading.Tasks.ValueTask`1.AsTask*>.
+A <xref:System.Threading.Tasks.ValueTask`1> instance may either be awaited or converted to a <xref:System.Threading.Tasks.Task`1> using <xref:System.Threading.Tasks.ValueTask`1.AsTask*>. If the instance wraps a <xref:System.Threading.Tasks.Task`1> or a synchronous result, multiple awaits might succeed. However, a <xref:System.Threading.Tasks.ValueTask`1> instance can also be backed by a pooled <xref:System.Threading.Tasks.Sources.IValueTaskSource`1>, so consumers should treat an arbitrary <xref:System.Threading.Tasks.ValueTask`1> as single-consumption unless the provider explicitly documents support for multiple consumption. Consumers may not read <xref:System.Threading.Tasks.ValueTask`1.Result> until the instance has completed. If these limitations are unacceptable, convert the <xref:System.Threading.Tasks.ValueTask`1> to a <xref:System.Threading.Tasks.Task`1> by calling <xref:System.Threading.Tasks.ValueTask`1.AsTask*>.
 
-The following operations should never be performed on a <xref:System.Threading.Tasks.ValueTask`1> instance:
+The following operations should not be performed on a <xref:System.Threading.Tasks.ValueTask`1> instance unless the provider explicitly documents that they are supported:
 
   - Awaiting the instance multiple times.
   - Calling <xref:System.Threading.Tasks.ValueTask`1.AsTask*> multiple times.


### PR DESCRIPTION
Fixes #12704.

This updates the `ValueTask` and `ValueTask<TResult>` remarks so the guidance is less absolute and reflects the backing-source distinction:

- instances backed by `Task` or a synchronous result may allow repeated awaits
- arbitrary `ValueTask` instances should still be treated as single-consumption because they may be backed by pooled `IValueTaskSource`
- `AsTask` remains the documented path when multiple consumption is needed

Validation:
- `git diff --check`
- confirmed the previous may-only-be-awaited-once wording no longer appears in the ValueTask XML docs

Disclosure: I used OpenAI Codex to implement and verify this documentation update.
