### PR TITLE
Clean up exceptions

### DIFF
--- a/xml/System.Data.Common/DbDataReader.xml
+++ b/xml/System.Data.Common/DbDataReader.xml
@@ -2148,7 +2148,7 @@ private static void GetCredits(String connectionString)
 Returns <see langword="null" /> if the executed command returned no resultset, or after <see cref="M:System.Data.Common.DbDataReader.NextResult" /> returns <see langword="false" />.</summary>
         <returns>A <see cref="T:System.Data.DataTable" /> that describes the column metadata.</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.NotSupportedException">In all cases.</exception>
+        <exception cref="T:System.NotSupportedException">The base class implementation always throws this exception.</exception>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
       </Docs>
     </Member>

--- a/xml/System.Data.Common/DbDataReader.xml
+++ b/xml/System.Data.Common/DbDataReader.xml
@@ -2148,8 +2148,6 @@ private static void GetCredits(String connectionString)
 Returns <see langword="null" /> if the executed command returned no resultset, or after <see cref="M:System.Data.Common.DbDataReader.NextResult" /> returns <see langword="false" />.</summary>
         <returns>A <see cref="T:System.Data.DataTable" /> that describes the column metadata.</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Data.Common.DbDataReader" /> is closed.</exception>
-        <exception cref="T:System.IndexOutOfRangeException">The column index is out of range.</exception>
         <exception cref="T:System.NotSupportedException">In all cases.</exception>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
       </Docs>

--- a/xml/System.IO.Ports/SerialPort.xml
+++ b/xml/System.IO.Ports/SerialPort.xml
@@ -361,11 +361,6 @@
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">The stream is closed. This can occur because the <see cref="M:System.IO.Ports.SerialPort.Open" /> method has not been called or the <see cref="M:System.IO.Ports.SerialPort.Close" /> method has been called.</exception>
-        <exception cref="T:System.NotSupportedException">The stream is in a .NET Compact Framework application and one of the following methods was called:
-
- <see cref="M:System.IO.Stream.BeginRead(System.Byte[],System.Int32,System.Int32,System.AsyncCallback,System.Object)" /><see cref="M:System.IO.Stream.BeginWrite(System.Byte[],System.Int32,System.Int32,System.AsyncCallback,System.Object)" /><see cref="M:System.IO.Stream.EndRead(System.IAsyncResult)" /><see cref="M:System.IO.Stream.EndWrite(System.IAsyncResult)" />
-
- The .NET Compact Framework does not support the asynchronous model with base streams.</exception>
       </Docs>
     </Member>
     <Member MemberName="BaudRate">

--- a/xml/System.IO/Directory.xml
+++ b/xml/System.IO/Directory.xml
@@ -2060,9 +2060,6 @@ The returned collection is not cached. Each call to the <xref:System.Collections
  ]]></format>
         </remarks>
         <exception cref="T:System.UnauthorizedAccessException">The caller does not have the required permission.</exception>
-        <exception cref="T:System.NotSupportedException">The operating system is Windows CE, which does not have current directory functionality.
-
- This method is available in the .NET Compact Framework, but is not currently supported.</exception>
         <related type="Article" href="/dotnet/standard/io/">File and Stream I/O</related>
         <related type="Article" href="/dotnet/standard/io/how-to-read-text-from-a-file">How to: Read Text from a File</related>
         <related type="Article" href="/dotnet/standard/io/how-to-write-text-to-a-file">How to: Write Text to a File</related>

--- a/xml/System.IO/DirectoryInfo.xml
+++ b/xml/System.IO/DirectoryInfo.xml
@@ -445,11 +445,7 @@
 
  -or-
 
- The directory is the application's current working directory.
-
- -or-
-
- There is an open handle on the directory, and the operating system is Windows XP or earlier. This open handle can result from enumerating directories. For more information, see <see href="/dotnet/standard/io/how-to-enumerate-directories-and-files">How to: Enumerate Directories and Files</see>.</exception>
+ The directory is the application's current working directory.</exception>
         <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
         <related type="Article" href="/dotnet/standard/io/">File and Stream I/O</related>
         <related type="Article" href="/dotnet/standard/io/how-to-read-text-from-a-file">How to: Read Text from a File</related>
