### PR TITLE
Remove assembly info from MemberGroup elements (System.X* ++)

### DIFF
--- a/xml/System.Data.Common/DBDataPermission.xml
+++ b/xml/System.Data.Common/DBDataPermission.xml
@@ -57,11 +57,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see langword="DBDataPermission" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.Common/DataAdapter.xml
+++ b/xml/System.Data.Common/DataAdapter.xml
@@ -75,11 +75,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Common.DataAdapter" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -540,11 +535,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Fill">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds or refreshes rows in the <see cref="T:System.Data.DataSet" /> to match those in the data source.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -909,11 +899,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="FillSchema">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a <see cref="T:System.Data.DataTable" /> to the specified <see cref="T:System.Data.DataSet" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.Common/DataColumnMapping.xml
+++ b/xml/System.Data.Common/DataColumnMapping.xml
@@ -82,11 +82,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Common.DataColumnMapping" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -260,11 +255,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetDataColumnBySchemaAction">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets a <see cref="T:System.Data.DataColumn" /> from the given <see cref="T:System.Data.DataTable" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.Common/DataColumnMappingCollection.xml
+++ b/xml/System.Data.Common/DataColumnMappingCollection.xml
@@ -128,11 +128,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a <see cref="T:System.Data.Common.DataColumnMapping" /> object to the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -267,11 +262,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="AddRange">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds an array of values to the end of the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -425,11 +415,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Contains">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets a value indicating whether a <see cref="T:System.Data.Common.DataColumnMapping" /> object exists in the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -561,11 +546,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies the elements of the collection to an array.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1014,11 +994,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="IndexOf">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the location of the specified <see cref="T:System.Data.Common.DataColumnMapping" /> within the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1205,11 +1180,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Insert">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Inserts an object into the <see cref="T:System.Data.Common.DataColumnMappingCollection" /> at a specified index.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1315,11 +1285,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Data.Common.DataColumnMapping" /> object specified.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1460,11 +1425,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Remove">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes a specified object from the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1578,11 +1538,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="RemoveAt">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes the specified <see cref="T:System.Data.Common.DataColumnMapping" /> object from the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.Common/DataTableMapping.xml
+++ b/xml/System.Data.Common/DataTableMapping.xml
@@ -80,11 +80,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Common.DataTableMapping" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.Common/DataTableMappingCollection.xml
+++ b/xml/System.Data.Common/DataTableMappingCollection.xml
@@ -134,11 +134,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a <see cref="T:System.Data.Common.DataTableMapping" /> object to the collection.</summary>
       </Docs>
@@ -270,11 +265,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="AddRange">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies the elements of a given array to the end of the collection.</summary>
       </Docs>
@@ -424,11 +414,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Contains">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets a value indicating whether a particular <see cref="T:System.Data.Common.DataTableMapping" /> object exists in the collection.</summary>
       </Docs>
@@ -556,11 +541,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies the elements of a given collection to the specified array.</summary>
       </Docs>
@@ -925,11 +905,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="IndexOf">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the location of the specified <see cref="T:System.Data.Common.DataTableMapping" /> object within the collection.</summary>
       </Docs>
@@ -1112,11 +1087,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Insert">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Inserts an object into the <see cref="T:System.Data.Common.DataTableMappingCollection" /> at a specified index.</summary>
       </Docs>
@@ -1219,11 +1189,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Data.Common.DataTableMapping" /> object specified.</summary>
       </Docs>
@@ -1361,11 +1326,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Remove">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes a specified object from the collection.</summary>
       </Docs>
@@ -1476,11 +1436,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="RemoveAt">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes the specified <see cref="T:System.Data.Common.DataTableMapping" /> object from the collection.</summary>
       </Docs>

--- a/xml/System.Data.Common/DbCommand.xml
+++ b/xml/System.Data.Common/DbCommand.xml
@@ -980,10 +980,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ExecuteNonQueryAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>This method implements the asynchronous version of <see cref="M:System.Data.Common.DbCommand.ExecuteNonQuery" />, but returns a <see cref="T:System.Threading.Tasks.Task" /> synchronously, blocking the calling thread.</summary>
         <remarks>
@@ -1115,11 +1111,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ExecuteReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Executes the command against its connection, returning a <see cref="T:System.Data.Common.DbDataReader" /> that can be used to access the results.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1217,10 +1208,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ExecuteReaderAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>An asynchronous version of <see cref="Overload:System.Data.Common.DbCommand.ExecuteReader" />, which executes the command against its connection, returning a <see cref="T:System.Data.Common.DbDataReader" /> that can be used to access the results.</summary>
         <remarks>
@@ -1527,10 +1514,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ExecuteScalarAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Implements the asynchronous version of <see cref="M:System.Data.Common.DbCommand.ExecuteScalar" />, but returns a <see cref="T:System.Threading.Tasks.Task" /> synchronously, blocking the calling thread.</summary>
         <remarks>
@@ -1947,11 +1930,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="System.Data.IDbCommand.ExecuteReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Executes the <see cref="P:System.Data.IDbCommand.CommandText" /> against the <see cref="P:System.Data.IDbCommand.Connection" /> and builds an <see cref="T:System.Data.IDataReader" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.Common/DbCommandBuilder.xml
+++ b/xml/System.Data.Common/DbCommandBuilder.xml
@@ -450,11 +450,6 @@ When the `disposing` parameter is `true`, this method releases all resources hel
       </Docs>
     </Member>
     <MemberGroup MemberName="GetDeleteCommand">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the automatically generated <see cref="T:System.Data.Common.DbCommand" /> object required to perform deletions at the data source.</summary>
         <remarks>
@@ -597,11 +592,6 @@ When the `disposing` parameter is `true`, this method releases all resources hel
       </Docs>
     </Member>
     <MemberGroup MemberName="GetInsertCommand">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the automatically generated <see cref="T:System.Data.Common.DbCommand" /> object required to perform insertions at the data source.</summary>
         <remarks>
@@ -744,11 +734,6 @@ When the `disposing` parameter is `true`, this method releases all resources hel
       </Docs>
     </Member>
     <MemberGroup MemberName="GetParameterName">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the name of the specified parameter.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -964,11 +949,6 @@ When the `disposing` parameter is `true`, this method releases all resources hel
       </Docs>
     </Member>
     <MemberGroup MemberName="GetUpdateCommand">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the automatically generated <see cref="T:System.Data.Common.DbCommand" /> object required to perform updates at the data source.</summary>
         <remarks>

--- a/xml/System.Data.Common/DbConnection.xml
+++ b/xml/System.Data.Common/DbConnection.xml
@@ -233,10 +233,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginTransaction">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Starts a database transaction.</summary>
         <remarks>
@@ -1312,11 +1308,6 @@ This property returns `false` by default; providers that implement <xref:System.
       </Docs>
     </Member>
     <MemberGroup MemberName="GetSchema">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns schema information for the data source of this <see cref="T:System.Data.Common.DbConnection" />.</summary>
         <remarks>
@@ -1748,10 +1739,6 @@ This property returns `false` by default; providers that implement <xref:System.
       </Docs>
     </Member>
     <MemberGroup MemberName="OpenAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.Data.Common.DbException">An error occurred while opening the connection.</exception>
         <summary>This method implements an asynchronous version of <see cref="M:System.Data.Common.DbConnection.Open" />.</summary>
@@ -2046,11 +2033,6 @@ This property returns `false` by default; providers that implement <xref:System.
       </Docs>
     </Member>
     <MemberGroup MemberName="System.Data.IDbConnection.BeginTransaction">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins a database transaction.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.Common/DbConnectionStringBuilder.xml
+++ b/xml/System.Data.Common/DbConnectionStringBuilder.xml
@@ -130,11 +130,6 @@ initial catalog="AdventureWorks;NewValue=Bad"
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Common.DbConnectionStringBuilder" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/connection-strings">Connection Strings in ADO.NET</related>
@@ -298,11 +293,6 @@ initial catalog="AdventureWorks;NewValue=Bad"
       </Docs>
     </Member>
     <MemberGroup MemberName="AppendKeyValuePair">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Provides an efficient and safe way to append a key and value to an existing <see cref="T:System.Text.StringBuilder" /> object.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/connection-strings">Connection Strings in ADO.NET</related>
@@ -2399,11 +2389,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ComponentModel.ICustomTypeDescriptor.GetEvents">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the events for this instance of a component.</summary>
       </Docs>
@@ -2528,11 +2513,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ComponentModel.ICustomTypeDescriptor.GetProperties">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the properties for this instance of a component.</summary>
       </Docs>

--- a/xml/System.Data.Common/DbDataAdapter.xml
+++ b/xml/System.Data.Common/DbDataAdapter.xml
@@ -105,11 +105,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see langword="DataAdapter" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -701,11 +696,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Fill">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Fills a <see cref="T:System.Data.DataSet" /> or a <see cref="T:System.Data.DataTable" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1554,11 +1544,6 @@ adapter.Fill(dataset, "AAA"); // Fills table "aaa" because only one similarly na
       </Docs>
     </Member>
     <MemberGroup MemberName="FillSchema">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a <see cref="T:System.Data.DataTable" /> to a <see cref="T:System.Data.DataSet" /> and configures the schema to match that in the data source.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -2989,11 +2974,6 @@ adapter.FillSchema(dataset, "AAA"); // Fills the schema of table "aaa" because o
       </Docs>
     </Member>
     <MemberGroup MemberName="Update">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Updates the values in the database by executing the respective INSERT, UPDATE, or DELETE statements for each inserted, updated, or deleted row in the <see cref="T:System.Data.DataSet" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.Common/DbDataReader.xml
+++ b/xml/System.Data.Common/DbDataReader.xml
@@ -268,11 +268,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Dispose">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Releases the resources used by the <see cref="T:System.Data.Common.DbDataReader" /> and calls <see cref="M:System.Data.Common.DbDataReader.Close" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1350,10 +1345,6 @@ private static void GetDataTypes(String connectionString)
       </Docs>
     </Member>
     <MemberGroup MemberName="GetFieldValueAsync&lt;T&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Asynchronously gets the value of the specified column as the requested type.</summary>
       </Docs>
@@ -2645,11 +2636,6 @@ Returns <see langword="null" /> if the executed command returned no resultset, o
       </Docs>
     </Member>
     <MemberGroup MemberName="IsDBNullAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Asynchronously gets a value that indicates whether the column contains non-existent or missing values.</summary>
       </Docs>
@@ -2817,11 +2803,6 @@ Returns <see langword="null" /> if the executed command returned no resultset, o
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the value of a specified column as an instance of <see cref="T:System.Object" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -2985,10 +2966,6 @@ Returns <see langword="null" /> if the executed command returned no resultset, o
       </Docs>
     </Member>
     <MemberGroup MemberName="NextResultAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Asynchronously advances the reader to the next result when reading the results of a batch of statements.</summary>
         <remarks>
@@ -3174,10 +3151,6 @@ Returns <see langword="null" /> if the executed command returned no resultset, o
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Asynchronously advances the reader to the next record in a result set.</summary>
         <remarks>

--- a/xml/System.Data.Common/DbDataRecord.xml
+++ b/xml/System.Data.Common/DbDataRecord.xml
@@ -1457,11 +1457,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Indicates that value from a column in its native format. This property is read-only.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.Common/DbEnumerator.xml
+++ b/xml/System.Data.Common/DbEnumerator.xml
@@ -70,11 +70,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Common.DbEnumerator" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.Common/DbException.xml
+++ b/xml/System.Data.Common/DbException.xml
@@ -73,10 +73,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Common.DbException" /> class.</summary>
         <remarks>

--- a/xml/System.Data.Common/DbParameterCollection.xml
+++ b/xml/System.Data.Common/DbParameterCollection.xml
@@ -259,11 +259,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Contains">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Indicates whether a <see cref="T:System.Data.Common.DbParameter" /> with the specified property exists in the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -532,11 +527,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetParameter">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the <see cref="T:System.Data.Common.DbParameter" /> with the specified property value.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -637,11 +627,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="IndexOf">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the index of the specified <see cref="T:System.Data.Common.DbParameter" /> object.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -979,11 +964,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets a <see cref="T:System.Data.Common.DbParameter" /> in the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1135,11 +1115,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="RemoveAt">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes a specified <see cref="T:System.Data.Common.DbParameter" /> object from the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1244,11 +1219,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="SetParameter">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sets the specified parameter to the specified value.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.Common/DbProviderFactories.xml
+++ b/xml/System.Data.Common/DbProviderFactories.xml
@@ -53,10 +53,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="GetFactory">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns an instance of a <see cref="T:System.Data.Common.DbProviderFactory" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dbproviderfactories">DbProviderFactories (ADO.NET)</related>

--- a/xml/System.Data.Common/DbTransaction.xml
+++ b/xml/System.Data.Common/DbTransaction.xml
@@ -329,10 +329,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Dispose">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Releases the unmanaged resources used by the <see cref="T:System.Data.Common.DbTransaction" /> and optionally releases the managed resources.</summary>
         <remarks>

--- a/xml/System.Data.Common/RowUpdatedEventArgs.xml
+++ b/xml/System.Data.Common/RowUpdatedEventArgs.xml
@@ -172,11 +172,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyToRows">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Lets you access the rows processed during a batch update operation.</summary>
         <remarks>To be added.</remarks>

--- a/xml/System.Data.Odbc/OdbcCommand.xml
+++ b/xml/System.Data.Odbc/OdbcCommand.xml
@@ -85,10 +85,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Odbc.OdbcCommand" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/executing-a-command">Executing a Command</related>
@@ -835,10 +831,6 @@ SELECT * FROM Customers WHERE CustomerID = ?
       </Docs>
     </Member>
     <MemberGroup MemberName="ExecuteReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sends the <see cref="P:System.Data.Odbc.OdbcCommand.CommandText" /> to the <see cref="P:System.Data.Odbc.OdbcCommand.Connection" /> and builds an <see cref="T:System.Data.Odbc.OdbcDataReader" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/executing-a-command">Executing a Command</related>

--- a/xml/System.Data.Odbc/OdbcCommandBuilder.xml
+++ b/xml/System.Data.Odbc/OdbcCommandBuilder.xml
@@ -66,10 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Odbc.OdbcCommandBuilder" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/generating-commands-with-commandbuilders">Generating Commands with CommandBuilders</related>
@@ -265,10 +261,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetDeleteCommand">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the automatically generated <see cref="T:System.Data.Odbc.OdbcCommand" /> object required to perform deletions at the data source.</summary>
         <remarks>
@@ -377,10 +369,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetInsertCommand">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the automatically generated <see cref="T:System.Data.Odbc.OdbcCommand" /> object required to perform insertions at the data source.</summary>
         <remarks>
@@ -579,10 +567,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetUpdateCommand">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the automatically generated <see cref="T:System.Data.Odbc.OdbcCommand" /> object required to perform updates at the data source.</summary>
         <remarks>
@@ -691,10 +675,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="QuoteIdentifier">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Given an unquoted identifier in the correct catalog case, returns the correct quoted form of that identifier. This includes correctly escaping any embedded quotes in the identifier.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/generating-commands-with-commandbuilders">Generating Commands with CommandBuilders</related>
@@ -801,10 +781,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="UnquoteIdentifier">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Given a quoted identifier, returns the correct unquoted form of that identifier, including correctly unescaping any embedded quotes in the identifier.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/generating-commands-with-commandbuilders">Generating Commands with CommandBuilders</related>

--- a/xml/System.Data.Odbc/OdbcConnection.xml
+++ b/xml/System.Data.Odbc/OdbcConnection.xml
@@ -66,10 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Odbc.OdbcConnection" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/connecting-to-a-data-source">Connecting to Data Sources</related>
@@ -204,10 +200,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginTransaction">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Starts a transaction at the data source.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/connecting-to-a-data-source">Connecting to Data Sources</related>
@@ -786,10 +778,6 @@ driver-defined-attribute-keyword ::= identifier
       </Docs>
     </Member>
     <MemberGroup MemberName="GetSchema">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns schema information for the data source of this <see cref="T:System.Data.Odbc.OdbcConnection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/retrieving-database-schema-information">Obtaining Schema Information from a Database</related>

--- a/xml/System.Data.Odbc/OdbcConnectionStringBuilder.xml
+++ b/xml/System.Data.Odbc/OdbcConnectionStringBuilder.xml
@@ -88,10 +88,6 @@ Driver={SQL Server};Server="MyServer;NewValue=Bad"
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Odbc.OdbcConnectionStringBuilder" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/connection-string-builders">Connection String Builders</related>

--- a/xml/System.Data.Odbc/OdbcDataAdapter.xml
+++ b/xml/System.Data.Odbc/OdbcDataAdapter.xml
@@ -92,10 +92,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Odbc.OdbcDataAdapter" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataadapters-and-datareaders">DataAdapters and DataReaders</related>

--- a/xml/System.Data.Odbc/OdbcDataReader.xml
+++ b/xml/System.Data.Odbc/OdbcDataReader.xml
@@ -1338,10 +1338,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the value of a column in its native format.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataadapters-and-datareaders">DataAdapters and DataReaders</related>

--- a/xml/System.Data.Odbc/OdbcErrorCollection.xml
+++ b/xml/System.Data.Odbc/OdbcErrorCollection.xml
@@ -62,10 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="CopyTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies the elements of the <see cref="T:System.Data.Odbc.OdbcErrorCollection" /> into an array, starting at the specified index within the array.</summary>
         <related type="Article" href="/dotnet/standard/exceptions/">Handling and throwing exceptions in .NET</related>

--- a/xml/System.Data.Odbc/OdbcParameter.xml
+++ b/xml/System.Data.Odbc/OdbcParameter.xml
@@ -85,10 +85,6 @@ OleDbDataReader reader = command.ExecuteReader();
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Odbc.OdbcParameter" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>

--- a/xml/System.Data.Odbc/OdbcParameterCollection.xml
+++ b/xml/System.Data.Odbc/OdbcParameterCollection.xml
@@ -74,10 +74,6 @@ INSERT INTO MyTable VALUES (@p1, @p2, @p3);
   </Docs>
   <Members>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds an <see cref="T:System.Data.Odbc.OdbcParameter" /> to the <see cref="T:System.Data.Odbc.OdbcParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -366,10 +362,6 @@ INSERT INTO MyTable VALUES (@p1, @p2, @p3);
       </Docs>
     </Member>
     <MemberGroup MemberName="AddRange">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds elements to the end of the <see cref="T:System.Data.Odbc.OdbcParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -508,10 +500,6 @@ INSERT INTO MyTable VALUES (@p1, @p2, @p3);
       </Docs>
     </Member>
     <MemberGroup MemberName="Contains">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets a value indicating whether an <see cref="T:System.Data.Odbc.OdbcParameter" /> object exists in the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -630,10 +618,6 @@ INSERT INTO MyTable VALUES (@p1, @p2, @p3);
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies all the elements of the current <see cref="T:System.Data.Odbc.OdbcParameterCollection" /> to the specified object.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -827,10 +811,6 @@ INSERT INTO MyTable VALUES (@p1, @p2, @p3);
       </Docs>
     </Member>
     <MemberGroup MemberName="IndexOf">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the location of the specified <see cref="T:System.Data.Odbc.OdbcParameter" /> within the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -936,10 +916,6 @@ INSERT INTO MyTable VALUES (@p1, @p2, @p3);
       </Docs>
     </Member>
     <MemberGroup MemberName="Insert">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Inserts a <see cref="T:System.Data.Odbc.OdbcParameter" /> object into the <see cref="T:System.Data.Odbc.OdbcParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -1101,10 +1077,6 @@ INSERT INTO MyTable VALUES (@p1, @p2, @p3);
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Data.Odbc.OdbcParameter" /> with a specified attribute.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -1220,10 +1192,6 @@ INSERT INTO MyTable VALUES (@p1, @p2, @p3);
       </Docs>
     </Member>
     <MemberGroup MemberName="Remove">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes the <see cref="T:System.Data.Odbc.OdbcParameter" /> object from the <see cref="T:System.Data.Odbc.OdbcParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -1296,10 +1264,6 @@ INSERT INTO MyTable VALUES (@p1, @p2, @p3);
       </Docs>
     </Member>
     <MemberGroup MemberName="RemoveAt">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes the <see cref="T:System.Data.Odbc.OdbcParameter" /> object from the <see cref="T:System.Data.Odbc.OdbcParameterCollection" /> at the specified index.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>

--- a/xml/System.Data.Odbc/OdbcPermission.xml
+++ b/xml/System.Data.Odbc/OdbcPermission.xml
@@ -51,10 +51,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.Odbc.OdbcPermission" /> class.</summary>
       </Docs>

--- a/xml/System.Data.OleDb/OleDbCommand.xml
+++ b/xml/System.Data.OleDb/OleDbCommand.xml
@@ -99,10 +99,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.OleDb.OleDbCommand" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -929,10 +925,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ExecuteReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sends the <see cref="P:System.Data.OleDb.OleDbCommand.CommandText" /> to the <see cref="P:System.Data.OleDb.OleDbCommand.Connection" /> and builds an <see cref="T:System.Data.OleDb.OleDbDataReader" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -1249,10 +1241,6 @@ Int32 count = (Int32) ExecuteScalar();
       </Docs>
     </Member>
     <MemberGroup MemberName="System.Data.IDbCommand.ExecuteReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>For a description of this member, see <see cref="M:System.Data.IDbCommand.ExecuteReader" />.</summary>
         <remarks>

--- a/xml/System.Data.OleDb/OleDbCommandBuilder.xml
+++ b/xml/System.Data.OleDb/OleDbCommandBuilder.xml
@@ -68,10 +68,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.OleDb.OleDbCommandBuilder" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/generating-commands-with-commandbuilders">Generating Commands with CommandBuilders</related>
@@ -266,10 +262,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetDeleteCommand">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the automatically generated <see cref="T:System.Data.OleDb.OleDbCommand" /> object required to perform deletions at the data source.</summary>
         <remarks>
@@ -378,10 +370,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetInsertCommand">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the automatically generated <see cref="T:System.Data.OleDb.OleDbCommand" /> object required to perform insertions at the data source.</summary>
         <remarks>
@@ -580,10 +568,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetUpdateCommand">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the automatically generated <see cref="T:System.Data.OleDb.OleDbCommand" /> object required to perform updates at the data source.</summary>
         <remarks>
@@ -692,10 +676,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="QuoteIdentifier">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Given an unquoted identifier in the correct catalog case, returns the correct quoted form of that identifier. This includes correctly escaping any embedded quotes in the identifier.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/generating-commands-with-commandbuilders">Generating Commands with CommandBuilders</related>
@@ -802,10 +782,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="UnquoteIdentifier">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Given a quoted identifier, returns the correct unquoted form of that identifier. This includes correctly un-escaping any embedded quotes in the identifier.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/generating-commands-with-commandbuilders">Generating Commands with CommandBuilders</related>

--- a/xml/System.Data.OleDb/OleDbConnection.xml
+++ b/xml/System.Data.OleDb/OleDbConnection.xml
@@ -99,10 +99,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.OleDb.OleDbConnection" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/connecting-to-a-data-source">Connecting to Data Sources</related>
@@ -239,10 +235,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginTransaction">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Starts a database transaction.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/connecting-to-a-data-source">Connecting to Data Sources</related>
@@ -899,10 +891,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetSchema">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns schema information for the data source of this <see cref="T:System.Data.OleDb.OleDbConnection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/retrieving-database-schema-information">Obtaining Schema Information from a Database</related>

--- a/xml/System.Data.OleDb/OleDbConnectionStringBuilder.xml
+++ b/xml/System.Data.OleDb/OleDbConnectionStringBuilder.xml
@@ -111,10 +111,6 @@ Provider=Microsoft.Jet.OLEDB.4.0;Data Source=C:\Sample.mdb;User ID="Admin;NewVal
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.OleDb.OleDbConnectionStringBuilder" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/connection-strings">Connection Strings in ADO.NET</related>

--- a/xml/System.Data.OleDb/OleDbDataAdapter.xml
+++ b/xml/System.Data.OleDb/OleDbDataAdapter.xml
@@ -93,10 +93,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.OleDb.OleDbDataAdapter" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataadapters-and-datareaders">DataAdapters and DataReaders</related>
@@ -452,10 +448,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Fill">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds or refreshes rows in the <see cref="T:System.Data.DataSet" /> to match those in an ADO <see langword="Recordset" /> or <see langword="Record" /> object.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataadapters-and-datareaders">DataAdapters and DataReaders</related>

--- a/xml/System.Data.OleDb/OleDbDataReader.xml
+++ b/xml/System.Data.OleDb/OleDbDataReader.xml
@@ -1354,10 +1354,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the value of a column in its native format.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataadapters-and-datareaders">DataAdapters and DataReaders</related>

