### PR TITLE
Reword some regex safety warnings

### DIFF
--- a/xml/System.Text.RegularExpressions/Regex.xml
+++ b/xml/System.Text.RegularExpressions/Regex.xml
@@ -199,9 +199,6 @@
 
 ## Remarks
 
-> [!WARNING]
-> When using <xref:System.Text.RegularExpressions> to process untrusted input, pass a [time-out value](/dotnet/standard/base-types/best-practices-regex#use-time-out-values) to prevent malicious users from causing a [denial-of-service attack](https://www.cisa.gov/news-events/news/understanding-denial-service-attacks). A time-out value specifies how long a pattern-matching method should try to find a match before it times out.
-
  The `pattern` parameter consists of regular expression language elements that symbolically describe the string to match. For more information about regular expressions, see the [.NET Regular Expressions](/dotnet/standard/base-types/regular-expressions) and [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference) topics.
 
  Calling the <xref:System.Text.RegularExpressions.Regex.%23ctor(System.String)> constructor is equivalent to calling the <xref:System.Text.RegularExpressions.Regex.%23ctor(System.String,System.Text.RegularExpressions.RegexOptions)> constructor with a value of <xref:System.Text.RegularExpressions.RegexOptions.None> for the `options` argument.
@@ -346,9 +343,6 @@
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
-
-> [!WARNING]
-> When using <xref:System.Text.RegularExpressions> to process untrusted input, pass a [time-out value](/dotnet/standard/base-types/best-practices-regex#use-time-out-values) to prevent malicious users from causing a [denial-of-service attack](https://www.cisa.gov/news-events/news/understanding-denial-service-attacks). A time-out value specifies how long a pattern-matching method should try to find a match before it times out.
 
  The `pattern` parameter consists of regular expression language elements that symbolically describe the string to match. For more information about regular expressions, see the [.NET Regular Expressions](/dotnet/standard/base-types/regular-expressions) and [Regular Expression Language - Quick Reference](/dotnet/standard/base-types/regular-expression-language-quick-reference) topics.
 


### PR DESCRIPTION
I'm updating regex docs across the various docs repos. This is one part of that update.

Changes:
- Remove misleading guidance that timeout values are appropriate ways to guard against _all_ hostile values.
- Consolidate the warnings to the Regex type rather than just two specific constructors.
- Update external link from CISA to OWASP. The CISA guidance is primarily DDoS-related, which isn't quite relevant to the discussion here. OWASP's discussion is geared specifically toward ReDoS, which is on point.

Related PRs:
- https://github.com/dotnet/docs-desktop/pull/2250
- https://github.com/dotnet/docs/pull/54621
- https://github.com/dotnet/dotnet-api-docs/pull/12848 (this one)
- https://github.com/dotnet/runtime/pull/130271