@@ -533,11 +529,7 @@
 
  -or-
 
- The directory is the application's current working directory.
-
- -or-
-
- There is an open handle on the directory or on one of its files, and the operating system is Windows XP or earlier. This open handle can result from enumerating directories and files. For more information, see <see href="/dotnet/standard/io/how-to-enumerate-directories-and-files">How to: Enumerate Directories and Files</see>.</exception>
+ The directory is the application's current working directory.</exception>
         <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
         <related type="Article" href="/dotnet/standard/io/">File and Stream I/O</related>
         <related type="Article" href="/dotnet/standard/io/how-to-read-text-from-a-file">How to: Read Text from a File</related>

--- a/xml/System.IO/File.xml
+++ b/xml/System.IO/File.xml
@@ -2118,11 +2118,7 @@ An I/O error occurred.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="path" /> is <see langword="null" />.</exception>
         <exception cref="T:System.IO.DirectoryNotFoundException">The specified path is invalid (for example, it is on an unmapped drive).</exception>
-        <exception cref="T:System.IO.IOException">The specified file is in use.
-
- -or-
-
- There is an open handle on the file, and the operating system is Windows XP or earlier. This open handle can result from enumerating directories and files. For more information, see <see href="/dotnet/standard/io/how-to-enumerate-directories-and-files">How to: Enumerate Directories and Files</see>.</exception>
+        <exception cref="T:System.IO.IOException">The specified file is in use.</exception>
         <exception cref="T:System.NotSupportedException">
           <paramref name="path" /> is in an invalid format.</exception>
         <exception cref="T:System.IO.PathTooLongException">The specified path, file name, or both exceed the system-defined maximum length. </exception>

--- a/xml/System.IO/FileInfo.xml
+++ b/xml/System.IO/FileInfo.xml
@@ -793,11 +793,6 @@ C:\Users\userName\AppData\Local\Temp\tmp70CB.tmp was successfully deleted.
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.IO.IOException">The target file is open or memory-mapped on a computer running Microsoft Windows NT.
-
- -or-
-
- There is an open handle on the file, and the operating system is Windows XP or earlier. This open handle can result from enumerating directories and files. For more information, see <see href="/dotnet/standard/io/how-to-enumerate-directories-and-files">How to: Enumerate Directories and Files</see>.</exception>
         <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
         <exception cref="T:System.UnauthorizedAccessException">The path is a directory.</exception>
         <related type="Article" href="/dotnet/standard/io/">File and Stream I/O</related>

--- a/xml/System.IO/FileSystemInfo.xml
+++ b/xml/System.IO/FileSystemInfo.xml
@@ -617,7 +617,6 @@ On Unix platforms that do not support creation or birth time, this property retu
         <summary>Deletes a file or directory.</summary>
         <remarks>To be added.</remarks>
         <exception cref="T:System.IO.DirectoryNotFoundException">The specified path is invalid; for example, it is on an unmapped drive.</exception>
-        <exception cref="T:System.IO.IOException">There is an open handle on the file or directory, and the operating system is Windows XP or earlier. This open handle can result from enumerating directories and files. For more information, see <see href="/dotnet/standard/io/how-to-enumerate-directories-and-files">How to: Enumerate Directories and Files</see>.</exception>
         <altmember cref="T:System.IO.FileSystemWatcher" />
         <related type="Article" href="/dotnet/standard/io/">File and Stream I/O</related>
         <related type="Article" href="/dotnet/standard/io/how-to-read-text-from-a-file">How to: Read Text from a File</related>

--- a/xml/System.IO/FileSystemWatcher.xml
+++ b/xml/System.IO/FileSystemWatcher.xml
@@ -184,23 +184,20 @@ Note that a <xref:System.IO.FileSystemWatcher> may miss an event when the buffer
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- You cannot watch a remote computer that does not have Windows NT or Windows 2000. You cannot watch a remote Windows NT 4.0 computer from a Windows NT 4.0 computer.
 