--- a/xml/System.Data.OleDb/OleDbErrorCollection.xml
+++ b/xml/System.Data.OleDb/OleDbErrorCollection.xml
@@ -71,10 +71,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="CopyTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies the elements of the <see cref="T:System.Data.OleDb.OleDbErrorCollection" /> into an <see cref="T:System.Array" />.</summary>
         <related type="Article" href="/dotnet/standard/exceptions/">Handling and throwing exceptions in .NET</related>

--- a/xml/System.Data.OleDb/OleDbParameter.xml
+++ b/xml/System.Data.OleDb/OleDbParameter.xml
@@ -94,10 +94,6 @@ OleDbDataReader reader = command.ExecuteReader();
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.OleDb.OleDbParameter" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>

--- a/xml/System.Data.OleDb/OleDbParameterCollection.xml
+++ b/xml/System.Data.OleDb/OleDbParameterCollection.xml
@@ -66,10 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds an <see cref="T:System.Data.OleDb.OleDbParameter" /> to the <see cref="T:System.Data.OleDb.OleDbParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -368,10 +364,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="AddRange">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds elements to the end of the <see cref="T:System.Data.OleDb.OleDbParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -510,10 +502,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Contains">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Determines whether the specified object is in this <see cref="T:System.Data.OleDb.OleDbParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -622,10 +610,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies all the elements of the current <see cref="T:System.Data.OleDb.OleDbParameterCollection" /> to the specified object.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -819,10 +803,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="IndexOf">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the location of the specified <see cref="T:System.Data.OleDb.OleDbParameterCollection" /> within the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -928,10 +908,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Insert">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Inserts a <see cref="T:System.Data.OleDb.OleDbParameter" /> object into the <see cref="T:System.Data.OleDb.OleDbParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -1093,10 +1069,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Data.OleDb.OleDbParameter" /> with a specified attribute.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -1212,10 +1184,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Remove">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes the <see cref="T:System.Data.OleDb.OleDbParameter" /> object from the <see cref="T:System.Data.OleDb.OleDbParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>
@@ -1288,10 +1256,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="RemoveAt">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes the <see cref="T:System.Data.OleDb.OleDbParameter" /> object from the <see cref="T:System.Data.OleDb.OleDbParameterCollection" /> at the specified index.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Working with Commands</related>

--- a/xml/System.Data.OleDb/OleDbPermission.xml
+++ b/xml/System.Data.OleDb/OleDbPermission.xml
@@ -53,10 +53,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.OleDb.OleDbPermission" /> class.</summary>
       </Docs>

--- a/xml/System.Data.OleDb/OleDbTransaction.xml
+++ b/xml/System.Data.OleDb/OleDbTransaction.xml
@@ -59,10 +59,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Begin">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initiates a nested database transaction.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/transactions-and-concurrency">Performing Transactions</related>

--- a/xml/System.Data.SqlClient/SqlBulkCopy.xml
+++ b/xml/System.Data.SqlClient/SqlBulkCopy.xml
@@ -64,10 +64,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -746,10 +742,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteToServer">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies all rows from a data source to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
         <remarks>
@@ -798,10 +790,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteToServerAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>An asynchronous version of <see cref="Overload:System.Data.SqlClient.SqlBulkCopy.WriteToServer" />, which copies all rows from a data source to a destination table specified by the <see cref="P:System.Data.SqlClient.SqlBulkCopy.DestinationTableName" /> property of the <see cref="T:System.Data.SqlClient.SqlBulkCopy" /> object.</summary>
         <remarks>

