### PR TITLE
Allow synchronization action for PRs in disallow-edits policy

### DIFF
--- a/.github/policies/disallow-edits.yml
+++ b/.github/policies/disallow-edits.yml
@@ -9,7 +9,7 @@ configuration:
         if:
           - payloadType: Pull_Request
           - isAction:
-              action: Opened
+              action: Opened, Synchronize
           - targetsBranch:
               branch: main
           - or:

--- a/.github/policies/disallow-edits.yml
+++ b/.github/policies/disallow-edits.yml
@@ -9,9 +9,9 @@ configuration:
         if:
           - payloadType: Pull_Request
           - isAction:
-              - or:
-                  action: Opened
-                  action: Synchronize
+              or:
+                - action: Opened
+                - action: Synchronize
           - targetsBranch:
               branch: main
           - or:

--- a/.github/policies/disallow-edits.yml
+++ b/.github/policies/disallow-edits.yml
@@ -9,7 +9,9 @@ configuration:
         if:
           - payloadType: Pull_Request
           - isAction:
-              action: Opened, Synchronize
+              - or:
+                  action: Opened
+                  action: Synchronize
           - targetsBranch:
               branch: main
           - or:

--- a/.github/policies/disallow-edits.yml
+++ b/.github/policies/disallow-edits.yml
@@ -8,10 +8,11 @@ configuration:
       - description: Close PRs that modify files whose "source of truth" is not in this repo.
         if:
           - payloadType: Pull_Request
-          - isAction:
-              or:
-                - action: Opened
-                - action: Synchronize
+          - or:
+              - isAction:
+                  action: Opened
+              - isAction:
+                  action: Synchronize
           - targetsBranch:
               branch: main
           - or:


### PR DESCRIPTION
Policy should fire if affected file is edited in PR branch after the PR is opened.