- The following table shows initial property values for an instance of <xref:System.IO.FileSystemWatcher>.
+The following table shows initial property values for an instance of <xref:System.IO.FileSystemWatcher>.
 
-|Property|Initial Value|
-|--------------|-------------------|
-|<xref:System.IO.FileSystemWatcher.NotifyFilter*>|bitwise OR combination of `LastWrite`, `FileName`, and `DirectoryName`|
-|<xref:System.IO.FileSystemWatcher.EnableRaisingEvents*>|`false`|
-|<xref:System.IO.FileSystemWatcher.Filter*>|"*.\*" (Watch all files.)|
-|<xref:System.IO.FileSystemWatcher.IncludeSubdirectories*>|`false`|
-|<xref:System.IO.FileSystemWatcher.InternalBufferSize*>|8192|
-|<xref:System.IO.FileSystemWatcher.Path*>|empty string ("")|
+| Property                                                  | Initial Value                                                          |
+|-----------------------------------------------------------|------------------------------------------------------------------------|
+| <xref:System.IO.FileSystemWatcher.NotifyFilter*>         | bitwise OR combination of `LastWrite`, `FileName`, and `DirectoryName` |
+| <xref:System.IO.FileSystemWatcher.EnableRaisingEvents*>  | `false`                                                                |
+| <xref:System.IO.FileSystemWatcher.Filter*>               | "*.\*" (Watch all files.)                                              |
+| <xref:System.IO.FileSystemWatcher.IncludeSubdirectories*> | `false`                                                                |
+| <xref:System.IO.FileSystemWatcher.InternalBufferSize*>   | 8192                                                                   |
+| <xref:System.IO.FileSystemWatcher.Path*>                 | empty string ("")                                                      |
 
 > [!NOTE]
->  The component will not watch the specified directory until the <xref:System.IO.FileSystemWatcher.Path*> is set, and <xref:System.IO.FileSystemWatcher.EnableRaisingEvents*> is `true`.
-
-
+> The component will not watch the specified directory until the <xref:System.IO.FileSystemWatcher.Path*> is set, and <xref:System.IO.FileSystemWatcher.EnableRaisingEvents*> is `true`.
 
 ## Examples
  The following example creates a <xref:System.IO.FileSystemWatcher> object to watch the directory specified at run time. The <xref:System.IO.FileSystemWatcher> object watches for changes in `LastWrite` and `LastAccess` times, and for the creation, deletion, or renaming of text files in the directory. If a file is changed, created, or deleted, the path to the file displays to the console. When a file is renamed, the old and new paths display to the console.
@@ -269,11 +266,11 @@ Note that a <xref:System.IO.FileSystemWatcher> may miss an event when the buffer
 ## Remarks
 
 > [!NOTE]
->  The component will not watch the specified directory until the <xref:System.IO.FileSystemWatcher.Path*> is set, and <xref:System.IO.FileSystemWatcher.EnableRaisingEvents*> is `true`.
+> The component will not watch the specified directory until the <xref:System.IO.FileSystemWatcher.Path*> is set, and <xref:System.IO.FileSystemWatcher.EnableRaisingEvents*> is `true`.
 
  The component can watch files on your personal computer, a network drive, or a remote computer.
 
- You cannot watch a remote computer that does not have Windows NT or Windows 2000. You cannot watch a remote Windows NT 4.0 computer from a Windows NT 4.0 computer. The <xref:System.IO.FileSystemWatcher.Filter> property is set by default to watch all files.
+The <xref:System.IO.FileSystemWatcher.Filter> property is set by default to watch all files.
 
  ]]></format>
         </remarks>
@@ -345,11 +342,9 @@ Note that a <xref:System.IO.FileSystemWatcher> may miss an event when the buffer
 ## Remarks
 
 > [!NOTE]