--- a/xml/System.Data.SqlClient/SqlBulkCopyColumnMapping.xml
+++ b/xml/System.Data.SqlClient/SqlBulkCopyColumnMapping.xml
@@ -62,10 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.SqlClient/SqlBulkCopyColumnMappingCollection.xml
+++ b/xml/System.Data.SqlClient/SqlBulkCopyColumnMappingCollection.xml
@@ -72,10 +72,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a new <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMapping" /> to the <see cref="T:System.Data.SqlClient.SqlBulkCopyColumnMappingCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.SqlClient/SqlClientPermission.xml
+++ b/xml/System.Data.SqlClient/SqlClientPermission.xml
@@ -59,11 +59,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlClientPermission" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.SqlClient/SqlCommand.xml
+++ b/xml/System.Data.SqlClient/SqlCommand.xml
@@ -395,10 +395,6 @@ class Program {
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlCommand" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -635,33 +631,18 @@ class Program {
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginExecuteNonQuery">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
       </Docs>
     </MemberGroup>
     <MemberGroup MemberName="BeginExecuteReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" />, and retrieves one or more result sets from the server.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
       </Docs>
     </MemberGroup>
     <MemberGroup MemberName="BeginExecuteXmlReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" /> and returns results as an <see cref="T:System.Xml.XmlReader" /> object.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1421,10 +1402,6 @@ The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped durin
       </Docs>
     </Member>
     <MemberGroup MemberName="ExecuteReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sends the <see cref="P:System.Data.SqlClient.SqlCommand.CommandText" /> to the <see cref="P:System.Data.SqlClient.SqlCommand.Connection" /> and builds a <see cref="T:System.Data.SqlClient.SqlDataReader" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1584,10 +1561,6 @@ The <see cref="T:System.Data.SqlClient.SqlConnection" /> closed or dropped durin
       </Docs>
     </Member>
     <MemberGroup MemberName="ExecuteReaderAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" />.</summary>
         <remarks>
@@ -2112,10 +2085,6 @@ A timeout occurred during a streaming operation. For more information about stre
       </Docs>
     </Member>
     <MemberGroup MemberName="ExecuteXmlReaderAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initiates the asynchronous execution of the Transact-SQL statement or stored procedure that is described by this <see cref="T:System.Data.SqlClient.SqlCommand" /> and returns results as an <see cref="T:System.Xml.XmlReader" /> object.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.SqlClient/SqlConnection.xml
+++ b/xml/System.Data.SqlClient/SqlConnection.xml
@@ -94,10 +94,6 @@ using (SqlConnection connection = new SqlConnection(connectionString))
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlConnection" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -254,10 +250,6 @@ using (SqlConnection connection = new SqlConnection(connectionString))
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginTransaction">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Starts a database transaction.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -585,11 +577,6 @@ using (SqlConnection connection = new SqlConnection(connectionString))
       </Docs>
     </Member>
     <MemberGroup MemberName="ChangePassword">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Changes the SQL Server password.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1228,11 +1215,6 @@ The <xref:System.Data.SqlClient.SqlConnection.ConnectionString*> is similar to a
       </Docs>
     </Member>
     <MemberGroup MemberName="GetSchema">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns schema information for the data source of this <see cref="T:System.Data.SqlClient.SqlConnection" />.</summary>
         <remarks>

--- a/xml/System.Data.SqlClient/SqlConnectionStringBuilder.xml
+++ b/xml/System.Data.SqlClient/SqlConnectionStringBuilder.xml
@@ -82,10 +82,6 @@ The following console application builds connection strings for a SQL Server dat
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlConnectionStringBuilder" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.SqlClient/SqlDataReader.xml
+++ b/xml/System.Data.SqlClient/SqlDataReader.xml
@@ -2824,10 +2824,6 @@ Boolean, Byte, Char, DateTime, DateTimeOffset, Decimal, Double, Float, Guid, Int
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the value of a column in its native format.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.SqlClient/SqlErrorCollection.xml
+++ b/xml/System.Data.SqlClient/SqlErrorCollection.xml
@@ -62,10 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="CopyTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies the elements of the <see cref="T:System.Data.SqlClient.SqlErrorCollection" /> collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.SqlClient/SqlParameter.xml
+++ b/xml/System.Data.SqlClient/SqlParameter.xml
@@ -64,10 +64,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlClient.SqlParameter" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.SqlClient/SqlParameterCollection.xml
+++ b/xml/System.Data.SqlClient/SqlParameterCollection.xml
@@ -59,10 +59,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a <see cref="T:System.Data.SqlClient.SqlParameter" /> to the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -284,10 +280,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="AddRange">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds elements to the end of the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -483,10 +475,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="Contains">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Determines whether the specified object is in this <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/commands-and-parameters">Commands and Parameters (ADO.NET)</related>
@@ -635,10 +623,6 @@ This method uses the collection's objects' <xref:System.Object.Equals*> and <xre
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies all the elements of the current <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> to the specified object.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -895,10 +879,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="IndexOf">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the location of the specified <see cref="T:System.Data.SqlClient.SqlParameter" /> within the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1041,10 +1021,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="Insert">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Inserts a <see cref="T:System.Data.SqlClient.SqlParameter" /> object into the <see cref="T:System.Data.SqlClient.SqlParameterCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1153,10 +1129,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the <see cref="T:System.Data.SqlClient.SqlParameter" /> with a specified attribute.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1261,10 +1233,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="Remove">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes the specified <see cref="T:System.Data.SqlClient.SqlParameter" /> from the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>
@@ -1377,10 +1345,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="RemoveAt">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes the <see cref="T:System.Data.SqlClient.SqlParameter" /> object from the <see cref="T:System.Data.SqlClient.SqlParameterCollection" /> at the specified index.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.SqlClient/SqlTransaction.xml
+++ b/xml/System.Data.SqlClient/SqlTransaction.xml
@@ -275,10 +275,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Rollback">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Rolls back a transaction from a pending state.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/ado-net-overview">ADO.NET Overview</related>

--- a/xml/System.Data.SqlTypes/SqlAlreadyFilledException.xml
+++ b/xml/System.Data.SqlTypes/SqlAlreadyFilledException.xml
@@ -61,11 +61,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlAlreadyFilledException" /> class.</summary>
         <remarks>

--- a/xml/System.Data.SqlTypes/SqlBinary.xml
+++ b/xml/System.Data.SqlTypes/SqlBinary.xml
@@ -193,10 +193,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this instance to a specified object and returns an indication of their relative values.</summary>
         <remarks>
@@ -405,10 +401,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares two <see cref="T:System.Data.SqlTypes.SqlBinary" /> structures to determine whether they are equal.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -1269,10 +1261,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to a <see cref="T:System.Data.SqlTypes.SqlBinary" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlBoolean.xml
+++ b/xml/System.Data.SqlTypes/SqlBoolean.xml
@@ -91,10 +91,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlBoolean" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -302,10 +298,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this instance to a specified object and returns an indication of their relative values.</summary>
         <remarks>
@@ -475,10 +467,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares two <see cref="T:System.Data.SqlTypes.SqlBoolean" /> structures to determine whether they are equal.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -1637,10 +1625,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts a <see cref="T:System.Data.SqlTypes.SqlBoolean" /> to a specified structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlByte.xml
+++ b/xml/System.Data.SqlTypes/SqlByte.xml
@@ -288,10 +288,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this instance to the supplied object and returns an indication of their relative values.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -500,10 +496,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Performs a logical comparison to determine whether a <see cref="T:System.Data.SqlTypes.SqlByte" /> structure's value is equal to another object.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -1782,10 +1774,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts a parameter to a <see cref="T:System.Data.SqlTypes.SqlByte" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlBytes.xml
+++ b/xml/System.Data.SqlTypes/SqlBytes.xml
@@ -78,10 +78,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlBytes" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -662,10 +658,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to a <see cref="T:System.Data.SqlTypes.SqlBytes" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlChars.xml
+++ b/xml/System.Data.SqlTypes/SqlChars.xml
@@ -86,10 +86,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlChars" /> class.</summary>
         <remarks>
@@ -637,10 +633,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to a <see cref="T:System.Data.SqlTypes.SqlChars" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlDateTime.xml
+++ b/xml/System.Data.SqlTypes/SqlDateTime.xml
@@ -82,10 +82,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlDateTime" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -466,10 +462,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this <see cref="T:System.Data.SqlTypes.SqlDateTime" /> structure to the supplied parameter and returns an indication of their relative values.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -672,10 +664,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Performs a logical comparison of two <see cref="T:System.Data.SqlTypes.SqlDateTime" /> structures to determine whether they are equal.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -1516,10 +1504,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts a parameter to and from a <see cref="T:System.Data.SqlTypes.SqlDateTime" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlDecimal.xml
+++ b/xml/System.Data.SqlTypes/SqlDecimal.xml
@@ -93,10 +93,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlDecimal" /> structure.</summary>
       </Docs>
@@ -659,10 +655,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this instance to the supplied object and returns an indication of their relative values.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -973,10 +965,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a value that indicates whether an instance of <see cref="T:System.Data.SqlTypes.SqlDecimal" /> and the supplied object parameter represent the same value.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -2124,10 +2112,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts the supplied structure to <see cref="T:System.Data.SqlTypes.SqlDecimal" />.</summary>
       </Docs>
@@ -2557,10 +2541,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Implicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts the supplied structure to <see cref="T:System.Data.SqlTypes.SqlDecimal" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlDouble.xml
+++ b/xml/System.Data.SqlTypes/SqlDouble.xml
@@ -182,10 +182,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this <see cref="T:System.Data.SqlTypes.SqlDouble" /> instance to the supplied object and returns an indication of their relative values.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -396,10 +392,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a value that indicates whether an instance of <see cref="T:System.Data.SqlTypes.SqlDouble" /> and the supplied object parameter represent the same value.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -1353,10 +1345,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to and from a <see cref="T:System.Data.SqlTypes.SqlDouble" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -1630,10 +1618,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Implicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to a <see cref="T:System.Data.SqlTypes.SqlDouble" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlGuid.xml
+++ b/xml/System.Data.SqlTypes/SqlGuid.xml
@@ -91,10 +91,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlGuid" /> structure.</summary>
       </Docs>
@@ -319,10 +315,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this <see cref="T:System.Data.SqlTypes.SqlGuid" /> structure to the supplied object and returns an indication of their relative values.</summary>
         <remarks>
@@ -489,10 +481,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Performs a logical comparison of two structures to determine whether they are equal.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/comparing-guid-and-uniqueidentifier-values">Comparing GUID and uniqueidentifier Values</related>
@@ -1187,10 +1175,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to and from a <see cref="T:System.Data.SqlTypes.SqlGuid" /> instance.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/comparing-guid-and-uniqueidentifier-values">Comparing GUID and uniqueidentifier Values</related>

--- a/xml/System.Data.SqlTypes/SqlInt16.xml
+++ b/xml/System.Data.SqlTypes/SqlInt16.xml
@@ -288,10 +288,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this instance to the supplied object and returns an indication of their relative values.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -496,10 +492,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Performs a logical comparison of two structures to determine whether they are equal.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -1772,10 +1764,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to and from a <see cref="T:System.Data.SqlTypes.SqlInt16" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -2367,10 +2355,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Implicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to a <see cref="T:System.Data.SqlTypes.SqlInt16" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlInt32.xml
+++ b/xml/System.Data.SqlTypes/SqlInt32.xml
@@ -288,10 +288,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this instance to the supplied object and returns an indication of their relative values.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -500,10 +496,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Performs a logical comparison of two structures to determine whether they are equal.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -1782,10 +1774,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to and from a <see cref="T:System.Data.SqlTypes.SqlInt32" />.</summary>
       </Docs>
@@ -2323,10 +2311,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Implicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to a <see cref="T:System.Data.SqlTypes.SqlInt32" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlInt64.xml
+++ b/xml/System.Data.SqlTypes/SqlInt64.xml
@@ -288,10 +288,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this instance to the supplied object and returns an indication of their relative values.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -500,10 +496,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Performs a logical comparison of two structures to determine whether they are equal.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -1782,10 +1774,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to and from a <see cref="T:System.Data.SqlTypes.SqlInt64" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -2259,10 +2247,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Implicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to a <see cref="T:System.Data.SqlTypes.SqlInt64" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlMoney.xml
+++ b/xml/System.Data.SqlTypes/SqlMoney.xml
@@ -89,10 +89,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlMoney" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -340,10 +336,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this instance to the supplied object and returns an indication of their relative values.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -552,10 +544,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Performs a logical comparison of two structures to determine whether they are equal.</summary>
       </Docs>
@@ -1575,10 +1563,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to and from a <see cref="T:System.Data.SqlTypes.SqlMoney" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -2065,10 +2049,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Implicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to a <see cref="T:System.Data.SqlTypes.SqlMoney" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlNotFilledException.xml
+++ b/xml/System.Data.SqlTypes/SqlNotFilledException.xml
@@ -54,11 +54,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlNotFilledException" /> class.</summary>
         <remarks>

--- a/xml/System.Data.SqlTypes/SqlNullValueException.xml
+++ b/xml/System.Data.SqlTypes/SqlNullValueException.xml
@@ -67,10 +67,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlNullValueException" /> class.</summary>
       </Docs>

--- a/xml/System.Data.SqlTypes/SqlSingle.xml
+++ b/xml/System.Data.SqlTypes/SqlSingle.xml
@@ -89,10 +89,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlSingle" /> structure using the supplied floating point value.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -246,10 +242,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this instance to the supplied object and returns an indication of their relative values.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -458,10 +450,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Performs a logical comparison of two structures to determine whether they are equal.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -1413,10 +1401,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to and from a <see cref="T:System.Data.SqlTypes.SqlSingle" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -1743,10 +1727,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Implicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to a <see cref="T:System.Data.SqlTypes.SqlSingle" /> structure.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlString.xml
+++ b/xml/System.Data.SqlTypes/SqlString.xml
@@ -106,10 +106,6 @@ SqlString mySqlString = new SqlString("abc", CultureInfo.CurrentCulture.LCID);
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlString" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -789,10 +785,6 @@ SqlString mySqlString = new SqlString("abc", CultureInfo.CurrentCulture.LCID);
       </Docs>
     </Member>
     <MemberGroup MemberName="CompareTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compares this instance to a specified object and returns an indication of their relative values.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -1048,10 +1040,6 @@ SqlString mySqlString = new SqlString("abc", CultureInfo.CurrentCulture.LCID);
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Performs a logical comparison of two structures to determine whether they are equal.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>
@@ -2151,10 +2139,6 @@ SqlString mySqlString = new SqlString("abc", CultureInfo.CurrentCulture.LCID);
       </Docs>
     </Member>
     <MemberGroup MemberName="op_Explicit">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts to and from a <see cref="T:System.Data.SqlTypes.SqlString" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/sql-server-data-types">SQL Server Data Types and ADO.NET</related>

--- a/xml/System.Data.SqlTypes/SqlTruncateException.xml
+++ b/xml/System.Data.SqlTypes/SqlTruncateException.xml
@@ -60,10 +60,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlTruncateException" /> class.</summary>
       </Docs>

--- a/xml/System.Data.SqlTypes/SqlTypeException.xml
+++ b/xml/System.Data.SqlTypes/SqlTypeException.xml
@@ -66,10 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SqlTypes.SqlTypeException" /> class.</summary>
       </Docs>

--- a/xml/System.Data.SqlTypes/SqlXml.xml
+++ b/xml/System.Data.SqlTypes/SqlXml.xml
@@ -83,10 +83,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.SqlClient</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.Data.SqlTypes.SqlXml" /> instance.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/sql/xml-data-in-sql-server">Working with SQLXML</related>

--- a/xml/System.Data/ConstraintCollection.xml
+++ b/xml/System.Data/ConstraintCollection.xml
@@ -93,11 +93,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a <see cref="T:System.Data.Constraint" /> object to the collection.</summary>
       </Docs>
@@ -834,11 +829,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="IndexOf">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the index of the specified <see cref="T:System.Data.Constraint" />.</summary>
       </Docs>
@@ -974,11 +964,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the specified <see cref="T:System.Data.Constraint" /> from the collection.</summary>
       </Docs>
@@ -1157,11 +1142,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Remove">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes a <see cref="T:System.Data.Constraint" /> from the <see cref="T:System.Data.ConstraintCollection" />.</summary>
       </Docs>

--- a/xml/System.Data/ConstraintException.xml
+++ b/xml/System.Data/ConstraintException.xml
@@ -66,11 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.ConstraintException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/DBConcurrencyException.xml
+++ b/xml/System.Data/DBConcurrencyException.xml
@@ -63,11 +63,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.DBConcurrencyException" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataadapters-and-datareaders">DataAdapters and DataReaders</related>
@@ -271,11 +266,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyToRows">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies the <see cref="T:System.Data.DataRow" /> objects whose update failure generated this exception to the specified array.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataadapters-and-datareaders">DataAdapters and DataReaders</related>

--- a/xml/System.Data/DataColumn.xml
+++ b/xml/System.Data/DataColumn.xml
@@ -113,11 +113,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.DataColumn" /> class.</summary>
       </Docs>

--- a/xml/System.Data/DataColumnCollection.xml
+++ b/xml/System.Data/DataColumnCollection.xml
@@ -87,11 +87,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates and adds a <see cref="T:System.Data.DataColumn" /> object to the <see cref="T:System.Data.DataColumnCollection" />.</summary>
       </Docs>
@@ -848,11 +843,6 @@ Another column's expression depends on this column. </exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="IndexOf">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Searches for the specified <see cref="T:System.Data.DataColumn" /> and returns the zero-based index of the first occurrence within the collection.</summary>
       </Docs>
@@ -967,11 +957,6 @@ Another column's expression depends on this column. </exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the specified <see cref="T:System.Data.DataColumn" /> from the collection.</summary>
       </Docs>
@@ -1155,11 +1140,6 @@ Another column's expression depends on this column. </exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="Remove">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes a <see cref="T:System.Data.DataColumn" /> object from the collection.</summary>
       </Docs>

--- a/xml/System.Data/DataException.xml
+++ b/xml/System.Data/DataException.xml
@@ -55,11 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.DataException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/DataRelation.xml
+++ b/xml/System.Data/DataRelation.xml
@@ -101,11 +101,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.DataRelation" /> class.</summary>
       </Docs>

--- a/xml/System.Data/DataRelationCollection.xml
+++ b/xml/System.Data/DataRelationCollection.xml
@@ -123,11 +123,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a <see cref="T:System.Data.DataRelation" /> to the <see cref="T:System.Data.DataRelationCollection" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/adding-datarelations">Adding DataRelations</related>
@@ -1005,11 +1000,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="IndexOf">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the index of the specified data relation.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/adding-datarelations">Adding DataRelations</related>
@@ -1115,11 +1105,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the specified <see cref="T:System.Data.DataRelation" /> from the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/adding-datarelations">Adding DataRelations</related>
@@ -1345,11 +1330,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Remove">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes the specified relation from the collection.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/adding-datarelations">Adding DataRelations</related>

--- a/xml/System.Data/DataRow.xml
+++ b/xml/System.Data/DataRow.xml
@@ -566,11 +566,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetChildRows">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the child rows of a <see cref="T:System.Data.DataRow" />.</summary>
       </Docs>
@@ -873,11 +868,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetColumnError">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the error description for a column.</summary>
       </Docs>
@@ -1170,11 +1160,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetParentRow">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the parent row of a <see cref="T:System.Data.DataRow" />.</summary>
       </Docs>
@@ -1479,11 +1464,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetParentRows">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the parent rows of a <see cref="T:System.Data.DataRow" />.</summary>
       </Docs>
@@ -1927,11 +1907,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="IsNull">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets a value that indicates whether the specified column contains a null value.</summary>
       </Docs>
@@ -2167,11 +2142,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets data stored in a specified column.</summary>
       </Docs>
@@ -2908,11 +2878,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="SetColumnError">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sets the error description for a column.</summary>
       </Docs>
@@ -3279,11 +3244,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="SetParentRow">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sets the parent row of a <see cref="T:System.Data.DataRow" />.</summary>
       </Docs>

--- a/xml/System.Data/DataRowCollection.xml
+++ b/xml/System.Data/DataRowCollection.xml
@@ -78,11 +78,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a <see cref="T:System.Data.DataRow" /> to the <see cref="T:System.Data.DataRowCollection" />.</summary>
       </Docs>
@@ -288,11 +283,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Contains">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets a value that indicates whether the primary key columns of any row in the collection contain the specified value.</summary>
       </Docs>
@@ -439,11 +429,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies all the <see cref="T:System.Data.DataRow" /> objects from the collection into the given array, starting at the given destination array index.</summary>
       </Docs>
@@ -582,11 +567,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Find">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets a <see cref="T:System.Data.DataRow" /> using the specified <see cref="P:System.Data.DataTable.PrimaryKey" /> value.</summary>
         <remarks>Performance should be an O(log n) operation.</remarks>

--- a/xml/System.Data/DataRowExtensions.xml
+++ b/xml/System.Data/DataRowExtensions.xml
@@ -67,10 +67,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Field&lt;T&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.DataSetExtensions</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Provides strongly-typed access to each of the column values in the <see cref="T:System.Data.DataRow" />.</summary>
       </Docs>
@@ -526,10 +522,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="SetField&lt;T&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.DataSetExtensions</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sets a new value for the specified column in the <see cref="T:System.Data.DataRow" />.</summary>
       </Docs>

--- a/xml/System.Data/DataRowView.xml
+++ b/xml/System.Data/DataRowView.xml
@@ -226,11 +226,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateChildView">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a <see cref="T:System.Data.DataView" /> for the child <see cref="T:System.Data.DataTable" />.</summary>
       </Docs>
@@ -792,11 +787,6 @@ This method checks for reference equality instead of checking whether <xref:Syst
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets a value in a specified column.</summary>
       </Docs>
@@ -1496,11 +1486,6 @@ The <see cref="P:System.Data.DataRowView.DataView" /> doesn't allow edits and <s
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ComponentModel.ICustomTypeDescriptor.GetEvents">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the events for this instance of a component.</summary>
         <remarks>
@@ -1629,11 +1614,6 @@ The <see cref="P:System.Data.DataRowView.DataView" /> doesn't allow edits and <s
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ComponentModel.ICustomTypeDescriptor.GetProperties">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the properties for this instance of a component.</summary>
         <remarks>

--- a/xml/System.Data/DataSet.xml
+++ b/xml/System.Data/DataSet.xml
@@ -139,11 +139,6 @@ The following example consists of several methods that, combined, create and fil
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.DataSet" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/">Using DataSets in ADO.NET</related>
@@ -763,11 +758,6 @@ If these classes have been subclassed, the copy will also be of the same subclas
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateDataReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a <see cref="T:System.Data.DataTableReader" /> with one result set per <see cref="T:System.Data.DataTable" />, in the same sequence as the tables appear in the <see cref="P:System.Data.DataSet.Tables" /> collection.</summary>
         <remarks>
@@ -1045,11 +1035,6 @@ If these classes have been subclassed, the copy will also be of the same subclas
       </Docs>
     </Member>
     <MemberGroup MemberName="DetermineSchemaSerializationMode">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Determines the <see cref="P:System.Data.DataSet.SchemaSerializationMode" /> for a <see cref="T:System.Data.DataSet" />.</summary>
         <remarks>
@@ -1357,11 +1342,6 @@ If these classes have been subclassed, the copy will also be of the same subclas
       </Docs>
     </Member>
     <MemberGroup MemberName="GetChanges">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets a copy of the <see cref="T:System.Data.DataSet" /> containing all changes made to it since it was last loaded, or since <see cref="M:System.Data.DataSet.AcceptChanges" /> was called.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/">Using DataSets in ADO.NET</related>
@@ -2176,11 +2156,6 @@ class Program {
       </Docs>
     </Member>
     <MemberGroup MemberName="HasChanges">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets a value indicating whether the <see cref="T:System.Data.DataSet" /> has changes, including new, deleted, or modified rows.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/">Using DataSets in ADO.NET</related>
@@ -2370,11 +2345,6 @@ class Program {
       </Docs>
     </Member>
     <MemberGroup MemberName="InferXmlSchema">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Applies XML schema to the <see cref="T:System.Data.DataSet" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/">Using DataSets in ADO.NET</related>
@@ -2860,11 +2830,6 @@ class Program {
       </Docs>
     </Member>
     <MemberGroup MemberName="Load">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Fills a <see cref="T:System.Data.DataSet" /> with values from a data source using the supplied <see cref="T:System.Data.IDataReader" />.</summary>
         <remarks>
@@ -3235,11 +3200,6 @@ class Program {
       </Docs>
     </Member>
     <MemberGroup MemberName="Merge">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Merges a specified <see cref="T:System.Data.DataSet" />, <see cref="T:System.Data.DataTable" />, or array of <see cref="T:System.Data.DataRow" /> objects into the current <see langword="DataSet" /> or <see langword="DataTable" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/">Using DataSets in ADO.NET</related>
@@ -4184,11 +4144,6 @@ class Program {
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadXml">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads XML schema and data into the <see cref="T:System.Data.DataSet" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/">Using DataSets in ADO.NET</related>
@@ -4967,11 +4922,6 @@ class Program {
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadXmlSchema">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads an XML schema into the <see cref="T:System.Data.DataSet" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/">Using DataSets in ADO.NET</related>
@@ -6153,11 +6103,6 @@ class Program {
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteXml">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes XML data, and optionally the schema, from the <see cref="T:System.Data.DataSet" />.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/">Using DataSets in ADO.NET</related>
@@ -6758,11 +6703,6 @@ class Program {
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteXmlSchema">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes the <see cref="T:System.Data.DataSet" /> structure as an XML schema.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/">Using DataSets in ADO.NET</related>

--- a/xml/System.Data/DataTable.xml
+++ b/xml/System.Data/DataTable.xml
@@ -145,11 +145,6 @@ This sample demonstrates how to create a DataTable manually with specific schema
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.DataTable" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/datatables">DataTables</related>
@@ -2226,11 +2221,6 @@ class Program {
       </Docs>
     </Member>
     <MemberGroup MemberName="GetChanges">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets a copy of the <see cref="T:System.Data.DataTable" /> containing all changes made to it since it was last loaded, or since <see cref="M:System.Data.DataTable.AcceptChanges" /> was called.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/datatables">DataTables</related>
@@ -2884,11 +2874,6 @@ class Program {
       </Docs>
     </Member>
     <MemberGroup MemberName="Load">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Fills a <see cref="T:System.Data.DataTable" /> with values from a data source using the supplied <see cref="T:System.Data.IDataReader" />. If the <see langword="DataTable" /> already contains rows, the incoming data from the data source is merged with the existing rows.</summary>
         <remarks>
@@ -3253,11 +3238,6 @@ Not present)|Current = \<Incoming><br /><br /> Original = \<Not available><br />
       </Docs>
     </Member>
     <MemberGroup MemberName="LoadDataRow">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Finds and updates a specific row. If no matching row is found, a new row is created using the given values.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/datatables">DataTables</related>
@@ -3485,11 +3465,6 @@ Not present)|Current = \<Incoming><br /><br /> Original = \<Not available><br />
       </Docs>
     </Member>
     <MemberGroup MemberName="Merge">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Merge the specified <see cref="T:System.Data.DataTable" /> with the current <see cref="T:System.Data.DataTable" />.</summary>
         <remarks>
@@ -4809,11 +4784,6 @@ Not present)|Current = \<Incoming><br /><br /> Original = \<Not available><br />
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadXml">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads XML schema and data into the <see cref="T:System.Data.DataTable" />.</summary>
         <remarks>
@@ -5195,11 +5165,6 @@ public class A {
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadXmlSchema">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads an XML schema into the <see cref="T:System.Data.DataTable" />.</summary>
         <remarks>
@@ -6074,11 +6039,6 @@ public class A {
       </Docs>
     </Member>
     <MemberGroup MemberName="Select">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets an array of <see cref="T:System.Data.DataRow" /> objects.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/datatables">DataTables</related>
@@ -7011,11 +6971,6 @@ To ensure the proper sort order, specify sort criteria with <xref:System.Data.Da
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteXml">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes the current contents of the <see cref="T:System.Data.DataTable" /> as XML.</summary>
         <remarks>
@@ -8482,11 +8437,6 @@ sdata:PrimaryKey="true">
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteXmlSchema">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes the current data structure of the <see cref="T:System.Data.DataTable" /> as an XML schema.</summary>
         <remarks>

--- a/xml/System.Data/DataTableCollection.xml
+++ b/xml/System.Data/DataTableCollection.xml
@@ -93,11 +93,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a <see cref="T:System.Data.DataTable" /> object to the collection.</summary>
       </Docs>
@@ -669,11 +664,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Contains">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets a value indicating whether a <see cref="T:System.Data.DataTable" /> object with the specified name exists in the collection.</summary>
       </Docs>
@@ -876,11 +866,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="IndexOf">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the index in the collection of the specified <see cref="T:System.Data.DataTable" /> object.</summary>
       </Docs>
@@ -1084,11 +1069,6 @@ This method returns -1 when two or more tables have the same name but different 
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the specified <see cref="T:System.Data.DataTable" /> object from the collection.</summary>
       </Docs>
@@ -1334,11 +1314,6 @@ This method returns -1 when two or more tables have the same name but different 
       </Docs>
     </Member>
     <MemberGroup MemberName="Remove">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes a specified <see cref="T:System.Data.DataTable" /> object from the collection.</summary>
       </Docs>

--- a/xml/System.Data/DataTableExtensions.xml
+++ b/xml/System.Data/DataTableExtensions.xml
@@ -270,10 +270,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyToDataTable&lt;T&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.DataSetExtensions</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a <see cref="T:System.Data.DataTable" /> that contains copies of the <see cref="T:System.Data.DataRow" /> objects, given an input <see cref="T:System.Collections.Generic.IEnumerable`1" /> object.</summary>
       </Docs>

--- a/xml/System.Data/DataTableReader.xml
+++ b/xml/System.Data/DataTableReader.xml
@@ -67,11 +67,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.DataTableReader" /> class.</summary>
       </Docs>
@@ -2171,11 +2166,6 @@ Russ
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the value of the specified column in its native format.</summary>
       </Docs>

--- a/xml/System.Data/DataView.xml
+++ b/xml/System.Data/DataView.xml
@@ -133,11 +133,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.DataView" /> class.</summary>
       </Docs>
@@ -1140,11 +1135,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Find">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Finds a row in the <see cref="T:System.Data.DataView" /> by the specified sort key value.</summary>
       </Docs>
@@ -1272,11 +1262,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="FindRows">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns an array of <see cref="T:System.Data.DataRowView" /> objects whose columns match the specified sort key value.</summary>
       </Docs>
@@ -4086,11 +4071,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ToTable">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates and returns a new <see cref="T:System.Data.DataTable" /> based on rows in an existing <see cref="T:System.Data.DataView" />.</summary>
         <remarks>
@@ -4485,11 +4465,6 @@ New table name: UniqueData
       </Docs>
     </Member>
     <MemberGroup MemberName="UpdateIndex">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reserved for internal use only.</summary>
       </Docs>

--- a/xml/System.Data/DataViewManager.xml
+++ b/xml/System.Data/DataViewManager.xml
@@ -77,11 +77,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.DataViewManager" /> class.</summary>
         <related type="Article" href="/dotnet/framework/data/adonet/dataset-datatable-dataview/managing-dataviews">Managing DataViews</related>

--- a/xml/System.Data/DataViewSettingCollection.xml
+++ b/xml/System.Data/DataViewSettingCollection.xml
@@ -74,11 +74,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="CopyTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies the collection objects to a one-dimensional <see cref="T:System.Array" /> instance starting at the specified index.</summary>
       </Docs>
@@ -392,11 +387,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the <see cref="T:System.Data.DataViewSetting" /> of the specified <see cref="T:System.Data.DataTable" /> from the collection.</summary>
       </Docs>

--- a/xml/System.Data/DeletedRowInaccessibleException.xml
+++ b/xml/System.Data/DeletedRowInaccessibleException.xml
@@ -79,11 +79,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.DeletedRowInaccessibleException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/DuplicateNameException.xml
+++ b/xml/System.Data/DuplicateNameException.xml
@@ -62,11 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.DuplicateNameException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/EnumerableRowCollectionExtensions.xml
+++ b/xml/System.Data/EnumerableRowCollectionExtensions.xml
@@ -140,10 +140,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="OrderBy&lt;TRow,TKey&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.DataSetExtensions</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sorts the rows of a <see cref="T:System.Data.EnumerableRowCollection" /> in ascending order.</summary>
         <forInternalUseOnly />
@@ -302,10 +298,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="OrderByDescending&lt;TRow,TKey&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.DataSetExtensions</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sorts the rows of a <see cref="T:System.Data.EnumerableRowCollection" /> in descending order.</summary>
         <forInternalUseOnly />
@@ -538,10 +530,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ThenBy&lt;TRow,TKey&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.DataSetExtensions</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Performs a secondary ordering of the rows of a <see cref="T:System.Data.EnumerableRowCollection" /> in ascending order.</summary>
         <forInternalUseOnly />
@@ -704,10 +692,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ThenByDescending&lt;TRow,TKey&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.DataSetExtensions</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Performs a secondary ordering of the rows of a <see cref="T:System.Data.EnumerableRowCollection" /> in descending order.</summary>
         <forInternalUseOnly />

--- a/xml/System.Data/EvaluateException.xml
+++ b/xml/System.Data/EvaluateException.xml
@@ -55,11 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.EvaluateException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/ForeignKeyConstraint.xml
+++ b/xml/System.Data/ForeignKeyConstraint.xml
@@ -96,11 +96,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.ForeignKeyConstraint" /> class.</summary>
       </Docs>

--- a/xml/System.Data/IDataRecord.xml
+++ b/xml/System.Data/IDataRecord.xml
@@ -1311,11 +1311,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the specified column.</summary>
       </Docs>

--- a/xml/System.Data/IDbCommand.xml
+++ b/xml/System.Data/IDbCommand.xml
@@ -488,11 +488,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ExecuteReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Executes the <see cref="P:System.Data.IDbCommand.CommandText" /> against the <see cref="P:System.Data.IDbCommand.Connection" /> and builds an <see cref="T:System.Data.IDataReader" />.</summary>
       </Docs>

--- a/xml/System.Data/IDbConnection.xml
+++ b/xml/System.Data/IDbConnection.xml
@@ -90,11 +90,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="BeginTransaction">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.Common</AssemblyName>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins a database transaction.</summary>
       </Docs>

--- a/xml/System.Data/InRowChangingEventException.xml
+++ b/xml/System.Data/InRowChangingEventException.xml
@@ -55,11 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.InRowChangingEventException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/InvalidConstraintException.xml
+++ b/xml/System.Data/InvalidConstraintException.xml
@@ -70,11 +70,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.InvalidConstraintException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/InvalidExpressionException.xml
+++ b/xml/System.Data/InvalidExpressionException.xml
@@ -62,11 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.InvalidExpressionException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/MissingPrimaryKeyException.xml
+++ b/xml/System.Data/MissingPrimaryKeyException.xml
@@ -66,11 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.MissingPrimaryKeyException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/NoNullAllowedException.xml
+++ b/xml/System.Data/NoNullAllowedException.xml
@@ -70,11 +70,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.NoNullAllowedException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/PropertyCollection.xml
+++ b/xml/System.Data/PropertyCollection.xml
@@ -81,11 +81,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.PropertyCollection" /> class.</summary>
       </Docs>

--- a/xml/System.Data/ReadOnlyException.xml
+++ b/xml/System.Data/ReadOnlyException.xml
@@ -66,11 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.ReadOnlyException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/RowNotInTableException.xml
+++ b/xml/System.Data/RowNotInTableException.xml
@@ -82,11 +82,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.RowNotInTableException" /> class without arguments.</summary>
       </Docs>

--- a/xml/System.Data/StrongTypingException.xml
+++ b/xml/System.Data/StrongTypingException.xml
@@ -62,11 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.StrongTypingException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/SyntaxErrorException.xml
+++ b/xml/System.Data/SyntaxErrorException.xml
@@ -55,11 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.SyntaxErrorException" /> class.</summary>
       </Docs>

--- a/xml/System.Data/TypedTableBaseExtensions.xml
+++ b/xml/System.Data/TypedTableBaseExtensions.xml
@@ -192,10 +192,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="OrderBy&lt;TRow,TKey&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.DataSetExtensions</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sorts the rows of a <see cref="T:System.Data.TypedTableBase`1" /> in ascending order.</summary>
       </Docs>
@@ -337,10 +333,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="OrderByDescending&lt;TRow,TKey&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.DataSetExtensions</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sorts the rows of a <see cref="T:System.Data.TypedTableBase`1" /> in descending order.</summary>
       </Docs>

--- a/xml/System.Data/TypedTableBase`1.xml
+++ b/xml/System.Data/TypedTableBase`1.xml
@@ -83,10 +83,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data.DataSetExtensions</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new <see cref="T:System.Data.TypedTableBase`1" />.</summary>
       </Docs>

--- a/xml/System.Data/UniqueConstraint.xml
+++ b/xml/System.Data/UniqueConstraint.xml
@@ -89,11 +89,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.UniqueConstraint" /> class.</summary>
       </Docs>

--- a/xml/System.Data/VersionNotFoundException.xml
+++ b/xml/System.Data/VersionNotFoundException.xml
@@ -65,11 +65,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Data.VersionNotFoundException" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/AddressHeader.xml
+++ b/xml/System.ServiceModel.Channels/AddressHeader.xml
@@ -101,11 +101,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateAddressHeader">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Channels.AddressHeader" /> class.</summary>
         <remarks>
@@ -468,11 +463,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetValue&lt;T&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Deserializes the information item from the current address header object.</summary>
         <remarks>
@@ -806,11 +796,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteAddressHeader">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes the address header to a stream or file.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Channels/AddressHeaderCollection.xml
+++ b/xml/System.ServiceModel.Channels/AddressHeaderCollection.xml
@@ -58,11 +58,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.AddressHeaderCollection" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/Binding.xml
+++ b/xml/System.ServiceModel.Channels/Binding.xml
@@ -93,11 +93,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.Binding" /> class.</summary>
       </Docs>
@@ -191,11 +186,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="BuildChannelFactory&lt;TChannel&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Builds the channel factory stack on the client specified by the binding.</summary>
       </Docs>
@@ -292,10 +282,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="BuildChannelListener&lt;TChannel&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Builds the channel listener on the service that accepts a specified type of channel and that satisfies the features specified.</summary>
       </Docs>
@@ -657,11 +643,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CanBuildChannelFactory&lt;TChannel&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a value that indicates whether the current binding can build a channel factory stack on the client that satisfies some specific criteria.</summary>
         <remarks>
@@ -780,10 +761,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CanBuildChannelListener&lt;TChannel&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a value that indicates whether the current binding can build a channel listener stack on the service that satisfies some specified criteria.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/BindingContext.xml
+++ b/xml/System.ServiceModel.Channels/BindingContext.xml
@@ -55,11 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.BindingContext" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/BindingElement.xml
+++ b/xml/System.ServiceModel.Channels/BindingElement.xml
@@ -74,11 +74,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.BindingElement" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/BindingElementCollection.xml
+++ b/xml/System.ServiceModel.Channels/BindingElementCollection.xml
@@ -51,11 +51,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.BindingElementCollection" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/ChannelFactoryBase.xml
+++ b/xml/System.ServiceModel.Channels/ChannelFactoryBase.xml
@@ -66,11 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.ChannelFactoryBase" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Channels/ChannelFactoryBase`1.xml
+++ b/xml/System.ServiceModel.Channels/ChannelFactoryBase`1.xml
@@ -72,11 +72,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.ChannelFactoryBase`1" /> class.</summary>
         <remarks>
@@ -166,11 +161,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateChannel">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a particular type of channel with a specified address.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/ChannelParameterCollection.xml
+++ b/xml/System.ServiceModel.Channels/ChannelParameterCollection.xml
@@ -58,11 +58,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.ChannelParameterCollection" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Channels/CommunicationObject.xml
+++ b/xml/System.ServiceModel.Channels/CommunicationObject.xml
@@ -59,11 +59,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.CommunicationObject" /> class.</summary>
       </Docs>
@@ -176,11 +171,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginClose">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous operation to close a communication object.</summary>
       </Docs>
@@ -294,11 +284,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginOpen">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous operation to open a communication object.</summary>
       </Docs>
@@ -416,11 +401,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Close">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Causes a communication object to transition from its current state into the closed state.</summary>
       </Docs>
@@ -1481,11 +1461,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Open">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Causes a communication object to transition from the created state into the opened state.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Channels/CustomBinding.xml
+++ b/xml/System.ServiceModel.Channels/CustomBinding.xml
@@ -140,11 +140,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.CustomBinding" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/HttpMessageHandlerFactory.xml
+++ b/xml/System.ServiceModel.Channels/HttpMessageHandlerFactory.xml
@@ -33,10 +33,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.HttpMessageHandlerFactory" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/HttpTransportBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/HttpTransportBindingElement.xml
@@ -100,11 +100,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.HttpTransportBindingElement" />class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/HttpsTransportBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/HttpsTransportBindingElement.xml
@@ -72,11 +72,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of <see cref="T:System.ServiceModel.Channels.HttpsTransportBindingElement" />.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/IChannelFactory`1.xml
+++ b/xml/System.ServiceModel.Channels/IChannelFactory`1.xml
@@ -64,11 +64,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="CreateChannel">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a channel of a specified type to a specified endpoint address.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Channels/IDuplexSession.xml
+++ b/xml/System.ServiceModel.Channels/IDuplexSession.xml
@@ -65,11 +65,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="BeginCloseOutputSession">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous operation to terminate the outbound session.</summary>
       </Docs>
@@ -169,11 +164,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CloseOutputSession">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Terminates the outbound session that indicates that no more messages will be sent from this endpoint on the channel associated with the session.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/IInputChannel.xml
+++ b/xml/System.ServiceModel.Channels/IInputChannel.xml
@@ -67,11 +67,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="BeginReceive">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous receive operation.</summary>
         <remarks>
@@ -521,11 +516,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Receive">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.ServiceProcess.TimeoutException">The operation did not complete with the timeout interval.</exception>
         <exception cref="T:System.ServiceModel.CommunicationException">The input channel failed.</exception>

--- a/xml/System.ServiceModel.Channels/IOutputChannel.xml
+++ b/xml/System.ServiceModel.Channels/IOutputChannel.xml
@@ -63,11 +63,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="BeginSend">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous operation to send a message.</summary>
       </Docs>
@@ -293,11 +288,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Send">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sends a message on the current output channel.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/IRequestChannel.xml
+++ b/xml/System.ServiceModel.Channels/IRequestChannel.xml
@@ -63,11 +63,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="BeginRequest">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous operation to transmit a request message to the reply side of a request-reply message exchange.</summary>
       </Docs>
@@ -290,11 +285,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Request">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sends a message-based request and returns the correlated message-based response.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/Message.xml
+++ b/xml/System.ServiceModel.Channels/Message.xml
@@ -295,11 +295,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateMessage">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a message.</summary>
         <remarks>
@@ -955,11 +950,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetBody&lt;T&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Retrieves the body of this <see cref="T:System.ServiceModel.Channels.Message" /> instance.</summary>
         <remarks>
@@ -2096,11 +2086,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteBody">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Serializes the body element to XML.</summary>
         <remarks>
@@ -2245,11 +2230,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteMessage">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Serializes the entire message.</summary>
         <remarks>
@@ -2357,11 +2337,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteStartBody">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Serializes the start body of the message.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/MessageBuffer.xml
+++ b/xml/System.ServiceModel.Channels/MessageBuffer.xml
@@ -259,10 +259,6 @@ public void AfterReceiveReply(ref Message reply, object correlationState)
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateNavigator">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.Xml.XPath.XPathNavigator" /> object for navigating this object.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Channels/MessageEncoder.xml
+++ b/xml/System.ServiceModel.Channels/MessageEncoder.xml
@@ -421,11 +421,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadMessage">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>When overridden in a derived class, reads a message from a specified stream.</summary>
       </Docs>
@@ -715,11 +710,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteMessage">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>When overridden in a derived class, writes a message to a specified stream or buffer.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/MessageEncodingBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/MessageEncodingBindingElement.xml
@@ -82,11 +82,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.MessageEncodingBindingElement" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/MessageFault.xml
+++ b/xml/System.ServiceModel.Channels/MessageFault.xml
@@ -162,11 +162,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateFault">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a new <see cref="T:System.ServiceModel.Channels.MessageFault" /> object.</summary>
       </Docs>
@@ -441,11 +436,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetDetail&lt;T&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the detail object of the message fault.</summary>
       </Docs>
@@ -892,11 +882,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteTo">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Serializes the message fault.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/MessageHeader.xml
+++ b/xml/System.ServiceModel.Channels/MessageHeader.xml
@@ -139,11 +139,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateHeader">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new message header.</summary>
       </Docs>
@@ -780,11 +775,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteHeader">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Serializes the header using an XML writer.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/MessageHeaders.xml
+++ b/xml/System.ServiceModel.Channels/MessageHeaders.xml
@@ -85,11 +85,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.MessageHeaders" /> class.</summary>
       </Docs>
@@ -313,11 +308,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyHeaderFrom">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies the header content from a specified object to this instance.</summary>
       </Docs>
@@ -399,11 +389,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CopyHeadersFrom">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Copies the content of all the headers from a specified object to this instance.</summary>
       </Docs>
@@ -592,11 +577,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="FindHeader">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Finds a message header in this collection.</summary>
       </Docs>
@@ -770,11 +750,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetHeader&lt;T&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Retrieves a message header in this collection.</summary>
       </Docs>
@@ -1062,11 +1037,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="HaveMandatoryHeadersBeenUnderstood">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Verifies whether all the message headers marked with <see langword="MustUnderstand" /> have been properly interpreted and processed.</summary>
       </Docs>
@@ -1627,11 +1597,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteHeader">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Serializes the header from the specified location using an XML writer.</summary>
       </Docs>
@@ -1713,11 +1678,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteHeaderContents">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Serializes the specified header content using the specified XML writer.</summary>
       </Docs>
@@ -1799,11 +1759,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteStartHeader">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Serializes the start header using the specified XML writer.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/MessageProperties.xml
+++ b/xml/System.ServiceModel.Channels/MessageProperties.xml
@@ -86,11 +86,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.MessageProperties" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/MessageVersion.xml
+++ b/xml/System.ServiceModel.Channels/MessageVersion.xml
@@ -118,11 +118,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateVersion">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a message version object with specified versions of the SOAP envelope and WS-Addressing.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/MtomMessageEncodingBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/MtomMessageEncodingBindingElement.xml
@@ -68,10 +68,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.MtomMessageEncodingBindingElement" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/NamedPipeTransportBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/NamedPipeTransportBindingElement.xml
@@ -61,10 +61,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.NamedPipeTransportBindingElement" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/ReliableSessionBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/ReliableSessionBindingElement.xml
@@ -88,11 +88,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.ReliableSessionBindingElement" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/RequestContext.xml
+++ b/xml/System.ServiceModel.Channels/RequestContext.xml
@@ -132,11 +132,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginReply">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous operation to reply to the request associated with the current context.</summary>
         <remarks>
@@ -258,11 +253,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Close">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Closes the operation that is replying to the request context associated with the current context.</summary>
       </Docs>
@@ -413,11 +403,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Reply">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Replies to a request message.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/SecurityBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/SecurityBindingElement.xml
@@ -479,10 +479,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateCertificateOverTransportBindingElement">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a security binding element that expects clients to do certificate-based authentication using SOAP message security. This binding element expects the transport to provide server authentication as well as message protection (for example, HTTPS).</summary>
         <remarks>
@@ -734,10 +730,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateIssuedTokenForSslBindingElement">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a symmetric security binding element that is configured to require client authentication based on an issued token and server authentication based on the server certificate.</summary>
         <remarks>
@@ -968,10 +960,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateMutualCertificateBindingElement">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an asymmetric security binding element that is configured to require certificate-based client authentication as well as certificate-based server authentication.</summary>
         <remarks>
@@ -1144,10 +1132,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateMutualCertificateDuplexBindingElement">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an asymmetric security binding element that is configured to require certificate-based client authentication as well as certificate-based server authentication. This authentication mode can be used to secure duplex message-exchange patterns and requires the service to be configured with the client certificate out of band.</summary>
       </Docs>
@@ -1223,11 +1207,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateSecureConversationBindingElement">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a symmetric security binding element that is configured to establish a secure conversation between the client and service. The security context token issued at the end of the secure conversation handshake is used to secure the messages.</summary>
       </Docs>
@@ -1421,10 +1400,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateSslNegotiationBindingElement">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a symmetric security binding element that is configured to do SOAP-level SSL negotiation between the client and server.</summary>
       </Docs>
@@ -1511,10 +1486,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateSspiNegotiationBindingElement">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a symmetric security binding element that does SOAP SSPI negotiation based on the Negotiate authentication package.</summary>
       </Docs>
@@ -1593,10 +1564,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateSspiNegotiationOverTransportBindingElement">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a security binding element that is configured for client authentication based on SOAP SSPI negotiation using the Negotiate authentication package. The binding element requires the transport to provide server authentication and message protection (for example, HTTPS).</summary>
       </Docs>
@@ -1718,10 +1685,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateUserNameForSslBindingElement">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a symmetric security binding element that is configured to require user name- and password-based client authentication and certificate-based server authentication. The client authenticates the server using the SOAP-level SSL protocol.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/SslStreamSecurityBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/SslStreamSecurityBindingElement.xml
@@ -204,11 +204,6 @@ namespace ServiceNamespace
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.SslStreamSecurityBindingElement" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/StreamSecurityUpgradeProvider.xml
+++ b/xml/System.ServiceModel.Channels/StreamSecurityUpgradeProvider.xml
@@ -54,10 +54,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.StreamSecurityUpgradeProvider" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/StreamUpgradeBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/StreamUpgradeBindingElement.xml
@@ -48,10 +48,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.StreamUpgradeBindingElement" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/StreamUpgradeProvider.xml
+++ b/xml/System.ServiceModel.Channels/StreamUpgradeProvider.xml
@@ -55,10 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.StreamUpgradeProvider" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Channels/TcpTransportBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/TcpTransportBindingElement.xml
@@ -72,11 +72,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.TcpTransportBindingElement" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/TextMessageEncodingBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/TextMessageEncodingBindingElement.xml
@@ -75,11 +75,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.TextMessageEncodingBindingElement" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/WebSocketTransportSettings.xml
+++ b/xml/System.ServiceModel.Channels/WebSocketTransportSettings.xml
@@ -238,10 +238,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Determines whether the specified object is equal with the current object.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Channels/WindowsStreamSecurityBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/WindowsStreamSecurityBindingElement.xml
@@ -96,11 +96,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Channels.WindowsStreamSecurityBindingElement" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Description/ClientCredentials.xml
+++ b/xml/System.ServiceModel.Description/ClientCredentials.xml
@@ -78,11 +78,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Description.ClientCredentials" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Description/ContractDescription.xml
+++ b/xml/System.ServiceModel.Description/ContractDescription.xml
@@ -81,11 +81,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Description.ContractDescription" /> class.</summary>
       </Docs>
@@ -402,11 +397,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetContract">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the contract description for a specified type of contract.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Description/DataContractSerializerOperationBehavior.xml
+++ b/xml/System.ServiceModel.Description/DataContractSerializerOperationBehavior.xml
@@ -81,11 +81,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Description.DataContractSerializerOperationBehavior" /> class.</summary>
       </Docs>
@@ -159,11 +154,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateSerializer">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an instance of a class that inherits from <see cref="T:System.Runtime.Serialization.XmlObjectSerializer" /> for serialization and deserialization processes.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Description/ServiceEndpoint.xml
+++ b/xml/System.ServiceModel.Description/ServiceEndpoint.xml
@@ -71,11 +71,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Description.ServiceEndpoint" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Description/TypedMessageConverter.xml
+++ b/xml/System.ServiceModel.Description/TypedMessageConverter.xml
@@ -75,10 +75,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Create">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Represents a static method that returns a <see cref="T:System.ServiceModel.Description.TypedMessageConverter" /> instance.</summary>
       </Docs>
@@ -367,10 +363,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ToMessage">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a <see cref="T:System.ServiceModel.Channels.Message" /> instance from the specified typed message.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Description/XmlSerializerOperationBehavior.xml
+++ b/xml/System.ServiceModel.Description/XmlSerializerOperationBehavior.xml
@@ -75,11 +75,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Description.XmlSerializerOperationBehavior" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Dispatcher/ChannelDispatcher.xml
+++ b/xml/System.ServiceModel.Dispatcher/ChannelDispatcher.xml
@@ -60,10 +60,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Dispatcher.ChannelDispatcher" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Dispatcher/ClientOperation.xml
+++ b/xml/System.ServiceModel.Dispatcher/ClientOperation.xml
@@ -101,11 +101,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Dispatcher.ClientOperation" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Dispatcher/DispatchOperation.xml
+++ b/xml/System.ServiceModel.Dispatcher/DispatchOperation.xml
@@ -77,11 +77,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Dispatcher.DispatchOperation" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Dispatcher/EndpointDispatcher.xml
+++ b/xml/System.ServiceModel.Dispatcher/EndpointDispatcher.xml
@@ -84,10 +84,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Dispatcher.EndpointDispatcher" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Security.Tokens/BinarySecretSecurityToken.xml
+++ b/xml/System.ServiceModel.Security.Tokens/BinarySecretSecurityToken.xml
@@ -59,10 +59,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.IdentityModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Security.Tokens.BinarySecretSecurityToken" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Security.Tokens/IssuedSecurityTokenParameters.xml
+++ b/xml/System.ServiceModel.Security.Tokens/IssuedSecurityTokenParameters.xml
@@ -56,10 +56,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Security.Tokens.IssuedSecurityTokenParameters" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Security.Tokens/SecureConversationSecurityTokenParameters.xml
+++ b/xml/System.ServiceModel.Security.Tokens/SecureConversationSecurityTokenParameters.xml
@@ -63,11 +63,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Security.Tokens.SecureConversationSecurityTokenParameters" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Security.Tokens/SecurityTokenParameters.xml
+++ b/xml/System.ServiceModel.Security.Tokens/SecurityTokenParameters.xml
@@ -71,11 +71,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Security.Tokens.SecurityTokenParameters" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Security.Tokens/SspiSecurityToken.xml
+++ b/xml/System.ServiceModel.Security.Tokens/SspiSecurityToken.xml
@@ -37,10 +37,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Security.Tokens.SspiSecurityToken" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Security.Tokens/UserNameSecurityTokenParameters.xml
+++ b/xml/System.ServiceModel.Security.Tokens/UserNameSecurityTokenParameters.xml
@@ -61,11 +61,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Security.Tokens.UserNameSecurityTokenParameters" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Security/MessageSecurityException.xml
+++ b/xml/System.ServiceModel.Security/MessageSecurityException.xml
@@ -62,11 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Security.MessageSecurityException" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Security/SecurityAccessDeniedException.xml
+++ b/xml/System.ServiceModel.Security/SecurityAccessDeniedException.xml
@@ -55,11 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Security.SecurityAccessDeniedException" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Security/SecurityNegotiationException.xml
+++ b/xml/System.ServiceModel.Security/SecurityNegotiationException.xml
@@ -66,10 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Security.SecurityNegotiationException" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Security/SupportingTokenSpecification.xml
+++ b/xml/System.ServiceModel.Security/SupportingTokenSpecification.xml
@@ -44,10 +44,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Security.SupportingTokenSpecification" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Security/X509CertificateInitiatorClientCredential.xml
+++ b/xml/System.ServiceModel.Security/X509CertificateInitiatorClientCredential.xml
@@ -88,11 +88,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="SetCertificate">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Specifies the certificate to use to represent the service.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Security/X509CertificateRecipientClientCredential.xml
+++ b/xml/System.ServiceModel.Security/X509CertificateRecipientClientCredential.xml
@@ -209,11 +209,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="SetDefaultCertificate">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Specifies the default certificate to use for the service.</summary>
         <remarks>
@@ -370,11 +365,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="SetScopedCertificate">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sets a certificate from a store and stores it in a collection indexed by the URL that sets the scope.</summary>
         <altmember cref="P:System.ServiceModel.Security.X509CertificateRecipientClientCredential.ScopedCertificates" />

--- a/xml/System.ServiceModel.Syndication/Atom10FeedFormatter.xml
+++ b/xml/System.ServiceModel.Syndication/Atom10FeedFormatter.xml
@@ -77,10 +77,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.Atom10FeedFormatter" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/Atom10FeedFormatter`1.xml
+++ b/xml/System.ServiceModel.Syndication/Atom10FeedFormatter`1.xml
@@ -82,10 +82,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.Atom10FeedFormatter`1" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/Atom10ItemFormatter.xml
+++ b/xml/System.ServiceModel.Syndication/Atom10ItemFormatter.xml
@@ -77,10 +77,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.Atom10ItemFormatter" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/Atom10ItemFormatter`1.xml
+++ b/xml/System.ServiceModel.Syndication/Atom10ItemFormatter`1.xml
@@ -82,10 +82,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.Atom10ItemFormatter`1" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/AtomPub10CategoriesDocumentFormatter.xml
+++ b/xml/System.ServiceModel.Syndication/AtomPub10CategoriesDocumentFormatter.xml
@@ -59,10 +59,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.AtomPub10CategoriesDocumentFormatter" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/AtomPub10ServiceDocumentFormatter.xml
+++ b/xml/System.ServiceModel.Syndication/AtomPub10ServiceDocumentFormatter.xml
@@ -66,10 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the Atom 1.0-based <see cref="T:System.ServiceModel.Syndication.ServiceDocumentFormatter" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/AtomPub10ServiceDocumentFormatter`1.xml
+++ b/xml/System.ServiceModel.Syndication/AtomPub10ServiceDocumentFormatter`1.xml
@@ -71,10 +71,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the Atom 1.0-based <see cref="T:System.ServiceModel.Syndication.ServiceDocumentFormatter" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/CategoriesDocument.xml
+++ b/xml/System.ServiceModel.Syndication/CategoriesDocument.xml
@@ -129,10 +129,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Create">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.ServiceModel.Syndication.CategoriesDocument" /> instance.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/CategoriesDocumentFormatter.xml
+++ b/xml/System.ServiceModel.Syndication/CategoriesDocumentFormatter.xml
@@ -62,10 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.CategoriesDocumentFormatter" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/InlineCategoriesDocument.xml
+++ b/xml/System.ServiceModel.Syndication/InlineCategoriesDocument.xml
@@ -51,10 +51,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.InlineCategoriesDocument" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/ReferencedCategoriesDocument.xml
+++ b/xml/System.ServiceModel.Syndication/ReferencedCategoriesDocument.xml
@@ -51,10 +51,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.ReferencedCategoriesDocument" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/ResourceCollectionInfo.xml
+++ b/xml/System.ServiceModel.Syndication/ResourceCollectionInfo.xml
@@ -51,10 +51,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.ResourceCollectionInfo" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/Rss20FeedFormatter.xml
+++ b/xml/System.ServiceModel.Syndication/Rss20FeedFormatter.xml
@@ -74,10 +74,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.Rss20FeedFormatter" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/Rss20FeedFormatter`1.xml
+++ b/xml/System.ServiceModel.Syndication/Rss20FeedFormatter`1.xml
@@ -79,10 +79,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.Rss20FeedFormatter`1" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/Rss20ItemFormatter.xml
+++ b/xml/System.ServiceModel.Syndication/Rss20ItemFormatter.xml
@@ -74,10 +74,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.Rss20ItemFormatter" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/Rss20ItemFormatter`1.xml
+++ b/xml/System.ServiceModel.Syndication/Rss20ItemFormatter`1.xml
@@ -83,10 +83,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.Rss20ItemFormatter`1" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/ServiceDocument.xml
+++ b/xml/System.ServiceModel.Syndication/ServiceDocument.xml
@@ -62,10 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.ServiceDocument" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/ServiceDocumentFormatter.xml
+++ b/xml/System.ServiceModel.Syndication/ServiceDocumentFormatter.xml
@@ -62,10 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.ServiceDocumentFormatter" /> class.</summary>
       </Docs>
@@ -393,10 +389,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="LoadElementExtensions">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Loads a collection of element extensions.</summary>
       </Docs>
@@ -616,10 +608,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="TryParseAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Attempts to parse an attribute extension.</summary>
       </Docs>
@@ -797,10 +785,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="TryParseElement">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Attempts to parse an element extension.</summary>
       </Docs>
@@ -992,10 +976,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteAttributeExtensions">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes attribute extensions.</summary>
       </Docs>
@@ -1149,10 +1129,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteElementExtensions">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes element extensions.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/SyndicationCategory.xml
+++ b/xml/System.ServiceModel.Syndication/SyndicationCategory.xml
@@ -66,10 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Syndication.SyndicationCategory" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/SyndicationContent.xml
+++ b/xml/System.ServiceModel.Syndication/SyndicationContent.xml
@@ -64,10 +64,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of <see cref="T:System.ServiceModel.Syndication.SyndicationContent" /> class.</summary>
       </Docs>
@@ -358,10 +354,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateXmlContent">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.ServiceModel.Syndication.XmlSyndicationContent" /> instance.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/SyndicationElementExtension.xml
+++ b/xml/System.ServiceModel.Syndication/SyndicationElementExtension.xml
@@ -70,10 +70,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Syndication.SyndicationElementExtension" /> class.</summary>
       </Docs>
@@ -323,10 +319,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetObject&lt;TExtension&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the object that represents the element extension.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/SyndicationElementExtensionCollection.xml
+++ b/xml/System.ServiceModel.Syndication/SyndicationElementExtensionCollection.xml
@@ -54,10 +54,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a <see cref="T:System.ServiceModel.Syndication.SyndicationElementExtension" /> object to the collection.</summary>
       </Docs>
@@ -421,10 +417,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadElementExtensions&lt;TExtension&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads the element extensions.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/SyndicationFeed.xml
+++ b/xml/System.ServiceModel.Syndication/SyndicationFeed.xml
@@ -116,10 +116,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Syndication.SyndicationFeed" /> class.</summary>
       </Docs>
@@ -1155,10 +1151,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetRss20Formatter">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets an <see cref="T:System.ServiceModel.Syndication.Rss20FeedFormatter" /> instance.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/SyndicationFeedFormatter.xml
+++ b/xml/System.ServiceModel.Syndication/SyndicationFeedFormatter.xml
@@ -62,10 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.SyndicationFeedFormatter" /> class.</summary>
       </Docs>
@@ -176,10 +172,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateCategory">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.SyndicationCategory" /> class.</summary>
       </Docs>
@@ -346,10 +338,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateLink">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.SyndicationLink" /> class.</summary>
       </Docs>
@@ -437,10 +425,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreatePerson">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.ServiceModel.Syndication.SyndicationPerson" /> instance.</summary>
       </Docs>
@@ -596,10 +580,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="LoadElementExtensions">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Loads element extensions.</summary>
       </Docs>
@@ -937,10 +917,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="TryParseAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Attempts to parse an attribute extension.</summary>
       </Docs>
@@ -1248,10 +1224,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="TryParseElement">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Attempts to parse an element extension.</summary>
       </Docs>
@@ -1555,10 +1527,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteAttributeExtensions">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes attribute extensions.</summary>
       </Docs>
@@ -1784,10 +1752,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteElementExtensions">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Write element extensions.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/SyndicationItem.xml
+++ b/xml/System.ServiceModel.Syndication/SyndicationItem.xml
@@ -106,10 +106,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Syndication.SyndicationItem" /> class.</summary>
       </Docs>
@@ -1020,10 +1016,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetRss20Formatter">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets an <see cref="T:System.ServiceModel.Syndication.Rss20FeedFormatter" /> instance.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/SyndicationItemFormatter.xml
+++ b/xml/System.ServiceModel.Syndication/SyndicationItemFormatter.xml
@@ -62,10 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.SyndicationItemFormatter" /> class.</summary>
       </Docs>
@@ -367,10 +363,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="LoadElementExtensions">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Loads element extensions.</summary>
       </Docs>
@@ -664,10 +656,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="TryParseAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Attempts to parse an attribute extension.</summary>
       </Docs>
@@ -918,10 +906,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="TryParseElement">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Attempts to parse an element extension.</summary>
       </Docs>
@@ -1144,10 +1128,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteAttributeExtensions">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes attribute extensions.</summary>
       </Docs>
@@ -1329,10 +1309,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteElementExtensions">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Write element extensions.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/SyndicationLink.xml
+++ b/xml/System.ServiceModel.Syndication/SyndicationLink.xml
@@ -66,10 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Syndication.SyndicationLink" /> class.</summary>
       </Docs>
@@ -358,10 +354,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateAlternateLink">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.ServiceModel.Syndication.SyndicationLink" /> object.</summary>
         <remarks>
@@ -518,10 +510,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateSelfLink">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.ServiceModel.Syndication.SyndicationLink" /> with the relationship type set to <see langword="self" />.</summary>
         <remarks>

--- a/xml/System.ServiceModel.Syndication/SyndicationPerson.xml
+++ b/xml/System.ServiceModel.Syndication/SyndicationPerson.xml
@@ -78,10 +78,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new <see cref="T:System.ServiceModel.Syndication.SyndicationPerson" /> instance.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/TextSyndicationContent.xml
+++ b/xml/System.ServiceModel.Syndication/TextSyndicationContent.xml
@@ -66,10 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Syndication.TextSyndicationContent" />.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/UrlSyndicationContent.xml
+++ b/xml/System.ServiceModel.Syndication/UrlSyndicationContent.xml
@@ -61,10 +61,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Syndication.UrlSyndicationContent" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/Workspace.xml
+++ b/xml/System.ServiceModel.Syndication/Workspace.xml
@@ -58,10 +58,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of the <see cref="T:System.ServiceModel.Syndication.Workspace" /> type.</summary>
       </Docs>

--- a/xml/System.ServiceModel.Syndication/XmlSyndicationContent.xml
+++ b/xml/System.ServiceModel.Syndication/XmlSyndicationContent.xml
@@ -58,10 +58,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.Syndication.XmlSyndicationContent" />.</summary>
       </Docs>
@@ -355,10 +351,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadContent&lt;TContent&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads content into the <see cref="T:System.ServiceModel.Syndication.XmlSyndicationContent" /> instance.</summary>
       </Docs>

--- a/xml/System.ServiceModel/ActionNotSupportedException.xml
+++ b/xml/System.ServiceModel/ActionNotSupportedException.xml
@@ -64,11 +64,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.ActionNotSupportedException" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel/AddressAccessDeniedException.xml
+++ b/xml/System.ServiceModel/AddressAccessDeniedException.xml
@@ -43,10 +43,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.AddressAccessDeniedException" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel/BasicHttpBinding.xml
+++ b/xml/System.ServiceModel/BasicHttpBinding.xml
@@ -70,11 +70,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.BasicHttpBinding" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/BasicHttpsBinding.xml
+++ b/xml/System.ServiceModel/BasicHttpsBinding.xml
@@ -47,11 +47,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.BasicHttpsBinding" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/ChannelFactory.xml
+++ b/xml/System.ServiceModel/ChannelFactory.xml
@@ -490,11 +490,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="InitializeEndpoint">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes the service endpoint of the channel factory.</summary>
         <remarks>

--- a/xml/System.ServiceModel/ChannelFactory`1.xml
+++ b/xml/System.ServiceModel/ChannelFactory`1.xml
@@ -87,11 +87,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.ChannelFactory`1" /> class.</summary>
       </Docs>
@@ -437,11 +432,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateChannel">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a channel of a specified type to a specified endpoint address.</summary>
         <remarks>
@@ -734,10 +724,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateChannelWithActAsToken">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a channel that is used to send messages to a service with an act as security token.</summary>
       </Docs>
@@ -833,10 +819,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateChannelWithIssuedToken">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a channel that is used to send messages to a service with an issued security token.</summary>
       </Docs>
@@ -932,10 +914,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateChannelWithOnBehalfOfToken">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a channel that is used to send messages to a service with an on behalf of security token.</summary>
       </Docs>

--- a/xml/System.ServiceModel/ChannelTerminatedException.xml
+++ b/xml/System.ServiceModel/ChannelTerminatedException.xml
@@ -58,10 +58,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.ChannelTerminatedException" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel/ClientBase`1+ChannelBase`1.xml
+++ b/xml/System.ServiceModel/ClientBase`1+ChannelBase`1.xml
@@ -304,11 +304,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ServiceModel.Channels.IOutputChannel.BeginSend">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous operation to transmit a message.</summary>
       </Docs>
@@ -482,11 +477,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ServiceModel.Channels.IOutputChannel.Send">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Transmits a message to the destination of the output channel.</summary>
       </Docs>
@@ -612,11 +602,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ServiceModel.Channels.IRequestChannel.BeginRequest">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous operation to transmit a request message.</summary>
       </Docs>
@@ -792,11 +777,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ServiceModel.Channels.IRequestChannel.Request">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sends a message-based request.</summary>
       </Docs>
@@ -1265,11 +1245,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ServiceModel.ICommunicationObject.BeginClose">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an operation to close a communication object.</summary>
       </Docs>
@@ -1359,11 +1334,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ServiceModel.ICommunicationObject.BeginOpen">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an operation to open a communication object.</summary>
       </Docs>
@@ -1453,11 +1423,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ServiceModel.ICommunicationObject.Close">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Causes a communication object to transition from its current state into the closed state.</summary>
       </Docs>
@@ -1727,11 +1692,6 @@ This member is an explicit interface member implementation. It can be used only 
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ServiceModel.ICommunicationObject.Open">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Causes a communication object to transition from the created state into the opened state.</summary>
       </Docs>

--- a/xml/System.ServiceModel/ClientBase`1.xml
+++ b/xml/System.ServiceModel/ClientBase`1.xml
@@ -101,11 +101,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.ClientBase`1" /> class.</summary>
         <remarks>
@@ -1244,11 +1239,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ServiceModel.ICommunicationObject.BeginClose">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous operation to close the <see cref="T:System.ServiceModel.ClientBase`1" />.</summary>
       </Docs>
@@ -1354,11 +1344,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="System.ServiceModel.ICommunicationObject.BeginOpen">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous operation to open the <see cref="T:System.ServiceModel.ClientBase`1" /> object.</summary>
       </Docs>

--- a/xml/System.ServiceModel/ClientCredentialsSecurityTokenManager.xml
+++ b/xml/System.ServiceModel/ClientCredentialsSecurityTokenManager.xml
@@ -233,10 +233,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateSecurityTokenSerializer">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a security token serializer.</summary>
         <remarks>

--- a/xml/System.ServiceModel/CommunicationException.xml
+++ b/xml/System.ServiceModel/CommunicationException.xml
@@ -87,11 +87,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.CommunicationException" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/CommunicationObjectAbortedException.xml
+++ b/xml/System.ServiceModel/CommunicationObjectAbortedException.xml
@@ -62,11 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.CommunicationObjectAbortedException" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/CommunicationObjectFaultedException.xml
+++ b/xml/System.ServiceModel/CommunicationObjectFaultedException.xml
@@ -65,11 +65,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.CommunicationObjectFaultedException" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/DnsEndpointIdentity.xml
+++ b/xml/System.ServiceModel/DnsEndpointIdentity.xml
@@ -61,10 +61,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.DnsEndpointIdentity" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/DuplexChannelFactory`1.xml
+++ b/xml/System.ServiceModel/DuplexChannelFactory`1.xml
@@ -77,11 +77,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.DuplexChannelFactory`1" /> class.</summary>
       </Docs>
@@ -993,11 +988,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateChannel">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a duplex channel of a specified type to a specified endpoint address.</summary>
       </Docs>

--- a/xml/System.ServiceModel/DuplexClientBase`1.xml
+++ b/xml/System.ServiceModel/DuplexClientBase`1.xml
@@ -85,11 +85,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.DuplexClientBase`1" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/EndpointAddress.xml
+++ b/xml/System.ServiceModel/EndpointAddress.xml
@@ -68,11 +68,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.EndpointAddress" /> class.</summary>
       </Docs>
@@ -894,11 +889,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadFrom">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads an endpoint address from a specified XML reader.</summary>
       </Docs>
@@ -1251,11 +1241,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteContentsTo">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Saves all the child nodes of the node to the XML writer specified.</summary>
       </Docs>
@@ -1351,11 +1336,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteTo">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Saves the current endpoint address of a specified version to an XML writer or an XML dictionary writer.</summary>
       </Docs>

--- a/xml/System.ServiceModel/EndpointAddressBuilder.xml
+++ b/xml/System.ServiceModel/EndpointAddressBuilder.xml
@@ -63,11 +63,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.EndpointAddressBuilder" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/EndpointIdentity.xml
+++ b/xml/System.ServiceModel/EndpointIdentity.xml
@@ -187,10 +187,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateRsaIdentity">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an RSA identity.</summary>
         <remarks>
@@ -399,10 +395,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateX509CertificateIdentity">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an X509Certificate identity.</summary>
         <remarks>
@@ -612,10 +604,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Initialize">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes an <see cref="T:System.ServiceModel.EndpointIdentity" />.</summary>
       </Docs>

--- a/xml/System.ServiceModel/EndpointNotFoundException.xml
+++ b/xml/System.ServiceModel/EndpointNotFoundException.xml
@@ -64,11 +64,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.EndpointNotFoundException" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel/ExtensionCollection`1.xml
+++ b/xml/System.ServiceModel/ExtensionCollection`1.xml
@@ -79,11 +79,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.ExtensionCollection`1" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/FaultCode.xml
+++ b/xml/System.ServiceModel/FaultCode.xml
@@ -61,11 +61,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.FaultCode" /> class.</summary>
       </Docs>
@@ -226,11 +221,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateReceiverFaultCode">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a receiver fault code for a message.</summary>
       </Docs>
@@ -306,11 +296,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateSenderFaultCode">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a sender fault code with the specified subcode.</summary>
       </Docs>

--- a/xml/System.ServiceModel/FaultException.xml
+++ b/xml/System.ServiceModel/FaultException.xml
@@ -101,11 +101,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.FaultException" /> class.</summary>
       </Docs>
@@ -495,11 +490,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateFault">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a <see cref="T:System.ServiceModel.FaultException" /> object.</summary>
       </Docs>

--- a/xml/System.ServiceModel/FaultException`1.xml
+++ b/xml/System.ServiceModel/FaultException`1.xml
@@ -91,11 +91,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.FaultException`1" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/FaultReason.xml
+++ b/xml/System.ServiceModel/FaultReason.xml
@@ -55,11 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.FaultReason" /> class.</summary>
       </Docs>
@@ -168,11 +163,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetMatchingTranslation">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the fault description in a specific language.</summary>
       </Docs>

--- a/xml/System.ServiceModel/FaultReasonText.xml
+++ b/xml/System.ServiceModel/FaultReasonText.xml
@@ -55,11 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.FaultReasonText" />class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/ICommunicationObject.xml
+++ b/xml/System.ServiceModel/ICommunicationObject.xml
@@ -127,11 +127,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginClose">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous operation to close a communication object.</summary>
         <remarks>
@@ -247,11 +242,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="BeginOpen">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Begins an asynchronous operation to open a communication object.</summary>
         <remarks>
@@ -372,11 +362,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Close">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Causes a communication object to transition from its current state into the closed state.</summary>
       </Docs>
@@ -674,11 +659,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Open">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Causes a communication object to transition from the created state into the opened state.</summary>
         <remarks>

--- a/xml/System.ServiceModel/InstanceContext.xml
+++ b/xml/System.ServiceModel/InstanceContext.xml
@@ -68,11 +68,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.InstanceContext" /> class.</summary>
       </Docs>
@@ -333,10 +328,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetServiceInstance">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the instance of the service.</summary>
       </Docs>

--- a/xml/System.ServiceModel/InvalidMessageContractException.xml
+++ b/xml/System.ServiceModel/InvalidMessageContractException.xml
@@ -91,11 +91,6 @@ public class AddMessage
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.InvalidMessageContractException" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/MessageHeaderException.xml
+++ b/xml/System.ServiceModel/MessageHeaderException.xml
@@ -62,11 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.MessageHeaderException" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel/MessageHeader`1.xml
+++ b/xml/System.ServiceModel/MessageHeader`1.xml
@@ -59,11 +59,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.MessageHeader`1" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/NetHttpBinding.xml
+++ b/xml/System.ServiceModel/NetHttpBinding.xml
@@ -62,11 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.NetHttpBinding" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/NetHttpsBinding.xml
+++ b/xml/System.ServiceModel/NetHttpsBinding.xml
@@ -46,11 +46,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.NetHttpsBinding" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/NetNamedPipeBinding.xml
+++ b/xml/System.ServiceModel/NetNamedPipeBinding.xml
@@ -57,10 +57,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.NetNamedPipeBinding" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel/NetTcpBinding.xml
+++ b/xml/System.ServiceModel/NetTcpBinding.xml
@@ -76,11 +76,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.NetTcpBinding" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel/OperationContextScope.xml
+++ b/xml/System.ServiceModel/OperationContextScope.xml
@@ -82,11 +82,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.OperationContextScope" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/OptionalReliableSession.xml
+++ b/xml/System.ServiceModel/OptionalReliableSession.xml
@@ -61,11 +61,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.OptionalReliableSession" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/ProtocolException.xml
+++ b/xml/System.ServiceModel/ProtocolException.xml
@@ -64,11 +64,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.ProtocolException" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel/QuotaExceededException.xml
+++ b/xml/System.ServiceModel/QuotaExceededException.xml
@@ -60,11 +60,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.QuotaExceededException" /> class.</summary>
         <remarks>

--- a/xml/System.ServiceModel/ReliableSession.xml
+++ b/xml/System.ServiceModel/ReliableSession.xml
@@ -57,11 +57,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.ReliableSession" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/ServerTooBusyException.xml
+++ b/xml/System.ServiceModel/ServerTooBusyException.xml
@@ -62,11 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.ServerTooBusyException" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/ServiceActivationException.xml
+++ b/xml/System.ServiceModel/ServiceActivationException.xml
@@ -62,11 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.ServiceActivationException" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/ServiceKnownTypeAttribute.xml
+++ b/xml/System.ServiceModel/ServiceKnownTypeAttribute.xml
@@ -84,11 +84,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.ServiceKnownTypeAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/ServiceSecurityContext.xml
+++ b/xml/System.ServiceModel/ServiceSecurityContext.xml
@@ -85,10 +85,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.ServiceSecurityContext" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/SpnEndpointIdentity.xml
+++ b/xml/System.ServiceModel/SpnEndpointIdentity.xml
@@ -79,10 +79,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of <see cref="T:System.ServiceModel.SpnEndpointIdentity" />.</summary>
       </Docs>

--- a/xml/System.ServiceModel/UpnEndpointIdentity.xml
+++ b/xml/System.ServiceModel/UpnEndpointIdentity.xml
@@ -63,10 +63,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.UpnEndpointIdentity" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/WS2007HttpBinding.xml
+++ b/xml/System.ServiceModel/WS2007HttpBinding.xml
@@ -54,10 +54,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.WS2007HttpBinding" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/WSHttpBinding.xml
+++ b/xml/System.ServiceModel/WSHttpBinding.xml
@@ -59,10 +59,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.WSHttpBinding" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/WSHttpBindingBase.xml
+++ b/xml/System.ServiceModel/WSHttpBindingBase.xml
@@ -72,10 +72,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.WSHttpBindingBase" /> class.</summary>
       </Docs>

--- a/xml/System.ServiceModel/X509CertificateEndpointIdentity.xml
+++ b/xml/System.ServiceModel/X509CertificateEndpointIdentity.xml
@@ -47,10 +47,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.ServiceModel</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.ServiceModel.X509CertificateEndpointIdentity" /> class.</summary>
         <remarks>

--- a/xml/System.Web.Services.Configuration/XmlFormatExtensionAttribute.xml
+++ b/xml/System.Web.Services.Configuration/XmlFormatExtensionAttribute.xml
@@ -66,11 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Web.Services.Configuration.XmlFormatExtensionAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Web.Services.Configuration/XmlFormatExtensionPrefixAttribute.xml
+++ b/xml/System.Web.Services.Configuration/XmlFormatExtensionPrefixAttribute.xml
@@ -62,11 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Web.Services.Configuration.XmlFormatExtensionPrefixAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Web.Services.Description/BindingCollection.xml
+++ b/xml/System.Web.Services.Description/BindingCollection.xml
@@ -266,11 +266,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Web.Services.Description.Binding" /> instance specified by the parameter passed in.</summary>
       </Docs>

--- a/xml/System.Web.Services.Description/FaultBindingCollection.xml
+++ b/xml/System.Web.Services.Description/FaultBindingCollection.xml
@@ -260,11 +260,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Web.Services.Description.FaultBinding" /> instance specified by the parameter passed in.</summary>
       </Docs>

--- a/xml/System.Web.Services.Description/MessageCollection.xml
+++ b/xml/System.Web.Services.Description/MessageCollection.xml
@@ -264,11 +264,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Web.Services.Description.Message" /> instance specified by the parameter passed in.</summary>
       </Docs>

--- a/xml/System.Web.Services.Description/MessagePartCollection.xml
+++ b/xml/System.Web.Services.Description/MessagePartCollection.xml
@@ -267,11 +267,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the value of a <see cref="T:System.Web.Services.Description.MessagePart" /> specified by the parameter passed in.</summary>
       </Docs>

--- a/xml/System.Web.Services.Description/OperationFaultCollection.xml
+++ b/xml/System.Web.Services.Description/OperationFaultCollection.xml
@@ -266,11 +266,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Web.Services.Description.OperationFault" /> specified by the parameter passed in.</summary>
       </Docs>

--- a/xml/System.Web.Services.Description/PortCollection.xml
+++ b/xml/System.Web.Services.Description/PortCollection.xml
@@ -264,11 +264,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Web.Services.Description.Port" /> instance specified by the parameter passed in.</summary>
       </Docs>

--- a/xml/System.Web.Services.Description/PortTypeCollection.xml
+++ b/xml/System.Web.Services.Description/PortTypeCollection.xml
@@ -264,11 +264,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Web.Services.Description.PortType" /> specified by the parameter passed in.</summary>
       </Docs>

--- a/xml/System.Web.Services.Description/ServiceCollection.xml
+++ b/xml/System.Web.Services.Description/ServiceCollection.xml
@@ -271,11 +271,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Web.Services.Description.Service" /> instance specified by the parameter passed in.</summary>
       </Docs>

--- a/xml/System.Web.Services.Description/ServiceDescription.xml
+++ b/xml/System.Web.Services.Description/ServiceDescription.xml
@@ -360,11 +360,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Read">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes an instance of the <see cref="T:System.Web.Services.Description.ServiceDescription" /> class by directly loading the XML.</summary>
       </Docs>
@@ -970,11 +965,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Write">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes out the <see cref="T:System.Web.Services.Description.ServiceDescription" /> as a Web Services Description Language (WSDL) file.</summary>
       </Docs>

--- a/xml/System.Web.Services.Description/ServiceDescriptionCollection.xml
+++ b/xml/System.Web.Services.Description/ServiceDescriptionCollection.xml
@@ -435,11 +435,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Web.Services.Description.ServiceDescription" /> instance specified by the parameter passed in.</summary>
       </Docs>

--- a/xml/System.Web.Services.Description/ServiceDescriptionFormatExtensionCollection.xml
+++ b/xml/System.Web.Services.Description/ServiceDescriptionFormatExtensionCollection.xml
@@ -187,11 +187,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Find">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Searches the <see cref="T:System.Web.Services.Description.ServiceDescriptionFormatExtensionCollection" /> and returns the first member of the collection specified by the parameter passed in.</summary>
       </Docs>
@@ -283,11 +278,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="FindAll">
-      <AssemblyInfo>
-        <AssemblyName>System.Web.Services</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Searches the <see cref="T:System.Web.Services.Description.ServiceDescriptionFormatExtensionCollection" /> for all members of the collection specified by the parameter passed in.</summary>
       </Docs>

--- a/xml/System.Web/AspNetHostingPermission.xml
+++ b/xml/System.Web/AspNetHostingPermission.xml
@@ -67,10 +67,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Web.AspNetHostingPermission" /> class.</summary>
       </Docs>

--- a/xml/System.Web/HttpUtility.xml
+++ b/xml/System.Web/HttpUtility.xml
@@ -124,10 +124,6 @@ To encode or decode values outside of a web application, use the <xref:System.Ne
       </Docs>
     </Member>
     <MemberGroup MemberName="HtmlAttributeEncode">
-      <AssemblyInfo>
-        <AssemblyName>System.Web</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Minimally converts a string into an HTML-encoded string.</summary>
       </Docs>
@@ -269,10 +265,6 @@ To encode or decode values outside of a web application, use the <xref:System.Ne
       </Docs>
     </Member>
     <MemberGroup MemberName="HtmlDecode">
-      <AssemblyInfo>
-        <AssemblyName>System.Web</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts a string that has been HTML-encoded for HTTP transmission into a decoded string.
 
@@ -424,10 +416,6 @@ To encode or decode values outside of a web application, use the <xref:System.Ne
       </Docs>
     </Member>
     <MemberGroup MemberName="HtmlEncode">
-      <AssemblyInfo>
-        <AssemblyName>System.Web</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts a string into an HTML-encoded string.
 
@@ -643,10 +631,6 @@ To encode or decode values outside of a web application, use the <xref:System.Ne
       </Docs>
     </Member>
     <MemberGroup MemberName="JavaScriptStringEncode">
-      <AssemblyInfo>
-        <AssemblyName>System.Web</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Encodes a string.</summary>
         <remarks>
@@ -774,10 +758,6 @@ To encode or decode values outside of a web application, use the <xref:System.Ne
       </Docs>
     </Member>
     <MemberGroup MemberName="ParseQueryString">
-      <AssemblyInfo>
-        <AssemblyName>System.Web</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Parses a query string into a <see cref="T:System.Collections.Specialized.NameValueCollection" />.</summary>
       </Docs>
@@ -921,10 +901,6 @@ To encode or decode values outside of a web application, use the <xref:System.Ne
       </Docs>
     </Member>
     <MemberGroup MemberName="UrlDecode">
-      <AssemblyInfo>
-        <AssemblyName>System.Web</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts a string that has been encoded for transmission in a URL into a decoded string.
 
@@ -1239,10 +1215,6 @@ To encode or decode values outside of a web application, use the <xref:System.Ne
       </Docs>
     </Member>
     <MemberGroup MemberName="UrlDecodeToBytes">
-      <AssemblyInfo>
-        <AssemblyName>System.Web</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts a URL-encoded string or byte array into a decoded array of bytes.
 
@@ -1539,10 +1511,6 @@ To encode or decode values outside of a web application, use the <xref:System.Ne
       </Docs>
     </Member>
     <MemberGroup MemberName="UrlEncode">
-      <AssemblyInfo>
-        <AssemblyName>System.Web</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Encodes a URL string. These method overloads can be used to encode the entire URL, including query-string values.
 
@@ -1841,10 +1809,6 @@ To encode or decode values outside of a web application, use the <xref:System.Ne
       </Docs>
     </Member>
     <MemberGroup MemberName="UrlEncodeToBytes">
-      <AssemblyInfo>
-        <AssemblyName>System.Web</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts a string or a byte array into an encoded array of bytes.
 

--- a/xml/System.Xaml.Permissions/XamlAccessLevel.xml
+++ b/xml/System.Xaml.Permissions/XamlAccessLevel.xml
@@ -62,10 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="AssemblyAccessTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a <see cref="T:System.Xaml.Permissions.XamlAccessLevel" /> instance based on an assembly.</summary>
       </Docs>
@@ -197,10 +193,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="PrivateAccessTo">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a <see cref="T:System.Xaml.Permissions.XamlAccessLevel" /> instance based on a specific type.</summary>
       </Docs>

--- a/xml/System.Xaml.Permissions/XamlLoadPermission.xml
+++ b/xml/System.Xaml.Permissions/XamlLoadPermission.xml
@@ -60,10 +60,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.Permissions.XamlLoadPermission" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml.Schema/XamlMemberInvoker.xml
+++ b/xml/System.Xaml.Schema/XamlMemberInvoker.xml
@@ -40,10 +40,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.Schema.XamlMemberInvoker" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml.Schema/XamlTypeInvoker.xml
+++ b/xml/System.Xaml.Schema/XamlTypeInvoker.xml
@@ -37,10 +37,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.Schema.XamlTypeInvoker" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml.Schema/XamlTypeName.xml
+++ b/xml/System.Xaml.Schema/XamlTypeName.xml
@@ -33,10 +33,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.Schema.XamlTypeName" /> class.</summary>
       </Docs>
@@ -325,10 +321,6 @@ XamlTypeNameList1 = empty | ',' XamlTypeNameList
       </Docs>
     </Member>
     <MemberGroup MemberName="ToString">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts the value of this <see cref="T:System.Xaml.Schema.XamlTypeName" /> to its equivalent string representation.</summary>
       </Docs>

--- a/xml/System.Xaml.Schema/XamlValueConverter`1.xml
+++ b/xml/System.Xaml.Schema/XamlValueConverter`1.xml
@@ -49,10 +49,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.Schema.XamlValueConverter`1" /> class.</summary>
       </Docs>
@@ -233,10 +229,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Determines whether this instance of <see cref="T:System.Xaml.Schema.XamlValueConverter`1" /> and an object have the same value.</summary>
       </Docs>

--- a/xml/System.Xaml/AttachableMemberIdentifier.xml
+++ b/xml/System.Xaml/AttachableMemberIdentifier.xml
@@ -97,10 +97,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Determines whether two <see cref="T:System.Xaml.AttachableMemberIdentifier" /> objects have the same value.</summary>
       </Docs>

--- a/xml/System.Xaml/IAmbientProvider.xml
+++ b/xml/System.Xaml/IAmbientProvider.xml
@@ -48,10 +48,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="GetAllAmbientValues">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns an enumerable set of ambient type or property information items for the requested scope.</summary>
       </Docs>
@@ -201,10 +197,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetFirstAmbientValue">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a single ambient type or property information item from the requested set, based on which property is first encountered.</summary>
       </Docs>

--- a/xml/System.Xaml/IXamlNameResolver.xml
+++ b/xml/System.Xaml/IXamlNameResolver.xml
@@ -69,10 +69,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetFixupToken">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns an object that can correct for certain markup patterns that produce forward references.</summary>
       </Docs>
@@ -226,10 +222,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Resolve">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Resolves an object from a name reference.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlBackgroundReader.xml
+++ b/xml/System.Xaml/XamlBackgroundReader.xml
@@ -368,10 +368,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="StartThread">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates and starts a new <see cref="T:System.Threading.Thread" /> (constructed from <see cref="T:System.Threading.ParameterizedThreadStart" />) that handles a named thread for the <see cref="T:System.Xaml.XamlReader" />.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlDirective.xml
+++ b/xml/System.Xaml/XamlDirective.xml
@@ -62,10 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlDirective" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlDuplicateMemberException.xml
+++ b/xml/System.Xaml/XamlDuplicateMemberException.xml
@@ -35,10 +35,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlDuplicateMemberException" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlException.xml
+++ b/xml/System.Xaml/XamlException.xml
@@ -33,10 +33,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlException" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlInternalException.xml
+++ b/xml/System.Xaml/XamlInternalException.xml
@@ -36,10 +36,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlInternalException" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlMember.xml
+++ b/xml/System.Xaml/XamlMember.xml
@@ -61,10 +61,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlMember" /> class.</summary>
       </Docs>
@@ -553,10 +549,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Indicates whether the current object is equal to another object.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlNodeList.xml
+++ b/xml/System.Xaml/XamlNodeList.xml
@@ -34,10 +34,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlNodeList" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlObjectReader.xml
+++ b/xml/System.Xaml/XamlObjectReader.xml
@@ -37,10 +37,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlObjectReader" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlObjectReaderException.xml
+++ b/xml/System.Xaml/XamlObjectReaderException.xml
@@ -26,10 +26,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlObjectReaderException" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlObjectWriter.xml
+++ b/xml/System.Xaml/XamlObjectWriter.xml
@@ -63,10 +63,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlObjectWriter" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlObjectWriterException.xml
+++ b/xml/System.Xaml/XamlObjectWriterException.xml
@@ -33,10 +33,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlObjectWriterException" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlObjectWriterSettings.xml
+++ b/xml/System.Xaml/XamlObjectWriterSettings.xml
@@ -35,10 +35,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlObjectWriterSettings" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlParseException.xml
+++ b/xml/System.Xaml/XamlParseException.xml
@@ -35,10 +35,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlParseException" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlReaderSettings.xml
+++ b/xml/System.Xaml/XamlReaderSettings.xml
@@ -39,10 +39,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlReaderSettings" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlSchemaContext.xml
+++ b/xml/System.Xaml/XamlSchemaContext.xml
@@ -33,10 +33,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlSchemaContext" /> class.</summary>
       </Docs>
@@ -430,10 +426,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetXamlType">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a <see cref="T:System.Xaml.XamlType" /> that is based on either a CLR or XAML type identifier.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlSchemaContextSettings.xml
+++ b/xml/System.Xaml/XamlSchemaContextSettings.xml
@@ -26,10 +26,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlSchemaContextSettings" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlSchemaException.xml
+++ b/xml/System.Xaml/XamlSchemaException.xml
@@ -33,10 +33,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlSchemaException" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlServices.xml
+++ b/xml/System.Xaml/XamlServices.xml
@@ -36,10 +36,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Load">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Loads source for a XAML reader and writes its output as an object graph.</summary>
       </Docs>
@@ -323,10 +319,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Save">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Processes a provided object graph into a XAML node representation and then into an output format for serialization.</summary>
       </Docs>
@@ -577,10 +569,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Transform">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Connects a <see cref="T:System.Xaml.XamlReader" /> and a <see cref="T:System.Xaml.XamlWriter" /> in order to use a common XAML node set intermediary. Potentially transforms the content, depending on the types of readers and writers that are provided.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlType.xml
+++ b/xml/System.Xaml/XamlType.xml
@@ -41,10 +41,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlType" /> class.</summary>
       </Docs>
@@ -474,10 +470,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Equals">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Indicates whether the current object is equal to another object.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlWriterSettings.xml
+++ b/xml/System.Xaml/XamlWriterSettings.xml
@@ -33,10 +33,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlWriterSettings" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlXmlReader.xml
+++ b/xml/System.Xaml/XamlXmlReader.xml
@@ -42,10 +42,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlXmlReader" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlXmlReaderSettings.xml
+++ b/xml/System.Xaml/XamlXmlReaderSettings.xml
@@ -26,10 +26,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlXmlReaderSettings" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlXmlWriter.xml
+++ b/xml/System.Xaml/XamlXmlWriter.xml
@@ -48,10 +48,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlXmlWriter" /> class.</summary>
       </Docs>

--- a/xml/System.Xaml/XamlXmlWriterException.xml
+++ b/xml/System.Xaml/XamlXmlWriterException.xml
@@ -35,10 +35,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xaml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xaml.XamlXmlWriterException" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Linq/Extensions.xml
+++ b/xml/System.Xml.Linq/Extensions.xml
@@ -73,11 +73,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Ancestors&lt;T&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of elements that contains the ancestors of every node in the source collection.</summary>
         <remarks>
@@ -651,11 +646,6 @@ Ancestors
       </Docs>
     </Member>
     <MemberGroup MemberName="AncestorsAndSelf">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of elements that contains every element in the source collection, and the ancestors of every element in the source collection.</summary>
         <remarks>
@@ -1208,11 +1198,6 @@ Ancestors and Self
       </Docs>
     </Member>
     <MemberGroup MemberName="Attributes">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of the attributes of every element in the source collection.</summary>
         <remarks>
@@ -1886,11 +1871,6 @@ Text: ddd
       </Docs>
     </Member>
     <MemberGroup MemberName="Descendants&lt;T&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of elements that contains the descendant elements of every element and document in the source collection.</summary>
         <remarks>
@@ -2355,11 +2335,6 @@ This is some text where all of the text nodes must be concatenated. This is a se
       </Docs>
     </Member>
     <MemberGroup MemberName="DescendantsAndSelf">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of every element in the source collection, and all descendant elements for every element in the source collection.</summary>
         <remarks>
@@ -2534,11 +2509,6 @@ This is some text where all of the text nodes must be concatenated. This is a se
       </Docs>
     </Member>
     <MemberGroup MemberName="Elements&lt;T&gt;">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of the child elements of every element and document in the source collection.</summary>
         <remarks>

--- a/xml/System.Xml.Linq/XAttribute.xml
+++ b/xml/System.Xml.Linq/XAttribute.xml
@@ -82,12 +82,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Linq.XAttribute" /> class.</summary>
         <altmember cref="P:System.Xml.Linq.XAttribute.Name" />

--- a/xml/System.Xml.Linq/XCData.xml
+++ b/xml/System.Xml.Linq/XCData.xml
@@ -66,12 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Linq.XCData" /> class.</summary>
         <related type="Article" href="/dotnet/standard/linq/linq-xml-overview">LINQ to XML overview</related>

--- a/xml/System.Xml.Linq/XComment.xml
+++ b/xml/System.Xml.Linq/XComment.xml
@@ -65,12 +65,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Linq.XComment" /> class.</summary>
         <related type="Article" href="/dotnet/standard/linq/linq-xml-overview">LINQ to XML overview</related>

--- a/xml/System.Xml.Linq/XContainer.xml
+++ b/xml/System.Xml.Linq/XContainer.xml
@@ -67,11 +67,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds the specified content as children to this <see cref="T:System.Xml.Linq.XContainer" />.</summary>
         <remarks>
@@ -438,11 +433,6 @@ Console.WriteLine(xmlTree)
       </Docs>
     </Member>
     <MemberGroup MemberName="AddFirst">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds the specified content as the first children of this document or element.</summary>
         <remarks>
@@ -1050,11 +1040,6 @@ element content
       </Docs>
     </Member>
     <MemberGroup MemberName="Descendants">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of the descendant elements for this document or element, in document order.</summary>
         <remarks>
@@ -1536,11 +1521,6 @@ End Module
       </Docs>
     </Member>
     <MemberGroup MemberName="Elements">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of the child elements of this element or document, in document order.</summary>
         <remarks>
@@ -2337,11 +2317,6 @@ Console.WriteLine(xmltree)
       </Docs>
     </Member>
     <MemberGroup MemberName="ReplaceNodes">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Replaces the children nodes of this document or element with the specified content.</summary>
         <remarks>

--- a/xml/System.Xml.Linq/XDeclaration.xml
+++ b/xml/System.Xml.Linq/XDeclaration.xml
@@ -68,12 +68,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Linq.XDeclaration" /> class.</summary>
         <altmember cref="M:System.Xml.Linq.XDeclaration.ToString" />

--- a/xml/System.Xml.Linq/XDocument.xml
+++ b/xml/System.Xml.Linq/XDocument.xml
@@ -137,11 +137,6 @@ Console.WriteLine(doc)
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Linq.XDocument" /> class.</summary>
         <remarks>
@@ -876,11 +871,6 @@ Console.WriteLine(doc)
       </Docs>
     </Member>
     <MemberGroup MemberName="Load">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.Xml.Linq.XDocument" /> from a file specified by a URI, from an <see cref="T:System.IO.TextReader" />, or from an <see cref="T:System.Xml.XmlReader" />.</summary>
         <remarks>
@@ -1979,11 +1969,6 @@ Document
       </Docs>
     </Member>
     <MemberGroup MemberName="Parse">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.Xml.Linq.XDocument" /> from a string, optionally preserving white space, setting the base URI, and retaining line information.</summary>
         <remarks>
@@ -2357,12 +2342,6 @@ Pubs
       </Docs>
     </Member>
     <MemberGroup MemberName="Save">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Serializes this <see cref="T:System.Xml.Linq.XDocument" /> to a file, a <see cref="T:System.IO.TextWriter" />, or an <see cref="T:System.Xml.XmlWriter" />.</summary>
         <altmember cref="M:System.Xml.Linq.XDocument.WriteTo(System.Xml.XmlWriter)" />

--- a/xml/System.Xml.Linq/XDocumentType.xml
+++ b/xml/System.Xml.Linq/XDocumentType.xml
@@ -86,12 +86,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Linq.XDocumentType" /> class.</summary>
         <related type="Article" href="/dotnet/standard/linq/linq-xml-overview">LINQ to XML overview</related>

--- a/xml/System.Xml.Linq/XElement.xml
+++ b/xml/System.Xml.Linq/XElement.xml
@@ -207,11 +207,6 @@ End Module
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Linq.XElement" /> class.</summary>
         <remarks>
@@ -1238,11 +1233,6 @@ Console.WriteLine(root)
       </Docs>
     </Member>
     <MemberGroup MemberName="AncestorsAndSelf">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of elements that contain this element, and the ancestors of this element.</summary>
         <remarks>
@@ -1583,11 +1573,6 @@ aw:Att="attribute content"
       </Docs>
     </Member>
     <MemberGroup MemberName="Attributes">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of attributes of this element.</summary>
         <remarks>
@@ -1972,11 +1957,6 @@ element content
       </Docs>
     </Member>
     <MemberGroup MemberName="DescendantsAndSelf">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of elements that contain this element, and all descendant elements of this element, in document order.</summary>
         <remarks>
@@ -2932,11 +2912,6 @@ Att3="3"
       </Docs>
     </Member>
     <MemberGroup MemberName="Load">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.Xml.Linq.XElement" /> from a file specified by a URI, from an <see cref="T:System.IO.TextReader" />, or from an <see cref="T:System.Xml.XmlReader" />.</summary>
         <remarks>
@@ -6507,12 +6482,6 @@ value=18446744073709551615
       </Docs>
     </Member>
     <MemberGroup MemberName="Parse">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Load an <see cref="T:System.Xml.Linq.XElement" /> from a string that contains XML, optionally preserving white space and retaining line information.</summary>
         <related type="Article" href="/dotnet/standard/linq/linq-xml-overview">LINQ to XML overview</related>
@@ -6967,11 +6936,6 @@ Console.WriteLine(root)
       </Docs>
     </Member>
     <MemberGroup MemberName="ReplaceAll">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Replaces the child nodes and the attributes of this element with the specified content.</summary>
         <remarks>
@@ -7387,11 +7351,6 @@ Console.WriteLine(root)
       </Docs>
     </Member>
     <MemberGroup MemberName="ReplaceAttributes">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Replaces the attributes of this element with the specified content.</summary>
         <remarks>
@@ -7627,12 +7586,6 @@ Console.WriteLine(root)
       </Docs>
     </Member>
     <MemberGroup MemberName="Save">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Serialize this element's underlying XML tree. The output can be saved to a file, an <see cref="T:System.Xml.XmlTextWriter" />, a <see cref="T:System.IO.TextWriter" />, or an <see cref="T:System.Xml.XmlWriter" />. Optionally, formatting (indenting) can be disabled.</summary>
         <related type="Article" href="/dotnet/standard/linq/linq-xml-overview">LINQ to XML overview</related>

--- a/xml/System.Xml.Linq/XName.xml
+++ b/xml/System.Xml.Linq/XName.xml
@@ -254,11 +254,6 @@ Among other benefits, this feature allows for faster execution of queries. When 
       </Docs>
     </Member>
     <MemberGroup MemberName="Get">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets an <see cref="T:System.Xml.Linq.XName" /> object.</summary>
         <remarks>

--- a/xml/System.Xml.Linq/XNode.xml
+++ b/xml/System.Xml.Linq/XNode.xml
@@ -88,11 +88,6 @@ Objects of classes that derive from <xref:System.Xml.Linq.XContainer> can contai
   </Docs>
   <Members>
     <MemberGroup MemberName="AddAfterSelf">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds the specified content immediately after this node.</summary>
         <remarks>
@@ -417,11 +412,6 @@ Console.WriteLine(xmlTree)
       </Docs>
     </Member>
     <MemberGroup MemberName="AddBeforeSelf">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds the specified content immediately before this node.</summary>
         <remarks>
@@ -753,11 +743,6 @@ Console.WriteLine(xmlTree)
       </Docs>
     </Member>
     <MemberGroup MemberName="Ancestors">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of the ancestor elements of this node.</summary>
         <remarks>
@@ -1083,12 +1068,6 @@ el1 is before el2
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an <see cref="T:System.Xml.XmlReader" /> for this node.</summary>
       </Docs>
@@ -1543,11 +1522,6 @@ Next
       </Docs>
     </Member>
     <MemberGroup MemberName="ElementsAfterSelf">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of the sibling elements after this node, in document order.</summary>
         <remarks>
@@ -1765,11 +1739,6 @@ Child4
       </Docs>
     </Member>
     <MemberGroup MemberName="ElementsBeforeSelf">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of the sibling elements before this node, in document order.</summary>
         <remarks>
@@ -2974,11 +2943,6 @@ Console.WriteLine(xmlTree)
       </Docs>
     </Member>
     <MemberGroup MemberName="ReplaceWith">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Replaces this node with the specified content.</summary>
         <remarks>
@@ -3286,12 +3250,6 @@ Console.WriteLine(xmlTree)
       </Docs>
     </Member>
     <MemberGroup MemberName="ToString">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the XML for this node, optionally disabling formatting.</summary>
         <related type="Article" href="/dotnet/standard/linq/linq-xml-overview">LINQ to XML overview</related>

--- a/xml/System.Xml.Linq/XProcessingInstruction.xml
+++ b/xml/System.Xml.Linq/XProcessingInstruction.xml
@@ -66,12 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Linq.XProcessingInstruction" /> class.</summary>
         <related type="Article" href="/dotnet/standard/linq/linq-xml-overview">LINQ to XML overview</related>

--- a/xml/System.Xml.Linq/XStreamingElement.xml
+++ b/xml/System.Xml.Linq/XStreamingElement.xml
@@ -484,11 +484,6 @@ End Sub
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Linq.XStreamingElement" /> class.</summary>
         <remarks>
@@ -784,12 +779,6 @@ Console.WriteLine(dstTree)
       </Docs>
     </Member>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds the specified content as children to this <see cref="T:System.Xml.Linq.XStreamingElement" />.</summary>
         <related type="Article" href="/dotnet/standard/linq/linq-xml-overview">LINQ to XML overview</related>
@@ -1154,12 +1143,6 @@ NewRoot
       </Docs>
     </Member>
     <MemberGroup MemberName="Save">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Serialize this streaming element. The output can be saved to a file, an <see cref="T:System.Xml.XmlTextWriter" />, a <see cref="T:System.IO.TextWriter" />, or an <see cref="T:System.Xml.XmlWriter" />. Optionally, formatting (indenting) can be disabled.</summary>
         <related type="Article" href="/dotnet/standard/linq/linq-xml-overview">LINQ to XML overview</related>
@@ -1850,11 +1833,6 @@ Console.WriteLine(File.ReadAllText("Test2.xml"))
       </Docs>
     </Member>
     <MemberGroup MemberName="ToString">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the XML for this streaming element, optionally disabling formatting.</summary>
         <remarks>

--- a/xml/System.Xml.Linq/XText.xml
+++ b/xml/System.Xml.Linq/XText.xml
@@ -70,12 +70,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Linq.XText" /> class.</summary>
         <related type="Article" href="/dotnet/standard/linq/linq-xml-overview">LINQ to XML overview</related>

--- a/xml/System.Xml.Resolvers/XmlPreloadedResolver.xml
+++ b/xml/System.Xml.Resolvers/XmlPreloadedResolver.xml
@@ -60,11 +60,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Resolvers.XmlPreloadedResolver" /> class.</summary>
       </Docs>
@@ -289,11 +284,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a <see cref="T:System.IO.Stream" />, byte array, or string with preloaded data to the <see cref="T:System.Xml.Resolvers.XmlPreloadedResolver" /> store and maps it to a URI. If the store already contains a mapping for the same URI, the existing mapping is overridden.</summary>
       </Docs>

--- a/xml/System.Xml.Schema/Extensions.xml
+++ b/xml/System.Xml.Schema/Extensions.xml
@@ -138,11 +138,6 @@ custOrd did not validate
   </Docs>
   <Members>
     <MemberGroup MemberName="GetSchemaInfo">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.Linq</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the post-schema-validation infoset (PSVI) of a validated node.</summary>
         <remarks>
@@ -460,11 +455,6 @@ Invalid Element /Root/Child1/GrandChild3
       </Docs>
     </Member>
     <MemberGroup MemberName="Validate">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.Linq</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Validates that an <see cref="T:System.Xml.Linq.XDocument" />, an <see cref="T:System.Xml.Linq.XElement" />, or an <see cref="T:System.Xml.Linq.XAttribute" /> conforms to an XSD in an <see cref="T:System.Xml.Schema.XmlSchemaSet" />.</summary>
         <remarks>

--- a/xml/System.Xml.Schema/XmlSchema.xml
+++ b/xml/System.Xml.Schema/XmlSchema.xml
@@ -370,11 +370,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Compile">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compiles the XML Schema Object Model (SOM) into schema information for validation. Used to check the syntactic and semantic structure of the programmatically built SOM. Semantic validation checking is performed during compilation.</summary>
         <remarks>
@@ -1146,11 +1141,6 @@ schema.Includes.Add(include);
       </Docs>
     </Member>
     <MemberGroup MemberName="Read">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads an XML Schema.</summary>
       </Docs>
@@ -1541,11 +1531,6 @@ schema.Includes.Add(include);
       </Docs>
     </Member>
     <MemberGroup MemberName="Write">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes out an XML Schema.</summary>
       </Docs>

--- a/xml/System.Xml.Schema/XmlSchemaCollection.xml
+++ b/xml/System.Xml.Schema/XmlSchemaCollection.xml
@@ -78,11 +78,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see langword="XmlSchemaCollection" /> class.</summary>
         <remarks>To be added.</remarks>
@@ -169,11 +164,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds the given schema into the schema collection.</summary>
         <remarks>To be added.</remarks>
@@ -533,11 +523,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Contains">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets a value indicating whether a schema with the specified namespace is in the collection.</summary>
         <remarks>To be added.</remarks>

--- a/xml/System.Xml.Schema/XmlSchemaDatatype.xml
+++ b/xml/System.Xml.Schema/XmlSchemaDatatype.xml
@@ -115,11 +115,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ChangeType">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts the value specified, whose type is one of the valid Common Language Runtime (CLR) representations of the XML schema type represented by the <see cref="T:System.Xml.Schema.XmlSchemaDatatype" />, to another valid CLR representation of the same value.</summary>
       </Docs>

--- a/xml/System.Xml.Schema/XmlSchemaException.xml
+++ b/xml/System.Xml.Schema/XmlSchemaException.xml
@@ -72,11 +72,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Streams all the <see langword="XmlSchemaException" /> properties into the <see langword="SerializationInfo" /> class for the given <see langword="StreamingContext" />.</summary>
       </Docs>

--- a/xml/System.Xml.Schema/XmlSchemaInference.xml
+++ b/xml/System.Xml.Schema/XmlSchemaInference.xml
@@ -116,11 +116,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="InferSchema">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Infers an XML Schema Definition Language (XSD) schema from the XML document specified.</summary>
       </Docs>

--- a/xml/System.Xml.Schema/XmlSchemaInferenceException.xml
+++ b/xml/System.Xml.Schema/XmlSchemaInferenceException.xml
@@ -55,11 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Schema.XmlSchemaInferenceException" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Schema/XmlSchemaObjectCollection.xml
+++ b/xml/System.Xml.Schema/XmlSchemaObjectCollection.xml
@@ -62,11 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see langword="XmlSchemaObjectCollection" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Schema/XmlSchemaSet.xml
+++ b/xml/System.Xml.Schema/XmlSchemaSet.xml
@@ -98,11 +98,6 @@ The sample uses the following two input files.
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Schema.XmlSchemaSet" /> class.</summary>
       </Docs>
@@ -188,11 +183,6 @@ The sample uses the following two input files.
       </Docs>
     </Member>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds the given XML Schema definition language (XSD) schema to the <see cref="T:System.Xml.Schema.XmlSchemaSet" />.</summary>
       </Docs>
@@ -745,11 +735,6 @@ schemaSet.Compile();
       </Docs>
     </Member>
     <MemberGroup MemberName="Contains">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Indicates whether an XML Schema definition language (XSD) schema is in the <see cref="T:System.Xml.Schema.XmlSchemaSet" />.</summary>
       </Docs>
@@ -1520,11 +1505,6 @@ schemaSet.Reprocess(schema);
       </Docs>
     </Member>
     <MemberGroup MemberName="Schemas">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a collection of XML Schema definition language (XSD) schemas in the <see cref="T:System.Xml.Schema.XmlSchemaSet" />.</summary>
       </Docs>

--- a/xml/System.Xml.Schema/XmlSchemaType.xml
+++ b/xml/System.Xml.Schema/XmlSchemaType.xml
@@ -463,11 +463,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetBuiltInComplexType">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns an <see cref="T:System.Xml.Schema.XmlSchemaComplexType" /> that represents the built-in complex type of the complex type specified.</summary>
       </Docs>
@@ -572,11 +567,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetBuiltInSimpleType">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns an <see cref="T:System.Xml.Schema.XmlSchemaSimpleType" /> that represents the built-in simple type of the specified simple type.</summary>
       </Docs>

--- a/xml/System.Xml.Schema/XmlSchemaValidationException.xml
+++ b/xml/System.Xml.Schema/XmlSchemaValidationException.xml
@@ -54,11 +54,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Schema.XmlSchemaValidationException" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Schema/XmlSchemaValidator.xml
+++ b/xml/System.Xml.Schema/XmlSchemaValidator.xml
@@ -572,11 +572,6 @@ validator.ValidateEndElement(null);
       </Docs>
     </Member>
     <MemberGroup MemberName="Initialize">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes the state of the <see cref="T:System.Xml.Schema.XmlSchemaValidator" /> object.</summary>
       </Docs>
@@ -926,11 +921,6 @@ validator.ValidateEndElement(null);
       </Docs>
     </Member>
     <MemberGroup MemberName="ValidateAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Validates the attribute in the current element context.</summary>
       </Docs>
@@ -1133,11 +1123,6 @@ validator.ValidateEndElement(null);
       </Docs>
     </Member>
     <MemberGroup MemberName="ValidateElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Validates the element in the current context.</summary>
       </Docs>
@@ -1319,11 +1304,6 @@ validator.ValidateEndElement(null);
       </Docs>
     </Member>
     <MemberGroup MemberName="ValidateEndElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Verifies if the text content of the element is valid according to its data type for elements with simple content, and verifies if the content of the current element is complete for elements with complex content.</summary>
       </Docs>
@@ -1569,11 +1549,6 @@ validator.ValidateEndElement(null);
       </Docs>
     </Member>
     <MemberGroup MemberName="ValidateText">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Validates whether text is allowed in the current element context, and accumulates the text for validation if the current element has simple content.</summary>
       </Docs>
@@ -1696,11 +1671,6 @@ validator.ValidateEndElement(null);
       </Docs>
     </Member>
     <MemberGroup MemberName="ValidateWhitespace">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Validates whether white space is allowed in the current element context, and accumulates the white space for validation if the current element has simple content.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/SoapAttributeAttribute.xml
+++ b/xml/System.Xml.Serialization/SoapAttributeAttribute.xml
@@ -86,11 +86,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.SoapAttributeAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/SoapAttributeOverrides.xml
+++ b/xml/System.Xml.Serialization/SoapAttributeOverrides.xml
@@ -143,11 +143,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a <see cref="T:System.Xml.Serialization.SoapAttributes" /> to the collection of <see cref="T:System.Xml.Serialization.SoapAttributes" /> objects contained by the <see cref="T:System.Xml.Serialization.SoapAttributeOverrides" />.</summary>
       </Docs>
@@ -299,11 +294,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets an object that represents the collection of overriding SOAP attributes.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/SoapAttributes.xml
+++ b/xml/System.Xml.Serialization/SoapAttributes.xml
@@ -77,11 +77,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.SoapAttributes" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/SoapElementAttribute.xml
+++ b/xml/System.Xml.Serialization/SoapElementAttribute.xml
@@ -80,11 +80,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.SoapElementAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/SoapEnumAttribute.xml
+++ b/xml/System.Xml.Serialization/SoapEnumAttribute.xml
@@ -87,11 +87,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.SoapEnumAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/SoapReflectionImporter.xml
+++ b/xml/System.Xml.Serialization/SoapReflectionImporter.xml
@@ -72,11 +72,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.SoapReflectionImporter" /> class.</summary>
       </Docs>
@@ -251,11 +246,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ImportMembersMapping">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Generates a mapping to an XML Schema element for a .NET type.</summary>
       </Docs>
@@ -638,11 +628,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ImportTypeMapping">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns an object that is used to map from a type to an XML representation using the specified type.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/SoapTypeAttribute.xml
+++ b/xml/System.Xml.Serialization/SoapTypeAttribute.xml
@@ -82,11 +82,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.SoapTypeAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlAnyElementAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlAnyElementAttribute.xml
@@ -104,10 +104,6 @@ For more information about using attributes, see [Attributes](/dotnet/standard/a
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlAnyElementAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlArrayAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlArrayAttribute.xml
@@ -97,11 +97,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlArrayAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlArrayItemAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlArrayItemAttribute.xml
@@ -100,11 +100,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlArrayItemAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlAttributeAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlAttributeAttribute.xml
@@ -117,10 +117,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlAttributeAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlAttributeOverrides.xml
+++ b/xml/System.Xml.Serialization/XmlAttributeOverrides.xml
@@ -137,11 +137,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds an <see cref="T:System.Xml.Serialization.XmlAttributes" /> object to the collection of <see cref="T:System.Xml.Serialization.XmlAttributes" /> objects.</summary>
       </Docs>
@@ -291,11 +286,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets an object that represents the collection of overriding attributes.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlAttributes.xml
+++ b/xml/System.Xml.Serialization/XmlAttributes.xml
@@ -80,11 +80,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlAttributes" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlChoiceIdentifierAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlChoiceIdentifierAttribute.xml
@@ -174,11 +174,6 @@ public enum ItemsChoiceType {
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlChoiceIdentifierAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlElementAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlElementAttribute.xml
@@ -139,10 +139,6 @@ public class Things{
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlElementAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlEnumAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlEnumAttribute.xml
@@ -109,10 +109,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlEnumAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlReflectionImporter.xml
+++ b/xml/System.Xml.Serialization/XmlReflectionImporter.xml
@@ -79,11 +79,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlReflectionImporter" /> class.</summary>
       </Docs>
@@ -290,11 +285,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ImportMembersMapping">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns internal type mappings using information from a Web service method.</summary>
       </Docs>
@@ -647,11 +637,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ImportTypeMapping">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Generates a mapping to an XML Schema element for a specified .NET type.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlRootAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlRootAttribute.xml
@@ -106,10 +106,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlRootAttribute" /> class and uses the class name as the name of the XML root element.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlSchemaExporter.xml
+++ b/xml/System.Xml.Serialization/XmlSchemaExporter.xml
@@ -123,11 +123,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ExportAnyType">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds an element declaration for an object or type to a SOAP message or to an <see cref="T:System.Xml.Schema.XmlSchema" /> object.</summary>
       </Docs>
@@ -252,11 +247,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ExportMembersMapping">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds an element declaration to the applicable <see cref="T:System.Xml.Schema.XmlSchema" /> for each of the element parts of a literal SOAP message definition.</summary>
       </Docs>
@@ -365,11 +355,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ExportTypeMapping">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds an element declaration for an object or type to a SOAP message or an <see cref="T:System.Xml.Schema.XmlSchema" /> object.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlSchemaImporter.xml
+++ b/xml/System.Xml.Serialization/XmlSchemaImporter.xml
@@ -74,11 +74,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlSchemaImporter" /> class.</summary>
       </Docs>
@@ -293,11 +288,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ImportDerivedTypeMapping">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Generates internal type mapping information for an element defined in an XML schema document or as a part in a WSDL document.</summary>
       </Docs>
@@ -454,11 +444,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ImportMembersMapping">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Generates internal type mapping information for the element parts of a literal-use SOAP message defined in a WSDL document.</summary>
       </Docs>
@@ -747,11 +732,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ImportSchemaType">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Generates internal type mapping information for an element defined in an XML schema document.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlSchemas.xml
+++ b/xml/System.Xml.Serialization/XmlSchemas.xml
@@ -102,11 +102,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds an object to the collection of the <see cref="T:System.Xml.Schema.XmlSchema" /> objects.</summary>
       </Docs>
@@ -380,11 +375,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Contains">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Determines whether the specified item is a member of the collection.</summary>
       </Docs>
@@ -853,11 +843,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Xml.Schema.XmlSchema" /> object from the collection.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlSerializationReader+Fixup.xml
+++ b/xml/System.Xml.Serialization/XmlSerializationReader+Fixup.xml
@@ -70,11 +70,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlSerializationReader.Fixup" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlSerializationReader.xml
+++ b/xml/System.Xml.Serialization/XmlSerializationReader.xml
@@ -106,11 +106,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="AddFixup">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Stores an object that contains a callback method to subsequently be called, as necessary, to fill in .NET collections or enumerations that map to SOAP-encoded arrays or SOAP-encoded, multi-referenced elements.</summary>
         <remarks>
@@ -724,11 +719,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateInvalidCastException">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an <see cref="T:System.InvalidCastException" /> that indicates that an explicit reference conversion failed.</summary>
         <remarks>
@@ -2326,11 +2316,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadReferencedElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Deserializes an object from a SOAP-encoded <see langword="multiRef" /> element.</summary>
         <remarks>
@@ -2549,11 +2534,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadReferencingElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Deserializes an object from an XML element in a SOAP message that contains a reference to a <see langword="multiRef" /> element.</summary>
         <remarks>
@@ -2785,11 +2765,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadSerializable">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Populates an object from its XML representation at the current location of the <see cref="T:System.Xml.XmlReader" />.</summary>
       </Docs>
@@ -2897,11 +2872,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadString">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads and returns the current string appended to the input value.</summary>
       </Docs>
@@ -3445,11 +3415,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ToByteArrayBase64">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads the current value and returns it as a base-64 byte array.</summary>
         <remarks>
@@ -3582,11 +3547,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ToByteArrayHex">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the current value as a hexadecimal byte array.</summary>
       </Docs>
@@ -4406,11 +4366,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="UnknownAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Raises a <see cref="E:System.Xml.Serialization.XmlSerializer.UnknownAttribute" /> event for the current position of the <see cref="T:System.Xml.XmlReader" />.</summary>
       </Docs>
@@ -4538,11 +4493,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="UnknownElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Raises an <see cref="E:System.Xml.Serialization.XmlSerializer.UnknownElement" /> event.</summary>
       </Docs>
@@ -4661,11 +4611,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="UnknownNode">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Raises an <see cref="E:System.Xml.Serialization.XmlSerializer.UnknownNode" /> event for the current position of the <see cref="T:System.Xml.XmlReader" />.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlSerializationWriter.xml
+++ b/xml/System.Xml.Serialization/XmlSerializationWriter.xml
@@ -239,11 +239,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateInvalidAnyTypeException">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an <see cref="T:System.InvalidOperationException" />.</summary>
       </Docs>
@@ -559,11 +554,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateUnknownTypeException">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an <see cref="T:System.InvalidOperationException" /> that indicates that a type being serialized is not being used in a valid manner or is unexpectedly encountered.</summary>
       </Docs>
@@ -1055,11 +1045,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="FromEnum">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Takes a numeric enumeration value and returns a string that consists of delimited identifiers that represent the enumeration members that have been set.</summary>
         <remarks>
@@ -1558,11 +1543,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="FromXmlQualifiedName">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Produces an XML qualified name, with invalid characters replaced by escape sequences.</summary>
       </Docs>
@@ -1904,11 +1884,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Instructs an <see cref="T:System.Xml.XmlNode" /> object to write an XML attribute that has no namespace specified for its name.</summary>
       </Docs>
@@ -2383,11 +2358,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteElementQualifiedName">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes an XML element with a specified qualified name in its body.</summary>
       </Docs>
@@ -2653,11 +2623,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteElementString">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes an opening element tag, including any attributes.</summary>
       </Docs>
@@ -2923,11 +2888,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteElementStringRaw">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes an XML element with a specified value in its body.</summary>
       </Docs>
@@ -3453,11 +3413,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteEmptyTag">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes an XML element whose body is empty.</summary>
       </Docs>
@@ -3573,11 +3528,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteEndElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes a <see langword="&amp;lt;closing&amp;gt;" /> element tag.</summary>
       </Docs>
@@ -4009,11 +3959,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteNullableStringEncodedRaw">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes a byte array as the body of an XML element. <see cref="T:System.Xml.XmlNode" /> inserts an <see langword="xsi:nil='true'" /> attribute if the string's value is <see langword="null" />.</summary>
       </Docs>
@@ -4230,11 +4175,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteNullableStringLiteralRaw">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes a byte array as the body of an XML element. <see cref="T:System.Xml.XmlNode" /> inserts an <see langword="xsi:nil='true' " />attribute if the string's value is <see langword="null" />.</summary>
       </Docs>
@@ -4378,11 +4318,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteNullTagEncoded">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Instructs <see cref="T:System.Xml.XmlNode" /> to write an XML element with an <see langword="xsi:nil='true'" /> attribute.</summary>
       </Docs>
@@ -4506,11 +4441,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteNullTagLiteral">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Instructs <see cref="T:System.Xml.XmlNode" /> to write an XML element with an <see langword="xsi:nil='true'" /> attribute.</summary>
       </Docs>
@@ -4634,11 +4564,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WritePotentiallyReferencingElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes a SOAP message XML element that can contain a reference to a <see langword="&amp;lt;multiRef&amp;gt;" /> XML element for a given object.</summary>
       </Docs>
@@ -5054,11 +4979,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteReferencingElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes a SOAP message XML element that contains a reference to a <see langword="multiRef" /> element for a given object.</summary>
       </Docs>
@@ -5270,11 +5190,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteSerializable">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Instructs <see cref="T:System.Xml.XmlNode" /> to write an object that uses custom XML formatting as an XML element.</summary>
       </Docs>
@@ -5461,11 +5376,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteStartElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Instructs <see cref="T:System.Xml.XmlNode" /> to write an opening element tag, including any attributes.</summary>
       </Docs>
@@ -5924,11 +5834,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteValue">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Instructs <see cref="T:System.Xml.XmlNode" /> to write the specified value.</summary>
       </Docs>
@@ -6042,11 +5947,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteXmlAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Instructs <see cref="T:System.Xml.XmlNode" /> to write an XML attribute.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlSerializer.xml
+++ b/xml/System.Xml.Serialization/XmlSerializer.xml
@@ -270,11 +270,6 @@ The following example contains two main classes: `PurchaseOrder` and `Test`. The
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlSerializer" /> class.</summary>
       </Docs>
@@ -1127,11 +1122,6 @@ The following example contains two main classes: `PurchaseOrder` and `Test`. The
       </Docs>
     </Member>
     <MemberGroup MemberName="Deserialize">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Deserializes an XML document.</summary>
       </Docs>
@@ -1714,11 +1704,6 @@ The following example contains two main classes: `PurchaseOrder` and `Test`. The
       </Docs>
     </Member>
     <MemberGroup MemberName="FromMappings">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns an instance of the <see cref="T:System.Xml.Serialization.XmlSerializer" /> class from the specified mappings.</summary>
       </Docs>
@@ -1960,10 +1945,6 @@ The following example uses the <xref:System.Xml.Serialization.XmlSerializer.From
       </Docs>
     </Member>
     <MemberGroup MemberName="GenerateSerializer">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns an assembly that contains typed serializers.</summary>
         <remarks>
@@ -1979,11 +1960,6 @@ The following example uses the <xref:System.Xml.Serialization.XmlSerializer.From
       </Docs>
     </MemberGroup>
     <MemberGroup MemberName="GetXmlSerializerAssemblyName">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the name of the assembly that contains one or more versions of the <see cref="T:System.Xml.Serialization.XmlSerializer" /> especially created to serialize or deserialize specific types.</summary>
         <remarks>
@@ -2117,11 +2093,6 @@ The following example uses the <xref:System.Xml.Serialization.XmlSerializer.From
       </Docs>
     </Member>
     <MemberGroup MemberName="Serialize">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Serializes an object into an XML document.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlSerializerAssemblyAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlSerializerAssemblyAttribute.xml
@@ -58,11 +58,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlSerializerAssemblyAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlSerializerFactory.xml
+++ b/xml/System.Xml.Serialization/XmlSerializerFactory.xml
@@ -93,11 +93,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateSerializer">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns a derivation of the <see cref="T:System.Xml.Serialization.XmlSerializer" /> class that is used to serialize a type.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlSerializerNamespaces.xml
+++ b/xml/System.Xml.Serialization/XmlSerializerNamespaces.xml
@@ -131,10 +131,6 @@ ns.Add("", "")
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlSerializerNamespaces" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlSerializerVersionAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlSerializerVersionAttribute.xml
@@ -67,11 +67,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlSerializerVersionAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlTextAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlTextAttribute.xml
@@ -131,10 +131,6 @@ xmlns:xs="http://www.w3.org/2001/XMLSchema">
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlTextAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Serialization/XmlTypeAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlTypeAttribute.xml
@@ -95,11 +95,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Serialization.XmlTypeAttribute" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.XPath/Extensions.xml
+++ b/xml/System.Xml.XPath/Extensions.xml
@@ -66,10 +66,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="CreateNavigator">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an <see cref="T:System.Xml.XPath.XPathNavigator" /> for an <see cref="T:System.Xml.Linq.XNode" />.</summary>
         <remarks>
@@ -275,10 +271,6 @@ This example produces the following output:
       </Docs>
     </Member>
     <MemberGroup MemberName="XPathEvaluate">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Evaluates an XPath expression.</summary>
         <remarks>
@@ -494,11 +486,6 @@ aw:Att="attdata"
       </Docs>
     </Member>
     <MemberGroup MemberName="XPathSelectElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Selects an <see cref="T:System.Xml.Linq.XElement" /> using a XPath expression.</summary>
       </Docs>
@@ -714,10 +701,6 @@ Console.WriteLine(child1)
       </Docs>
     </Member>
     <MemberGroup MemberName="XPathSelectElements">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath.XDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Selects a collection of elements using an XPath expression.</summary>
         <remarks>

--- a/xml/System.Xml.XPath/XPathDocument.xml
+++ b/xml/System.Xml.XPath/XPathDocument.xml
@@ -69,11 +69,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.XPath.XPathDocument" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.XPath/XPathException.xml
+++ b/xml/System.Xml.XPath/XPathException.xml
@@ -62,11 +62,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.XPath.XPathException" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.XPath/XPathExpression.xml
+++ b/xml/System.Xml.XPath/XPathExpression.xml
@@ -133,10 +133,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="AddSort">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>When overridden in a derived class, sorts the nodes selected by the XPath expression.</summary>
       </Docs>
@@ -400,10 +396,6 @@ expression.AddSort("@ISBN", (IComparer)isbn);
       </Docs>
     </Member>
     <MemberGroup MemberName="Compile">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compiles the XPath expression specified and returns an <see cref="T:System.Xml.XPath.XPathExpression" /> object that represents the XPath expression.</summary>
       </Docs>
@@ -743,10 +735,6 @@ expression.AddSort("@ISBN", (IComparer)isbn);
       </Docs>
     </Member>
     <MemberGroup MemberName="SetContext">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>When overridden in a derived class, specifies the <see cref="T:System.Xml.IXmlNamespaceResolver" /> object to use for namespace resolution.</summary>
       </Docs>

--- a/xml/System.Xml.XPath/XPathItem.xml
+++ b/xml/System.Xml.XPath/XPathItem.xml
@@ -292,10 +292,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ValueAs">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the item's value as the specified type.</summary>
       </Docs>

--- a/xml/System.Xml.XPath/XPathNavigator.xml
+++ b/xml/System.Xml.XPath/XPathNavigator.xml
@@ -197,10 +197,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="AppendChild">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new child node at the end of the list of child nodes of the current node.</summary>
       </Docs>
@@ -1702,10 +1698,6 @@ editor.CreateAttribute(navigator.Prefix, "attributeName", LookupNamespace(naviga
       </Docs>
     </Member>
     <MemberGroup MemberName="Evaluate">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Evaluates the specified XPath expression and returns the typed result.</summary>
       </Docs>
@@ -2568,10 +2560,6 @@ nav.Evaluate(expr);
       </Docs>
     </Member>
     <MemberGroup MemberName="InsertAfter">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new sibling node after the currently selected node.</summary>
       </Docs>
@@ -2989,10 +2977,6 @@ nav.Evaluate(expr);
       </Docs>
     </Member>
     <MemberGroup MemberName="InsertBefore">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new sibling node before the currently selected node.</summary>
       </Docs>
@@ -4151,10 +4135,6 @@ navigator.InsertElementBefore(navigator.Prefix, "pages", LookupNamespaceURI(navi
       </Docs>
     </Member>
     <MemberGroup MemberName="Matches">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Determines whether the current node matches the specified <see cref="N:System.Xml.XPath" /> expression.</summary>
       </Docs>
@@ -4451,10 +4431,6 @@ navigator.InsertElementBefore(navigator.Prefix, "pages", LookupNamespaceURI(navi
       </Docs>
     </Member>
     <MemberGroup MemberName="MoveToChild">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Moves the <see cref="T:System.Xml.XPath.XPathNavigator" /> to the child node specified.</summary>
       </Docs>
@@ -4802,10 +4778,6 @@ navigator.InsertElementBefore(navigator.Prefix, "pages", LookupNamespaceURI(navi
       </Docs>
     </Member>
     <MemberGroup MemberName="MoveToFirstNamespace">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Moves the <see cref="T:System.Xml.XPath.XPathNavigator" /> to the first namespace node of the current node.</summary>
       </Docs>
@@ -4962,10 +4934,6 @@ navigator.InsertElementBefore(navigator.Prefix, "pages", LookupNamespaceURI(navi
       </Docs>
     </Member>
     <MemberGroup MemberName="MoveToFollowing">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Moves the <see cref="T:System.Xml.XPath.XPathNavigator" /> to the specified element in document order.</summary>
       </Docs>
@@ -5520,10 +5488,6 @@ navigator.InsertElementBefore(navigator.Prefix, "pages", LookupNamespaceURI(navi
       </Docs>
     </Member>
     <MemberGroup MemberName="MoveToNext">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Moves the <see cref="T:System.Xml.XPath.XPathNavigator" /> to the next sibling node of the current node.</summary>
       </Docs>
@@ -5841,10 +5805,6 @@ navigator.InsertElementBefore(navigator.Prefix, "pages", LookupNamespaceURI(navi
       </Docs>
     </Member>
     <MemberGroup MemberName="MoveToNextNamespace">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Moves the <see cref="T:System.Xml.XPath.XPathNavigator" /> to the next namespace node.</summary>
       </Docs>
@@ -6786,10 +6746,6 @@ navigator.InsertElementBefore(navigator.Prefix, "pages", LookupNamespaceURI(navi
       </Docs>
     </Member>
     <MemberGroup MemberName="PrependChild">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new child node at the beginning of the list of child nodes of the current node.</summary>
       </Docs>
@@ -7547,10 +7503,6 @@ navigator.PrependChildElement(navigator.Prefix, "pages", LookupNamespaceURI(navi
       </Docs>
     </Member>
     <MemberGroup MemberName="ReplaceSelf">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Replaces the current node with the content specified.</summary>
       </Docs>
@@ -7933,10 +7885,6 @@ navigator.PrependChildElement(navigator.Prefix, "pages", LookupNamespaceURI(navi
       </Docs>
     </Member>
     <MemberGroup MemberName="Select">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Selects a node set, using the specified XPath expression.</summary>
       </Docs>
@@ -8334,10 +8282,6 @@ XPathNodeIterator ni = nav.Select(expr);
       </Docs>
     </Member>
     <MemberGroup MemberName="SelectAncestors">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Selects all the ancestor nodes of the current node that match the selection criteria.</summary>
       </Docs>
@@ -8517,10 +8461,6 @@ XPathNodeIterator ni = nav.Select(expr);
       </Docs>
     </Member>
     <MemberGroup MemberName="SelectChildren">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Selects all the child nodes of the current node that match the selection criteria.</summary>
       </Docs>
@@ -8662,10 +8602,6 @@ XPathNodeIterator ni = nav.Select(expr);
       </Docs>
     </Member>
     <MemberGroup MemberName="SelectDescendants">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Selects all the descendant nodes of the current node that match the selection criteria.</summary>
       </Docs>
@@ -8815,10 +8751,6 @@ XPathNodeIterator ni = nav.Select(expr);
       </Docs>
     </Member>
     <MemberGroup MemberName="SelectSingleNode">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XPath</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Selects a single node in the <see cref="T:System.Xml.XPath.XPathNavigator" />.</summary>
       </Docs>

--- a/xml/System.Xml.Xsl/XslCompiledTransform.xml
+++ b/xml/System.Xml.Xsl/XslCompiledTransform.xml
@@ -109,11 +109,6 @@ The sample uses the following two input files:
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Xsl.XslCompiledTransform" /> class.</summary>
         <related type="Article" href="/dotnet/standard/data/xml/using-the-xslcompiledtransform-class">Using the XslCompiledTransform Class</related>
@@ -226,11 +221,6 @@ The sample uses the following two input files:
       </Docs>
     </Member>
     <MemberGroup MemberName="Load">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Compiles the style sheet.</summary>
         <remarks>
@@ -929,11 +919,6 @@ xslt.Load(typeof(bookOrders));
       </Docs>
     </Member>
     <MemberGroup MemberName="Transform">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Executes the XSLT transformation.</summary>
         <remarks>

--- a/xml/System.Xml.Xsl/XslTransform.xml
+++ b/xml/System.Xml.Xsl/XslTransform.xml
@@ -99,11 +99,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Load">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Loads the XSLT style sheet, including style sheets referenced in <see langword="xsl:include" /> and <see langword="xsl:import" /> elements.</summary>
         <remarks>To be added.</remarks>
@@ -562,11 +557,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Transform">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Transforms the XML data using the loaded XSLT style sheet.</summary>
         <remarks>To be added.</remarks>

--- a/xml/System.Xml.Xsl/XsltCompileException.xml
+++ b/xml/System.Xml.Xsl/XsltCompileException.xml
@@ -55,11 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see langword="XsltCompileException" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Xsl/XsltContext.xml
+++ b/xml/System.Xml.Xsl/XsltContext.xml
@@ -55,11 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Xsl.XsltContext" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Xsl/XsltException.xml
+++ b/xml/System.Xml.Xsl/XsltException.xml
@@ -55,11 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see langword="XsltException" /> class.</summary>
       </Docs>

--- a/xml/System.Xml.Xsl/XsltSettings.xml
+++ b/xml/System.Xml.Xsl/XsltSettings.xml
@@ -74,11 +74,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.Xsl.XsltSettings" /> class.</summary>
         <related type="Article" href="/dotnet/standard/data/xml/using-the-xslcompiledtransform-class">Using the XslCompiledTransform Class</related>

--- a/xml/System.Xml/IXmlBinaryReaderInitializer.xml
+++ b/xml/System.Xml/IXmlBinaryReaderInitializer.xml
@@ -46,11 +46,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="SetInput">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reinitializes the binary reader using the given input data.</summary>
       </Docs>

--- a/xml/System.Xml/IXmlDictionary.xml
+++ b/xml/System.Xml/IXmlDictionary.xml
@@ -55,10 +55,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="TryLookup">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Attempts to look up an entry in the dictionary.</summary>
         <remarks>

--- a/xml/System.Xml/IXmlTextReaderInitializer.xml
+++ b/xml/System.Xml/IXmlTextReaderInitializer.xml
@@ -46,11 +46,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName="SetInput">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Specifies initialization requirements for XML text readers that implement this method.</summary>
       </Docs>

--- a/xml/System.Xml/NameTable.xml
+++ b/xml/System.Xml/NameTable.xml
@@ -122,12 +122,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Atomizes the specified string and adds it to the <see langword="NameTable" />.</summary>
         <remarks>
@@ -270,12 +264,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Get">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the atomized string.</summary>
         <remarks>

--- a/xml/System.Xml/UniqueId.xml
+++ b/xml/System.Xml/UniqueId.xml
@@ -63,11 +63,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new instance of this class.</summary>
       </Docs>
@@ -762,11 +757,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="TryGetGuid">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Tries to get the value of the <see cref="T:System.Xml.UniqueId" /> as a <see cref="T:System.Guid" />.</summary>
       </Docs>

--- a/xml/System.Xml/XmlAttributeCollection.xml
+++ b/xml/System.Xml/XmlAttributeCollection.xml
@@ -384,10 +384,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ItemOf">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the attribute with the specified name or index.</summary>
       </Docs>

--- a/xml/System.Xml/XmlBinaryReaderSession.xml
+++ b/xml/System.Xml/XmlBinaryReaderSession.xml
@@ -206,11 +206,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="TryLookup">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Checks whether the internal collection contains an entry.</summary>
       </Docs>

--- a/xml/System.Xml/XmlConvert.xml
+++ b/xml/System.Xml/XmlConvert.xml
@@ -892,11 +892,6 @@ The <xref:System.Xml.XmlConvert> contains additional methods that validate token
       </Docs>
     </Member>
     <MemberGroup MemberName="ToDateTime">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts the <see cref="T:System.String" /> to a <see cref="T:System.DateTime" /> equivalent.</summary>
       </Docs>
@@ -1150,13 +1145,6 @@ The <xref:System.Xml.XmlConvert> contains additional methods that validate token
       </Docs>
     </Member>
     <MemberGroup MemberName="ToDateTimeOffset">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts the supplied <see cref="T:System.String" /> to a <see cref="T:System.DateTimeOffset" /> equivalent.</summary>
       </Docs>
@@ -1880,13 +1868,6 @@ The <xref:System.Xml.XmlConvert> contains additional methods that validate token
       </Docs>
     </Member>
     <MemberGroup MemberName="ToString">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts strongly typed data to an equivalent <see cref="T:System.String" /> representation.</summary>
       </Docs>

--- a/xml/System.Xml/XmlDataDocument.xml
+++ b/xml/System.Xml/XmlDataDocument.xml
@@ -56,11 +56,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.XmlDataDocument" /> class.</summary>
       </Docs>
@@ -613,11 +608,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Load">
-      <AssemblyInfo>
-        <AssemblyName>System.Data</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Loads the <see langword="XmlDataDocument" /> using the specified data source and synchronizes the <see cref="T:System.Data.DataSet" /> with the loaded data.</summary>
         <remarks>

--- a/xml/System.Xml/XmlDictionary.xml
+++ b/xml/System.Xml/XmlDictionary.xml
@@ -71,11 +71,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an instance of this class.</summary>
       </Docs>
@@ -274,10 +269,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="TryLookup">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Attempts to look up an entry in the dictionary.</summary>
         <remarks>

--- a/xml/System.Xml/XmlDictionaryReader.xml
+++ b/xml/System.Xml/XmlDictionaryReader.xml
@@ -161,10 +161,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateBinaryReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an instance of <see cref="T:System.Xml.XmlDictionaryReader" /> that can read .NET Binary XML Format.</summary>
         <remarks>
@@ -898,11 +894,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateMtomReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an instance of <see cref="T:System.Xml.XmlDictionaryReader" /> that reads XML in the MTOM format.</summary>
         <remarks>
@@ -1448,10 +1439,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateTextReader">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an instance of <see cref="T:System.Xml.XmlDictionaryReader" />.</summary>
         <remarks>
@@ -1930,11 +1917,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="IndexOfLocalName">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the index of the local name of the current node within an array of names.</summary>
       </Docs>
@@ -2062,11 +2044,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="IsLocalName">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Checks whether the parameter, <paramref name="localName" />, is the local name of the current node.</summary>
       </Docs>
@@ -2168,11 +2145,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="IsNamespaceUri">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Checks whether the parameter, <paramref name="namespaceUri" />, is the namespace of the current node.</summary>
       </Docs>
@@ -2427,11 +2399,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="MoveToStartElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Tests whether the current content node is a start element or an empty element.</summary>
       </Docs>
@@ -2660,11 +2627,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadArray">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads repeated occurrences of a data type into a typed array.</summary>
       </Docs>
@@ -3910,11 +3872,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadBooleanArray">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads repeated occurrences of <see cref="T:System.Boolean" /> nodes into a typed array.</summary>
       </Docs>
@@ -4137,11 +4094,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadContentAsBinHex">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads the content and returns the <see langword="BinHex" /> decoded binary bytes.</summary>
       </Docs>
@@ -4471,11 +4423,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadContentAsString">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts a node's content to a string.</summary>
       </Docs>
@@ -4779,11 +4726,6 @@ An entry in <paramref name="strings" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadDateTimeArray">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts a node's content to a <see cref="T:System.DateTime" /> array.</summary>
       </Docs>
@@ -4892,11 +4834,6 @@ An entry in <paramref name="strings" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadDecimalArray">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts a node's content to a <see cref="T:System.Decimal" /> array.</summary>
       </Docs>
@@ -5012,11 +4949,6 @@ An entry in <paramref name="strings" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadDoubleArray">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Converts a node's content to a <see cref="T:System.Double" /> array.</summary>
       </Docs>
@@ -5717,11 +5649,6 @@ An entry in <paramref name="strings" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadFullStartElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Checks whether the current node is an element and advances the reader to the next node.</summary>
       </Docs>
@@ -5916,11 +5843,6 @@ An entry in <paramref name="strings" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadGuidArray">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads the contents of a series of nodes into an array of <see cref="T:System.Guid" />.</summary>
       </Docs>
@@ -6036,11 +5958,6 @@ An entry in <paramref name="strings" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadInt16Array">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads the contents of a series of nodes into an array of <see langword="short" /> integers (<see cref="T:System.Int16" />).</summary>
       </Docs>
@@ -6156,11 +6073,6 @@ An entry in <paramref name="strings" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadInt32Array">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads the contents of a series of nodes into an array of integers (<see cref="T:System.Int32" />).</summary>
       </Docs>
@@ -6276,11 +6188,6 @@ An entry in <paramref name="strings" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadInt64Array">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads the contents of a series of nodes into an array of <see langword="long" /> integers (<see cref="T:System.Int64" />).</summary>
       </Docs>
@@ -6396,11 +6303,6 @@ An entry in <paramref name="strings" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadSingleArray">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads the contents of a series of nodes into an array of <see langword="float" /> numbers (<see cref="T:System.Single" />).</summary>
       </Docs>
@@ -6563,11 +6465,6 @@ An entry in <paramref name="strings" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadString">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads the contents of the current node into a string.</summary>
       </Docs>
@@ -6664,11 +6561,6 @@ An entry in <paramref name="strings" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadTimeSpanArray">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Reads the contents of a series of nodes into a <see cref="T:System.TimeSpan" /> array.</summary>
       </Docs>

--- a/xml/System.Xml/XmlDictionaryWriter.xml
+++ b/xml/System.Xml/XmlDictionaryWriter.xml
@@ -186,10 +186,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateBinaryWriter">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an instance of <see cref="T:System.Xml.XmlDictionaryWriter" /> that writes WCF binary XML format.</summary>
         <remarks>
@@ -499,11 +495,6 @@ binarywriter.WriteEndAttribute();
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateMtomWriter">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an instance of <see cref="T:System.Xml.XmlDictionaryWriter" /> that writes XML in the Message Transmission Optimization Mechanism (MTOM) format.</summary>
         <remarks>
@@ -644,11 +635,6 @@ binarywriter.WriteEndAttribute();
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateTextWriter">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an instance of <see cref="T:System.Xml.XmlDictionaryWriter" /> that writes text XML.</summary>
       </Docs>
@@ -958,11 +944,6 @@ binarywriter.WriteEndAttribute();
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteArray">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes repeated occurrences of a data type from a typed array.</summary>
       </Docs>
@@ -2528,11 +2509,6 @@ binarywriter.WriteEndAttribute();
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteAttributeString">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes an attribute qualified name and value.</summary>
       </Docs>
@@ -2716,11 +2692,6 @@ An <see cref="T:System.Xml.XmlDictionaryWriter" /> asynchronous method was calle
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteElementString">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes an element with a text content.</summary>
       </Docs>
@@ -2842,11 +2813,6 @@ An <see cref="T:System.Xml.XmlDictionaryWriter" /> asynchronous method was calle
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteNode">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes the current XML node from a given <see cref="T:System.Xml.XmlDictionaryReader" /> or <see langword="XmlReader" />.</summary>
       </Docs>
@@ -3018,11 +2984,6 @@ An <see cref="T:System.Xml.XmlDictionaryWriter" /> asynchronous method was calle
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteStartAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>When overridden in a derived class, writes the start of an attribute.</summary>
       </Docs>
@@ -3140,11 +3101,6 @@ An <see cref="T:System.Xml.XmlDictionaryWriter" /> asynchronous method was calle
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteStartElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>When overridden in a derived class, writes the specified start tag.</summary>
       </Docs>
@@ -3365,11 +3321,6 @@ An <see cref="T:System.Xml.XmlDictionaryWriter" /> asynchronous method was calle
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteValue">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes a single simple-typed value.</summary>
       </Docs>
@@ -3676,10 +3627,6 @@ An <see cref="T:System.Xml.XmlDictionaryWriter" /> asynchronous method was calle
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteXmlAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes a standard XML attribute in the current element.</summary>
         <remarks>
@@ -3803,11 +3750,6 @@ An <see cref="T:System.Xml.XmlDictionaryWriter" /> asynchronous method was calle
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteXmlnsAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
-        <AssemblyVersion>4.1.1.0</AssemblyVersion>
-        <AssemblyVersion>4.1.3.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes a namespace declaration attribute.</summary>
       </Docs>

--- a/xml/System.Xml/XmlDocument.xml
+++ b/xml/System.Xml/XmlDocument.xml
@@ -278,10 +278,6 @@ These methods could be used in an application that enables users to move books u
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.XmlDocument" /> class.</summary>
       </Docs>
@@ -567,10 +563,6 @@ The following example shows the difference between a deep and shallow clone.
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an <see cref="T:System.Xml.XmlAttribute" /> with the specified name.</summary>
       </Docs>
@@ -1163,10 +1155,6 @@ The following example creates a DocumentType node and adds it to an XML document
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an <see cref="T:System.Xml.XmlElement" />.</summary>
       </Docs>
@@ -1519,11 +1507,6 @@ The following example creates two entity reference nodes and inserts them into a
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateNavigator">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.Xml.XPath.XPathNavigator" /> object for navigating this document.</summary>
       </Docs>
@@ -1655,10 +1638,6 @@ The following example creates two entity reference nodes and inserts them into a
       </Docs>
     </Member>
     <MemberGroup MemberName="CreateNode">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an <see cref="T:System.Xml.XmlNode" />.</summary>
       </Docs>
@@ -2627,10 +2606,6 @@ The following example uses the `GetElementById` method.
       </Docs>
     </Member>
     <MemberGroup MemberName="GetElementsByTagName">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns an <see cref="T:System.Xml.XmlNodeList" /> containing a list of all descendant elements that match the specified name.</summary>
       </Docs>
@@ -3180,10 +3155,6 @@ The following example shows how to use the `IsReadOnly` property.
       </Docs>
     </Member>
     <MemberGroup MemberName="Load">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Loads the specified XML data from a <see cref="T:System.IO.Stream" />, a URL, a <see cref="T:System.IO.TextReader" />, or an <see cref="T:System.Xml.XmlReader" />.</summary>
       </Docs>
@@ -4420,10 +4391,6 @@ The example uses the file, `cd.xml`, as input.
       </Docs>
     </Member>
     <MemberGroup MemberName="Save">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Saves the XML document to the specified location.</summary>
       </Docs>
@@ -4840,11 +4807,6 @@ The following example loads XML into an `XmlDocument` object and saves it out to
       </Docs>
     </Member>
     <MemberGroup MemberName="Validate">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Validates the <see cref="T:System.Xml.XmlDocument" /> against the XML Schema Definition Language (XSD) schemas contained in the <see cref="P:System.Xml.XmlDocument.Schemas" /> property.</summary>
       </Docs>

--- a/xml/System.Xml/XmlElement.xml
+++ b/xml/System.Xml/XmlElement.xml
@@ -283,10 +283,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the attribute value for the specified attribute.</summary>
       </Docs>
@@ -414,10 +410,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetAttributeNode">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Return the specified <see cref="T:System.Xml.XmlAttribute" />.</summary>
       </Docs>
@@ -552,10 +544,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetElementsByTagName">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns an <see cref="T:System.Xml.XmlNodeList" /> containing a list of all descendant elements that match the specified name.</summary>
       </Docs>
@@ -697,10 +685,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="HasAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Determines whether the current node has the specified attribute.</summary>
       </Docs>
@@ -1677,10 +1661,6 @@ This property is a Microsoft extension to the Document Object Model (DOM).
       </Docs>
     </Member>
     <MemberGroup MemberName="RemoveAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes the specified attribute. (If the removed attribute has a default value, it is immediately replaced).</summary>
       </Docs>
@@ -1895,10 +1875,6 @@ This property is a Microsoft extension to the Document Object Model (DOM).
       </Docs>
     </Member>
     <MemberGroup MemberName="RemoveAttributeNode">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes an <see cref="T:System.Xml.XmlAttribute" />.</summary>
       </Docs>
@@ -2086,10 +2062,6 @@ This property is a Microsoft extension to the Document Object Model (DOM).
       </Docs>
     </Member>
     <MemberGroup MemberName="SetAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Sets the value of the specified attribute.</summary>
       </Docs>
@@ -2233,10 +2205,6 @@ This property is a Microsoft extension to the Document Object Model (DOM).
       </Docs>
     </Member>
     <MemberGroup MemberName="SetAttributeNode">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Adds a new <see cref="T:System.Xml.XmlAttribute" />.</summary>
       </Docs>

--- a/xml/System.Xml/XmlException.xml
+++ b/xml/System.Xml/XmlException.xml
@@ -64,13 +64,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see langword="XmlException" /> class.</summary>
       </Docs>

--- a/xml/System.Xml/XmlImplementation.xml
+++ b/xml/System.Xml/XmlImplementation.xml
@@ -79,10 +79,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.XmlImplementation" /> class.</summary>
       </Docs>

--- a/xml/System.Xml/XmlNameTable.xml
+++ b/xml/System.Xml/XmlNameTable.xml
@@ -118,12 +118,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Add">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>When overridden in a derived class, atomizes the specified string and adds it to the <see langword="XmlNameTable" />.</summary>
         <remarks>
@@ -266,12 +260,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="Get">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>When overridden in a derived class, gets the atomized string.</summary>
         <remarks>

--- a/xml/System.Xml/XmlNamedNodeMap.xml
+++ b/xml/System.Xml/XmlNamedNodeMap.xml
@@ -210,10 +210,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetNamedItem">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Retrieves the specified <see cref="T:System.Xml.XmlNode" /> from the collection of nodes in the <see cref="T:System.Xml.XmlNamedNodeMap" />.</summary>
       </Docs>
@@ -410,10 +406,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="RemoveNamedItem">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Removes the specified node from the <see langword="XmlNamedNodeMap" />.</summary>
       </Docs>

--- a/xml/System.Xml/XmlNode.xml
+++ b/xml/System.Xml/XmlNode.xml
@@ -1401,10 +1401,6 @@ d.</elem>
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.XmlDocument</AssemblyName>
-        <AssemblyVersion>4.0.1.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the specified child element.</summary>
       </Docs>
@@ -2849,11 +2845,6 @@ d.</elem>
       </Docs>
     </Member>
     <MemberGroup MemberName="SelectNodes">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Selects a list of nodes matching the XPath expression.</summary>
         <remarks>
@@ -3105,11 +3096,6 @@ nodeList = root.SelectNodes("//ab:book[contains(ab:title,""'Emma'"")]", nsmgr)
       </Docs>
     </Member>
     <MemberGroup MemberName="SelectSingleNode">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Selects the first <see langword="XmlNode" /> that matches the XPath expression.</summary>
         <remarks>

--- a/xml/System.Xml/XmlNodeReader.xml
+++ b/xml/System.Xml/XmlNodeReader.xml
@@ -538,11 +538,6 @@ Output:
       </Docs>
     </Member>
     <MemberGroup MemberName="GetAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the value of an attribute.</summary>
       </Docs>
@@ -1156,11 +1151,6 @@ String dt4 = reader.GetAttribute("dt",http://www.w3.org/2000/xmlns/);
       </Docs>
     </Member>
     <MemberGroup MemberName="MoveToAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Moves to the specified attribute.</summary>
       </Docs>

--- a/xml/System.Xml/XmlParserContext.xml
+++ b/xml/System.Xml/XmlParserContext.xml
@@ -68,13 +68,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see langword="XmlParserContext" /> class with the specified values.</summary>
       </Docs>

--- a/xml/System.Xml/XmlQualifiedName.xml
+++ b/xml/System.Xml/XmlQualifiedName.xml
@@ -72,13 +72,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.XmlQualifiedName" /> class.</summary>
       </Docs>
@@ -616,13 +609,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="ToString">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Returns the string value of the <see cref="T:System.Xml.XmlQualifiedName" />.</summary>
       </Docs>

--- a/xml/System.Xml/XmlReader.xml
+++ b/xml/System.Xml/XmlReader.xml
@@ -728,12 +728,6 @@ The following example code shows how to use the asynchronous API to parse XML.
       </Docs>
     </Member>
     <MemberGroup MemberName="Create">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.Xml.XmlReader" /> instance.</summary>
         <remarks>
@@ -1886,13 +1880,6 @@ This means that the <xref:System.Xml.XmlReader> can access any locations that do
       </Docs>
     </Member>
     <MemberGroup MemberName="Dispose">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Releases the resources used by the <see cref="T:System.Xml.XmlReader" /> class.</summary>
@@ -2039,13 +2026,6 @@ This means that the <xref:System.Xml.XmlReader> can access any locations that do
       </Docs>
     </Member>
     <MemberGroup MemberName="GetAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>When overridden in a derived class, gets the value of an attribute.</summary>
@@ -2755,13 +2735,6 @@ public class Sample
       </Docs>
     </Member>
     <MemberGroup MemberName="IsStartElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Tests if the current content node is a start tag.</summary>
@@ -2964,13 +2937,6 @@ public class Sample
       </Docs>
     </Member>
     <MemberGroup MemberName="Item">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>When overridden in a derived class, gets the value of the attribute.</summary>
@@ -3322,13 +3288,6 @@ public class Sample
       </Docs>
     </Member>
     <MemberGroup MemberName="MoveToAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>When overridden in a derived class, moves to the specified attribute.</summary>
@@ -5713,13 +5672,6 @@ An <see cref="T:System.Xml.XmlReader" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadElementContentAs">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Reads the current element and returns the contents as an object of the type specified.</summary>
@@ -6260,13 +6212,6 @@ An <see cref="T:System.Xml.XmlReader" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadElementContentAsBoolean">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Reads the current element value as a <see cref="T:System.Boolean" /> object.</summary>
@@ -6411,11 +6356,6 @@ An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadElementContentAsDateTime">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Reads the current element and returns the contents as a <see cref="T:System.DateTime" /> object.</summary>
@@ -6574,13 +6514,6 @@ An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadElementContentAsDecimal">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Reads the current element value as a <see cref="T:System.Decimal" /> object.</summary>
@@ -6725,13 +6658,6 @@ An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadElementContentAsDouble">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Reads the current element and returns the contents as a double-precision floating-point number.</summary>
@@ -6888,13 +6814,6 @@ An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadElementContentAsFloat">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Reads the current element value as a single-precision floating-point number.</summary>
@@ -7039,13 +6958,6 @@ An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadElementContentAsInt">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Reads the current element and returns the contents as a 32-bit signed integer.</summary>
@@ -7189,13 +7101,6 @@ An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadElementContentAsLong">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Reads the current element and returns the contents as a 64-bit signed integer.</summary>
@@ -7352,13 +7257,6 @@ An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadElementContentAsObject">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Reads the current element and returns the contents as an <see cref="T:System.Object" />.</summary>
@@ -7584,13 +7482,6 @@ An <see cref="T:System.Xml.XmlReader" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadElementContentAsString">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Reads the current element and returns the contents as a <see cref="T:System.String" /> object.</summary>
@@ -7818,11 +7709,6 @@ An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadElementString">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">
         An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."
@@ -8383,13 +8269,6 @@ An <see cref="T:System.Xml.XmlReader" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadStartElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Checks that the current node is an element and advances the reader to the next node.</summary>
@@ -8801,13 +8680,6 @@ An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadToDescendant">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Advances the <see cref="T:System.Xml.XmlReader" /> to the next matching descendant element.</summary>
@@ -8934,13 +8806,6 @@ An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadToFollowing">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Reads until the named element is found.</summary>
@@ -9097,13 +8962,6 @@ reader.ReadToFollowing("item", "urn:1");
       </Docs>
     </Member>
     <MemberGroup MemberName="ReadToNextSibling">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlReader" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Advances the <see langword="XmlReader" /> to the next matching sibling element.</summary>

--- a/xml/System.Xml/XmlReaderSettings.xml
+++ b/xml/System.Xml/XmlReaderSettings.xml
@@ -96,13 +96,6 @@ The following example creates an <xref:System.Xml.XmlReader> that uses an <xref:
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.XmlReaderSettings" /> class.</summary>
       </Docs>

--- a/xml/System.Xml/XmlSecureResolver.xml
+++ b/xml/System.Xml/XmlSecureResolver.xml
@@ -59,11 +59,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.XmlSecureResolver" /> class.</summary>
         <remarks>To be added.</remarks>

--- a/xml/System.Xml/XmlTextReader.xml
+++ b/xml/System.Xml/XmlTextReader.xml
@@ -122,11 +122,6 @@ The following are things to consider when using the <xref:System.Xml.XmlTextRead
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see cref="T:System.Xml.XmlTextReader" />.</summary>
         <remarks>
@@ -1715,11 +1710,6 @@ XmlTextReader reader = new XmlTextReader(s);
       </Docs>
     </Member>
     <MemberGroup MemberName="GetAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the value of an attribute.</summary>
         <remarks>
@@ -2642,11 +2632,6 @@ abc<tag/>
       </Docs>
     </Member>
     <MemberGroup MemberName="MoveToAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Moves to the specified attribute.</summary>
         <remarks>

--- a/xml/System.Xml/XmlTextWriter.xml
+++ b/xml/System.Xml/XmlTextWriter.xml
@@ -167,11 +167,6 @@ The following items are things to consider when working with the <xref:System.Xm
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates an instance of the <see langword="XmlTextWriter" /> class.</summary>
         <remarks>
@@ -2063,11 +2058,6 @@ writer.WriteStartElement("root");
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteRaw">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes raw markup manually.</summary>
         <remarks>
@@ -2303,11 +2293,6 @@ writer.WriteStartElement("root");
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteStartDocument">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Writes the XML declaration with the version "1.0".</summary>
         <remarks>

--- a/xml/System.Xml/XmlValidatingReader.xml
+++ b/xml/System.Xml/XmlValidatingReader.xml
@@ -75,11 +75,6 @@
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Initializes a new instance of the <see langword="XmlValidatingReader" /> class.</summary>
       </Docs>
@@ -634,11 +629,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="GetAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Gets the value of an attribute.</summary>
       </Docs>
@@ -1171,11 +1161,6 @@
       </Docs>
     </Member>
     <MemberGroup MemberName="MoveToAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml</AssemblyName>
-        <AssemblyVersion>2.0.5.0</AssemblyVersion>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Moves to the specified attribute.</summary>
       </Docs>

--- a/xml/System.Xml/XmlWriter.xml
+++ b/xml/System.Xml/XmlWriter.xml
@@ -327,12 +327,6 @@ An <see cref="T:System.Xml.XmlWriter" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="Create">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <summary>Creates a new <see cref="T:System.Xml.XmlWriter" /> instance.</summary>
         <remarks>
@@ -1108,13 +1102,6 @@ An <see cref="T:System.Xml.XmlWriter" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="Dispose">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlWriter" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Releases the resources used by the <see cref="T:System.Xml.XmlWriter" /> class.</summary>
@@ -1675,12 +1662,6 @@ An <see cref="T:System.Xml.XmlWriter" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteAttributeString">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlWriter" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>When overridden in a derived class, writes an attribute with the specified value.</summary>
@@ -3046,12 +3027,6 @@ An <see cref="T:System.Xml.XmlWriter" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteElementString">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlWriter" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Writes an element containing a string value.</summary>
@@ -4247,12 +4222,6 @@ An <see cref="T:System.Xml.XmlWriter" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteNode">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlWriter" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Copies everything from the source object to the current writer instance.</summary>
@@ -4468,12 +4437,6 @@ while (!reader.EOF){
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteNodeAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlWriter" /> asynchronous method was called without setting the <see cref="P:System.Xml.XmlWriterSettings.Async" /> flag to <see langword="true" />. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "Set XmlWriterSettings.Async to true if you want to use Async Methods."</exception>
         <summary>Asynchronously copies everything from the source object to the current writer instance.</summary>
@@ -4955,12 +4918,6 @@ An <see cref="T:System.Xml.XmlWriter" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteRaw">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlWriter" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>When overridden in a derived class, writes raw markup manually.</summary>
@@ -5114,12 +5071,6 @@ An <see cref="T:System.Xml.XmlWriter" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteRawAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlWriter" /> asynchronous method was called without setting the <see cref="P:System.Xml.XmlWriterSettings.Async" /> flag to <see langword="true" />. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "Set XmlWriterSettings.Async to true if you want to use Async Methods."</exception>
         <summary>Asynchronously writes raw markup manually.</summary>
@@ -5264,12 +5215,6 @@ An <see cref="T:System.Xml.XmlWriter" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteStartAttribute">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlWriter" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>When overridden in a derived class, writes the start of an attribute.</summary>
@@ -5570,12 +5515,6 @@ An <see cref="T:System.Xml.XmlWriter" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteStartDocument">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlWriter" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>When overridden in a derived class, writes the XML declaration.</summary>
@@ -5717,12 +5656,6 @@ An <see cref="T:System.Xml.XmlWriter" /> method was called before a previous asy
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteStartDocumentAsync">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlWriter" /> asynchronous method was called without setting the <see cref="P:System.Xml.XmlWriterSettings.Async" /> flag to <see langword="true" />. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "Set XmlWriterSettings.Async to true if you want to use Async Methods."</exception>
         <summary>Asynchronously writes the XML declaration.</summary>
@@ -5860,12 +5793,6 @@ An <see cref="T:System.Xml.XmlWriter" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteStartElement">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlWriter" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>When overridden in a derived class, writes the specified start tag.</summary>
@@ -6521,12 +6448,6 @@ An <see cref="T:System.Xml.XmlWriter" /> asynchronous method was called without 
       </Docs>
     </Member>
     <MemberGroup MemberName="WriteValue">
-      <AssemblyInfo>
-        <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.0.10.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-      </AssemblyInfo>
       <Docs>
         <exception cref="T:System.InvalidOperationException">An <see cref="T:System.Xml.XmlWriter" /> method was called before a previous asynchronous operation finished. In this case, <see cref="T:System.InvalidOperationException" /> is thrown with the message "An asynchronous operation is already in progress."</exception>
         <summary>Writes a single simple-typed value.</summary>


### PR DESCRIPTION
Contributes to #12626.