### PR TITLE
Document Expression.Block ReadOnlyCollection reuse

### DIFF
--- a/xml/System.Linq.Expressions/Expression.xml
+++ b/xml/System.Linq.Expressions/Expression.xml
@@ -2334,6 +2334,8 @@ If the implementing method is `null`:
 ## Remarks
  When the block expression is executed, it returns the value of the last expression in the block.
 
+If you pass a <xref:System.Collections.ObjectModel.ReadOnlyCollection%601> instance as the `expressions` argument, the returned <xref:System.Linq.Expressions.BlockExpression> might reuse that collection instead of copying it. Do not modify the collection's underlying storage after creating the block. If the source can be mutated, create a stable snapshot before passing it to this method.
+
  ]]></format>
         </remarks>
       </Docs>
@@ -2462,6 +2464,8 @@ If the implementing method is `null`:
 
 ## Remarks
  When the block expression is executed, it returns the value of the last expression in the block.
+
+If you pass a <xref:System.Collections.ObjectModel.ReadOnlyCollection%601> instance as the `expressions` argument, the returned <xref:System.Linq.Expressions.BlockExpression> might reuse that collection instead of copying it. Do not modify the collection's underlying storage after creating the block. If the source can be mutated, create a stable snapshot before passing it to this method.
 
 
 
@@ -2696,7 +2700,14 @@ If the implementing method is `null`:
         <param name="expressions">The expressions in the block.</param>
         <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given expressions, has no variables and has specific result type.</summary>
         <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+If you pass a <xref:System.Collections.ObjectModel.ReadOnlyCollection%601> instance as the `expressions` argument, the returned <xref:System.Linq.Expressions.BlockExpression> might reuse that collection instead of copying it. Do not modify the collection's underlying storage after creating the block. If the source can be mutated, create a stable snapshot before passing it to this method.
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="Block">
@@ -2809,7 +2820,14 @@ If the implementing method is `null`:
         <param name="expressions">The expressions in the block.</param>
         <summary>Creates a <see cref="T:System.Linq.Expressions.BlockExpression" /> that contains the given variables and expressions.</summary>
         <returns>The created <see cref="T:System.Linq.Expressions.BlockExpression" />.</returns>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[
+
+## Remarks
+If you pass a <xref:System.Collections.ObjectModel.ReadOnlyCollection%601> instance as the `expressions` argument, the returned <xref:System.Linq.Expressions.BlockExpression> might reuse that collection instead of copying it. Do not modify the collection's underlying storage after creating the block. If the source can be mutated, create a stable snapshot before passing it to this method.
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="Block">


### PR DESCRIPTION
﻿## Summary
- document that Expression.Block overloads accepting IEnumerable<Expression> can reuse a ReadOnlyCollection<Expression>
- warn callers not to mutate the underlying storage after creating the block
- suggest taking a stable snapshot when the original source can change

## Motivation
Addresses #12691. The runtime behavior discussed in dotnet/runtime#128813 is longstanding, so this adds the requested documentation warning rather than changing behavior.

## Validation
- git diff --check
- parsed xml/System.Linq.Expressions/Expression.xml with PowerShell [xml]

## Disclosure
Prepared with assistance from OpenAI Codex.