->  The component will not watch the specified directory until the <xref:System.IO.FileSystemWatcher.Path*> is set, and <xref:System.IO.FileSystemWatcher.EnableRaisingEvents*> is `true`.
+> The component will not watch the specified directory until the <xref:System.IO.FileSystemWatcher.Path*> is set, and <xref:System.IO.FileSystemWatcher.EnableRaisingEvents*> is `true`.
 
  The component can watch files on your personal computer, a network drive, or a remote computer.
-
- You cannot watch a remote computer that does not have Windows NT or Windows 2000. You cannot watch a remote Windows NT 4.0 computer from a Windows NT 4.0 computer.
 
  ]]></format>
         </remarks>
@@ -477,15 +472,15 @@ Note that a <xref:System.IO.FileSystemWatcher> may miss an event when the buffer
  The <xref:System.IO.FileSystemWatcher.Changed> event is raised when changes are made to the size, system attributes, last write time, last access time, or security permissions of a file or directory in the directory being monitored.
 
 > [!NOTE]
->  Common file system operations might raise more than one event. For example, when a file is moved from one directory to another, several <xref:System.IO.FileSystemWatcher.OnChanged*> and some <xref:System.IO.FileSystemWatcher.OnCreated*> and <xref:System.IO.FileSystemWatcher.OnDeleted*> events might be raised. Moving a file is a complex operation that consists of multiple simple operations, therefore raising multiple events. Likewise, some applications (for example, antivirus software) might cause additional file system events that are detected by <xref:System.IO.FileSystemWatcher>.
+> Common file system operations might raise more than one event. For example, when a file is moved from one directory to another, several <xref:System.IO.FileSystemWatcher.OnChanged*> and some <xref:System.IO.FileSystemWatcher.OnCreated*> and <xref:System.IO.FileSystemWatcher.OnDeleted*> events might be raised. Moving a file is a complex operation that consists of multiple simple operations, therefore raising multiple events. Likewise, some applications (for example, antivirus software) might cause additional file system events that are detected by <xref:System.IO.FileSystemWatcher>.
 
  Use <xref:System.IO.FileSystemWatcher.NotifyFilter*> to restrict the number of notifications raised when this event is handled.
 
 > [!NOTE]
->  The <xref:System.IO.FileSystemWatcher.Changed> event is raised unexpectedly when a file is renamed, but is not raised when a directory is renamed. To watch for renaming, use the <xref:System.IO.FileSystemWatcher.Renamed> event.
+> The <xref:System.IO.FileSystemWatcher.Changed> event is raised unexpectedly when a file is renamed, but is not raised when a directory is renamed. To watch for renaming, use the <xref:System.IO.FileSystemWatcher.Renamed> event.
 
 > [!NOTE]
->  The order in which the <xref:System.IO.FileSystemWatcher.Changed> event is raised in relation to the other <xref:System.IO.FileSystemWatcher> events may change when the <xref:System.IO.FileSystemWatcher.SynchronizingObject> property is not `null`.
+> The order in which the <xref:System.IO.FileSystemWatcher.Changed> event is raised in relation to the other <xref:System.IO.FileSystemWatcher> events may change when the <xref:System.IO.FileSystemWatcher.SynchronizingObject> property is not `null`.
 
 
 
@@ -551,10 +546,10 @@ Note that a <xref:System.IO.FileSystemWatcher> may miss an event when the buffer
  Some common occurrences, such as copying or moving a file or directory, do not correspond directly to an event, but these occurrences do cause events to be raised. When you copy a file or directory, the system raises a <xref:System.IO.FileSystemWatcher.Created> event in the directory to which the file was copied, if that directory is being watched. If the directory from which you copied was being watched by another instance of <xref:System.IO.FileSystemWatcher>, no event would be raised. For example, you create two instances of <xref:System.IO.FileSystemWatcher>. FileSystemWatcher1 is set to watch "C:\My Documents", and FileSystemWatcher2 is set to watch "C:\Your Documents". If you copy a file from "My Documents" into "Your Documents", a <xref:System.IO.FileSystemWatcher.Created> event will be raised by FileSystemWatcher2, but no event is raised for FileSystemWatcher1. Unlike copying, moving a file or directory would raise two events. From the previous example, if you moved a file from "My Documents" to "Your Documents", a <xref:System.IO.FileSystemWatcher.Created> event would be raised by FileSystemWatcher2 and a <xref:System.IO.FileSystemWatcher.Deleted> event would be raised by FileSystemWatcher1.
 
 > [!NOTE]
->  Common file system operations might raise more than one event. For example, when a file is moved from one directory to another, several <xref:System.IO.FileSystemWatcher.OnChanged*> and some <xref:System.IO.FileSystemWatcher.OnCreated*> and <xref:System.IO.FileSystemWatcher.OnDeleted*> events might be raised. Moving a file is a complex operation that consists of multiple simple operations, therefore raising multiple events. Likewise, some applications (for example, antivirus software) might cause additional file system events that are detected by <xref:System.IO.FileSystemWatcher>.
+> Common file system operations might raise more than one event. For example, when a file is moved from one directory to another, several <xref:System.IO.FileSystemWatcher.OnChanged*> and some <xref:System.IO.FileSystemWatcher.OnCreated*> and <xref:System.IO.FileSystemWatcher.OnDeleted*> events might be raised. Moving a file is a complex operation that consists of multiple simple operations, therefore raising multiple events. Likewise, some applications (for example, antivirus software) might cause additional file system events that are detected by <xref:System.IO.FileSystemWatcher>.
 
 > [!NOTE]
->  The order in which the <xref:System.IO.FileSystemWatcher.Created> event is raised in relation to the other <xref:System.IO.FileSystemWatcher> events may change when the <xref:System.IO.FileSystemWatcher.SynchronizingObject> property is not `null`.
+> The order in which the <xref:System.IO.FileSystemWatcher.Created> event is raised in relation to the other <xref:System.IO.FileSystemWatcher> events may change when the <xref:System.IO.FileSystemWatcher.SynchronizingObject> property is not `null`.
 
  The <xref:System.IO.FileSystemWatcher.OnCreated*> event is raised as soon as a file is created. If a file is being copied or transferred into a watched directory, the <xref:System.IO.FileSystemWatcher.OnCreated*> event will be raised immediately, followed by one or more <xref:System.IO.FileSystemWatcher.OnChanged*> events.
 
@@ -623,10 +618,10 @@ Note that a <xref:System.IO.FileSystemWatcher> may miss an event when the buffer
  Some common occurrences, such as copying or moving a file or directory, do not correspond directly to an event, but these occurrences do cause events to be raised. When you copy a file or directory, the system raises a <xref:System.IO.FileSystemWatcher.Created> event in the directory to which the file was copied, if that directory is being watched. If the directory from which you copied was being watched by another instance of <xref:System.IO.FileSystemWatcher>, no event would be raised. For example, you create two instances of <xref:System.IO.FileSystemWatcher>. FileSystemWatcher1 is set to watch "C:\My Documents", and FileSystemWatcher2 is set to watch "C:\Your Documents". If you copy a file from "My Documents" into "Your Documents", a <xref:System.IO.FileSystemWatcher.Created> event will be raised by FileSystemWatcher2, but no event is raised for FileSystemWatcher1. Unlike copying, moving a file or directory would raise two events. From the previous example, if you moved a file from "My Documents" to "Your Documents", a <xref:System.IO.FileSystemWatcher.Created> event would be raised by FileSystemWatcher2 and a <xref:System.IO.FileSystemWatcher.Deleted> event would be raised by FileSystemWatcher1.
 
 > [!NOTE]
->  Common file system operations might raise more than one event. For example, when a file is moved from one directory to another, several <xref:System.IO.FileSystemWatcher.OnChanged*> and some <xref:System.IO.FileSystemWatcher.OnCreated*> and <xref:System.IO.FileSystemWatcher.OnDeleted*> events might be raised. Moving a file is a complex operation that consists of multiple simple operations, therefore raising multiple events. Likewise, some applications (for example, antivirus software) might cause additional file system events that are detected by <xref:System.IO.FileSystemWatcher>.
+> Common file system operations might raise more than one event. For example, when a file is moved from one directory to another, several <xref:System.IO.FileSystemWatcher.OnChanged*> and some <xref:System.IO.FileSystemWatcher.OnCreated*> and <xref:System.IO.FileSystemWatcher.OnDeleted*> events might be raised. Moving a file is a complex operation that consists of multiple simple operations, therefore raising multiple events. Likewise, some applications (for example, antivirus software) might cause additional file system events that are detected by <xref:System.IO.FileSystemWatcher>.
 
 > [!NOTE]
->  The order in which the <xref:System.IO.FileSystemWatcher.Deleted> event is raised in relation to the other <xref:System.IO.FileSystemWatcher> events may change when the <xref:System.IO.FileSystemWatcher.SynchronizingObject> property is not `null`.
+> The order in which the <xref:System.IO.FileSystemWatcher.Deleted> event is raised in relation to the other <xref:System.IO.FileSystemWatcher> events may change when the <xref:System.IO.FileSystemWatcher.SynchronizingObject> property is not `null`.
 
 
 
@@ -792,7 +787,7 @@ Note that a <xref:System.IO.FileSystemWatcher> may miss an event when the buffer
  The component will not raise events unless you set <xref:System.IO.FileSystemWatcher.EnableRaisingEvents*> to `true`.
 
 > [!NOTE]
->  The component will not watch the specified directory until the <xref:System.IO.FileSystemWatcher.Path> property has been set and <xref:System.IO.FileSystemWatcher.EnableRaisingEvents*> is `true`.
+> The component will not watch the specified directory until the <xref:System.IO.FileSystemWatcher.Path> property has been set and <xref:System.IO.FileSystemWatcher.EnableRaisingEvents*> is `true`.
 
  The <xref:System.IO.FileSystemWatcher.WaitForChanged*> method allows event handlers to be invoked to respond to file changes even if this property is set to `false`.
 
@@ -915,7 +910,7 @@ Note that a <xref:System.IO.FileSystemWatcher> may miss an event when the buffer
  The system notifies you of file changes, and it stores those changes in a buffer that the component creates and passes to the APIs. If there are many changes in a short time, the buffer can overflow. This causes the component to lose track of changes in the directory, and it will only provide blanket notification. Increasing the size of the buffer is expensive, because it comes from non paged memory that cannot be swapped out to disk, so keep the buffer as small as possible. To avoid a buffer overflow, use the <xref:System.IO.FileSystemWatcher.NotifyFilter*>, <xref:System.IO.FileSystemWatcher.Filter*>, and <xref:System.IO.FileSystemWatcher.IncludeSubdirectories*> properties to filter out unwanted change notifications.
 
 > [!NOTE]
->  Common file system operations might raise more than one event. For example, when a file is moved from one directory to another, several <xref:System.IO.FileSystemWatcher.OnChanged*> and some <xref:System.IO.FileSystemWatcher.OnCreated*> and <xref:System.IO.FileSystemWatcher.OnDeleted*> events might be raised. Moving a file is a complex operation that consists of multiple simple operations, therefore raising multiple events. Likewise, some applications (for example, antivirus software) might cause additional file system events that are detected by <xref:System.IO.FileSystemWatcher>.
+> Common file system operations might raise more than one event. For example, when a file is moved from one directory to another, several <xref:System.IO.FileSystemWatcher.OnChanged*> and some <xref:System.IO.FileSystemWatcher.OnCreated*> and <xref:System.IO.FileSystemWatcher.OnDeleted*> events might be raised. Moving a file is a complex operation that consists of multiple simple operations, therefore raising multiple events. Likewise, some applications (for example, antivirus software) might cause additional file system events that are detected by <xref:System.IO.FileSystemWatcher>.
 
  ]]></format>
         </remarks>
@@ -1613,7 +1608,7 @@ Note that a <xref:System.IO.FileSystemWatcher> may miss an event when the buffer
  The <xref:System.IO.FileSystemWatcher.Path> property supports Universal Naming Convention (UNC) paths.
 
 > [!NOTE]
->  This property must be set before the component can watch for changes.
+> This property must be set before the component can watch for changes.
 
  When a directory is renamed, the <xref:System.IO.FileSystemWatcher> automatically reattaches itself to the newly renamed item. For example, if you set the <xref:System.IO.FileSystemWatcher.Path> property to "C:\My Documents" and then manually rename the directory to "C:\Your Documents", the component continues listening for change notifications on the newly renamed directory. However, when you ask for the <xref:System.IO.FileSystemWatcher.Path> property, it contains the old path. This happens because the component determines what directory watches based on the handle, rather than the name of the directory. Renaming does not affect the handle. So, if you destroy the component, and then recreate it without updating the <xref:System.IO.FileSystemWatcher.Path> property, your application will fail because the directory no longer exists.
 
@@ -1879,7 +1874,7 @@ Public Delegate Sub RenamedEventHandler(sender As Object, e As RenamedEventArgs)
  This method waits indefinitely until the first change occurs and then returns. This is the same as using <xref:System.IO.FileSystemWatcher.WaitForChanged*> with the `timeout` parameter set to -1.
 
 > [!NOTE]
->  This method allows an event handler to be invoked to respond to file changes even if the <xref:System.IO.FileSystemWatcher.EnableRaisingEvents> property is set to `false`.
+> This method allows an event handler to be invoked to respond to file changes even if the <xref:System.IO.FileSystemWatcher.EnableRaisingEvents> property is set to `false`.
 
  In some systems, <xref:System.IO.FileSystemWatcher> reports changes to files using the short 8.3 file name format. For example, a change to  "LongFileName.LongExtension" could be reported as "LongFi~.Lon".
 
@@ -1941,7 +1936,7 @@ Public Delegate Sub RenamedEventHandler(sender As Object, e As RenamedEventArgs)
  This method waits until a change occurs or it has timed out. A value of -1 for the `timeout` parameter means wait indefinitely.
 
 > [!NOTE]
->  This method allows an event handler to be invoked to respond to file changes even if the <xref:System.IO.FileSystemWatcher.EnableRaisingEvents> property is set to `false`.
+> This method allows an event handler to be invoked to respond to file changes even if the <xref:System.IO.FileSystemWatcher.EnableRaisingEvents> property is set to `false`.
 
  In some systems, <xref:System.IO.FileSystemWatcher> reports changes to files using the short 8.3 file name format. For example, a change to  "LongFileName.LongExtension" could be reported as "LongFi~.Lon".
 

--- a/xml/System.Net.Sockets/Socket.xml
+++ b/xml/System.Net.Sockets/Socket.xml
@@ -6411,11 +6411,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.
-
--or-
-
- In .NET Compact Framework applications, the Windows CE default buffer space is set to 32768 bytes. You can change the per socket buffer space by calling <see cref="Overload:System.Net.Sockets.Socket.SetSocketOption" />.</exception>
+        <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.SetSocketOption(System.Net.Sockets.SocketOptionLevel,System.Net.Sockets.SocketOptionName,System.Int32)" />
         <altmember cref="T:System.Net.Sockets.SocketOptionName" />
@@ -6490,11 +6486,7 @@ In general, the `GetSocketOption` method should be used whenever getting a <xref
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.
-
--or-
-
- In .NET Compact Framework applications, the Windows CE default buffer space is set to 32768 bytes. You can change the per socket buffer space by calling <see cref="Overload:System.Net.Sockets.Socket.SetSocketOption" />.</exception>
+        <exception cref="T:System.Net.Sockets.SocketException">An error occurred when attempting to access the socket.</exception>
         <exception cref="T:System.ObjectDisposedException"> The <see cref="T:System.Net.Sockets.Socket" /> has been closed.</exception>
         <altmember cref="M:System.Net.Sockets.Socket.SetSocketOption(System.Net.Sockets.SocketOptionLevel,System.Net.Sockets.SocketOptionName,System.Int32)" />
         <altmember cref="T:System.Net.Sockets.SocketOptionName" />

--- a/xml/System.Net.Sockets/TcpClient.xml
+++ b/xml/System.Net.Sockets/TcpClient.xml
@@ -2303,8 +2303,6 @@ The `GetStream` method returns a <xref:System.Net.Sockets.NetworkStream> that yo
 
  If the network buffer is smaller than the amount of data you request in the `Read` method, you will not be able to retrieve the desired amount of data in one read operation. This incurs the overhead of additional calls to the `Read` method.
 
-
-
 ## Examples
  The following code example sets and gets the receive buffer size.
 
@@ -2313,11 +2311,7 @@ The `GetStream` method returns a <xref:System.Net.Sockets.NetworkStream> that yo
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.Net.Sockets.SocketException">An error occurred when setting the buffer size.
-
- -or-
-
- In .NET Compact Framework applications, you cannot set this property. For a workaround, see the Platform Note in Remarks.</exception>
+        <exception cref="T:System.Net.Sockets.SocketException">An error occurred when setting the buffer size.</exception>
         <altmember cref="P:System.Net.Sockets.TcpClient.SendBufferSize" />
         <altmember cref="M:System.Net.Sockets.NetworkStream.Read(System.Byte[],System.Int32,System.Int32)" />
       </Docs>

--- a/xml/System.Net/HttpWebRequest.xml
+++ b/xml/System.Net/HttpWebRequest.xml
@@ -1058,7 +1058,6 @@
         <exception cref="T:System.NotSupportedException">The request cache validator indicated that the response for this request can be served from the cache; however, requests that write data must not use the cache. This exception can occur if you are using a custom cache validator that is incorrectly implemented.</exception>
         <exception cref="T:System.Net.WebException">
           <see cref="M:System.Net.HttpWebRequest.Abort" /> was previously called.</exception>
-        <exception cref="T:System.ObjectDisposedException">In a .NET Compact Framework application, a request stream with zero content length was not obtained and closed correctly.</exception>
       </Docs>
     </Member>
     <Member MemberName="BeginGetResponse">
@@ -2204,7 +2203,6 @@
  -or-
 
  An error occurred while processing the request.</exception>
-        <exception cref="T:System.ObjectDisposedException">In a .NET Compact Framework application, a request stream with zero content length was not obtained and closed correctly.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetRequestStream">

--- a/xml/System/Type.xml
+++ b/xml/System/Type.xml
@@ -11563,7 +11563,6 @@ The following table summarizes the interactions between `assemblyResolver`, `typ
  The current <see cref="T:System.Type" /> object represents a type that contains open type parameters, that is, <see cref="P:System.Type.ContainsGenericParameters" /> returns <see langword="true" />.</exception>
         <exception cref="T:System.Reflection.TargetException">The specified member cannot be invoked on <paramref name="target" />.</exception>
         <exception cref="T:System.Reflection.AmbiguousMatchException">More than one method matches the binding criteria.</exception>
-        <exception cref="T:System.NotSupportedException">The .NET Compact Framework does not currently support this method.</exception>
         <exception cref="T:System.InvalidOperationException">The method represented by <paramref name="name" /> has one or more unspecified generic type parameters. That is, the method's <see cref="P:System.Reflection.MethodBase.ContainsGenericParameters" /> property returns <see langword="true" />.</exception>
         <altmember cref="T:System.String" />
         <altmember cref="T:System.Reflection.Binder" />
@@ -17243,7 +17242,6 @@ The following example uses the <xref:System.Type.MakeGenericType*> method to cre
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.NotSupportedException">The .NET Compact Framework does not currently support this property.</exception>
         <altmember cref="T:System.RuntimeTypeHandle" />
         <altmember cref="M:System.Type.GetTypeHandle(System.Object)" />
         <altmember cref="M:System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)" />


### PR DESCRIPTION
- Remove exceptions for Compact Framework
- Remove exceptions for old Windows versions
- Remove other exceptions when NSE is always thrown

Contributes to #12513.