### PR TITLE
Clarify OutputCache intent and limitations for classic ASP.Net.

### DIFF
--- a/xml/System.Web.Caching/OutputCache.xml
+++ b/xml/System.Web.Caching/OutputCache.xml
@@ -18,8 +18,11 @@
     <remarks>
       <format type="text/markdown"><![CDATA[  
   
-## Remarks  
- Output caching stores the generated output of pages, controls, and HTTP responses in memory. Output caching enables you to cache different versions of content depending on the query string and on form-post parameters to a page, on browser type, or on the language of the user. You can configure ASP.NET to cache an output-cache entry for a specific period. You can also configure ASP.NET to evict a cache entry automatically based on an external event such as changes in the database that the cache depends on.  
+## Remarks
+ Output caching stores the generated output of pages, controls, and HTTP responses in memory. Output caching enables you to cache alternate representations of content depending on the query string and form-post parameters to a page, on browser type, or on the language of the user. You can configure ASP.NET to cache an output-cache entry for a specific period. You can also configure ASP.NET to evict a cache entry automatically based on an external event such as changes in the database that the cache depends on.
+
+> [!IMPORTANT]
+> Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.
   
  The <xref:System.Web.Caching.OutputCache> class enables you to extend output caching. For example, you can configure one or more custom output-cache providers that target other storage devices such as local or remote disks, databases, cloud storage, and distributed cache engines.  
   

--- a/xml/System.Web.Configuration/OutputCacheProfile.xml
+++ b/xml/System.Web.Configuration/OutputCacheProfile.xml
@@ -20,6 +20,10 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
+
+> [!IMPORTANT]
+> Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.
+
  The <xref:System.Web.Configuration.OutputCacheProfile> class provides a way to programmatically access and modify the `add` element of the `outputCacheProfiles` section in the `caching` section of a configuration file.
 
  The <xref:System.Web.Configuration.OutputCacheProfile> object centralizes frequently used configuration settings such as dependencies, cache location, and cache expiration time, eliminating the need to specify them on every page.

--- a/xml/System.Web.Configuration/OutputCacheSection.xml
+++ b/xml/System.Web.Configuration/OutputCacheSection.xml
@@ -20,6 +20,10 @@
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
+
+> [!IMPORTANT]
+> Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.
+
  The <xref:System.Web.Configuration.OutputCacheSection> class allows you to programmatically access and modify the `OutputCache` section.
 
  ]]></format>

--- a/xml/System.Web.UI/OutputCacheParameters.xml
+++ b/xml/System.Web.UI/OutputCacheParameters.xml
@@ -20,6 +20,10 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+  
+> [!IMPORTANT]
+> Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.
+  
  The <xref:System.Web.UI.OutputCacheParameters> class is not used by ASP.NET page or control developers. It provides a data structure used to store cache settings parsed from an [@ OutputCache](https://learn.microsoft.com/previous-versions/dotnet/netframework-4.0/hdxfb6cy(v=vs.100)) page directive by ASP.NET page and control parsers such as <xref:System.Web.UI.PageParser> and <xref:System.Web.UI.TemplateControlParser>. The <xref:System.Web.UI.OutputCacheParameters> object is used with the <xref:System.Web.UI.Page.InitOutputCache%2A?displayProperty=nameWithType> method to initialize the output cache for a page and its contents at run time.  
   
  ]]></format>

--- a/xml/System.Web.UI/PartialCachingAttribute.xml
+++ b/xml/System.Web.UI/PartialCachingAttribute.xml
@@ -27,6 +27,10 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+  
+> [!IMPORTANT]
+> Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.
+  
  The <xref:System.Web.UI.PartialCachingAttribute> attribute class marks user controls (.ascx files) that support fragment caching, and encapsulates the cache settings that ASP.NET uses when caching the control. Page and controls developers use the <xref:System.Web.UI.PartialCachingAttribute> attribute to enable output caching for a user control in a code-behind file.  
   
  Using the <xref:System.Web.UI.PartialCachingAttribute> is one of several ways you can enable output caching. The following list describes methods you can use to enable output caching.  

--- a/xml/System.Web/HttpCachePolicy.xml
+++ b/xml/System.Web/HttpCachePolicy.xml
@@ -1345,6 +1345,10 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+  
+> [!IMPORTANT]
+> Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.
+  
  <xref:System.Web.HttpCachePolicy.SetVaryByCustom%2A> is introduced in the .NET Framework version 3.5.  For more information, see [Versions and Dependencies](/dotnet/framework/migration-guide/versions-and-dependencies).  
   
    

--- a/xml/System.Web/HttpCachePolicy.xml
+++ b/xml/System.Web/HttpCachePolicy.xml
@@ -1349,7 +1349,7 @@
 > [!IMPORTANT]
 > Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.
   
- <xref:System.Web.HttpCachePolicy.SetVaryByCustom%2A> is introduced in the .NET Framework version 3.5.  For more information, see [Versions and Dependencies](/dotnet/framework/migration-guide/versions-and-dependencies).  
+ <xref:System.Web.HttpCachePolicy.SetVaryByCustom> was introduced in .NET Framework version 3.5.  For more information, see [Versions and Dependencies](/dotnet/framework/migration-guide/versions-and-dependencies).  
   
    
   

--- a/xml/System.Web/HttpCacheVaryByContentEncodings.xml
+++ b/xml/System.Web/HttpCacheVaryByContentEncodings.xml
@@ -20,6 +20,10 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+  
+> [!IMPORTANT]
+> Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.
+  
  The <xref:System.Web.HttpCachePolicy.VaryByContentEncodings%2A> property is used to specify whether dynamically compressed responses are cached. Caching dynamically compressed responses means that the cost of compression is incurred only one time, during the first request for the resource (or after an application restart) and when the cache item expires.  
   
  The <xref:System.Web.HttpCachePolicy.VaryByContentEncodings%2A> property of the <xref:System.Web.HttpCachePolicy> class identifies which request header parameters ASP.NET uses to uniquely identify a variation of the response if there are multiple cached responses for a resource. This is useful when a response depends on a set of client inputs, such as headers, parameters, or content encodings.  

--- a/xml/System.Web/HttpCacheVaryByContentEncodings.xml
+++ b/xml/System.Web/HttpCacheVaryByContentEncodings.xml
@@ -24,7 +24,7 @@
 > [!IMPORTANT]
 > Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.
   
- The <xref:System.Web.HttpCachePolicy.VaryByContentEncodings%2A> property is used to specify whether dynamically compressed responses are cached. Caching dynamically compressed responses means that the cost of compression is incurred only one time, during the first request for the resource (or after an application restart) and when the cache item expires.  
+The <xref:System.Web.HttpCachePolicy.VaryByContentEncodings> property is used to specify whether dynamically compressed responses are cached. Caching dynamically compressed responses means that the cost of compression is incurred only one time, during the first request for the resource (or after an application restart) and when the cache item expires.  
   
  The <xref:System.Web.HttpCachePolicy.VaryByContentEncodings%2A> property of the <xref:System.Web.HttpCachePolicy> class identifies which request header parameters ASP.NET uses to uniquely identify a variation of the response if there are multiple cached responses for a resource. This is useful when a response depends on a set of client inputs, such as headers, parameters, or content encodings.  
   

--- a/xml/System.Web/HttpCacheVaryByHeaders.xml
+++ b/xml/System.Web/HttpCacheVaryByHeaders.xml
@@ -21,7 +21,7 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Web.HttpCachePolicy.VaryByHeaders%2A> property identifies which request headers ASP.NET uses to uniquely identify a variation of the response when there are multiple cached responses for a resource. This is useful when a response depends on a set of request headers. In this way, `VaryByHeaders` lets the output cache store and serve the appropriate representation of a resource for a given request.  
+ The <xref:System.Web.HttpCachePolicy.VaryByHeaders> property identifies which request headers ASP.NET uses to uniquely identify a variation of the response when there are multiple cached responses for a resource. This is useful when a response depends on a set of request headers. In this way, `VaryByHeaders` lets the output cache store and serve the appropriate representation of a resource for a given request.  
   
 > [!IMPORTANT]
 > Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.

--- a/xml/System.Web/HttpCacheVaryByHeaders.xml
+++ b/xml/System.Web/HttpCacheVaryByHeaders.xml
@@ -21,7 +21,10 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Web.HttpCachePolicy.VaryByHeaders%2A> property identifies which request header parameters ASP.NET uses to uniquely identify a variation of the response when there are multiple cached responses for a resource. This is useful when a response depends on a set of client inputs, such as headers or parameters.  
+ The <xref:System.Web.HttpCachePolicy.VaryByHeaders%2A> property identifies which request headers ASP.NET uses to uniquely identify a variation of the response when there are multiple cached responses for a resource. This is useful when a response depends on a set of request headers. In this way, `VaryByHeaders` lets the output cache store and serve the appropriate representation of a resource for a given request.  
+  
+> [!IMPORTANT]
+> Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.
   
  The <xref:System.Web.HttpCacheVaryByHeaders> is not directly related to HTTP cache-control headers, but helps ensure that a client or proxy varies by the specified headers. For more information about `VaryByHeaders`, see RFC 2616: Hypertext Transfer Protocol -- HTTP/1.1, available on the [World Wide Web Consortium (W3C) Web site](https://go.microsoft.com/fwlink/?linkid=37125). See section 14, "Header Field Definitions", for complete details.  
   

--- a/xml/System.Web/HttpCacheVaryByParams.xml
+++ b/xml/System.Web/HttpCacheVaryByParams.xml
@@ -21,7 +21,10 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Web.HttpCachePolicy.VaryByParams%2A> property identifies which HTTP `Get` or `Post` parameters ASP.NET uses to uniquely identify a variation of the response when there are multiple cached responses for a resource. This is useful when a response depends on a set of client inputs, such as headers or parameters.  
+ The <xref:System.Web.HttpCachePolicy.VaryByParams%2A> property identifies which HTTP `GET` query string or `POST` form parameters ASP.NET uses to uniquely identify a variation of the response when there are multiple cached responses for a resource. This is useful when a response depends on a set of client inputs, such as query string values or form fields. In this way, `VaryByParams` lets the output cache store and serve the appropriate representation of a resource for a given request.  
+  
+> [!IMPORTANT]
+> Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.
   
  The <xref:System.Web.HttpCacheVaryByParams> is not directly related to HTTP cache-control headers, but helps ensure that a client or proxy varies by the specified parameters. For more information about `VaryByParams`, see RFC 2616: Hypertext Transfer Protocol -- HTTP/1.1, available on the [World Wide Web Consortium (W3C) Web](https://go.microsoft.com/fwlink/?linkid=37125) site. See section 14, "Header Field Definitions", for complete details.  
   

--- a/xml/System.Web/HttpCacheVaryByParams.xml
+++ b/xml/System.Web/HttpCacheVaryByParams.xml
@@ -21,7 +21,7 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Web.HttpCachePolicy.VaryByParams%2A> property identifies which HTTP `GET` query string or `POST` form parameters ASP.NET uses to uniquely identify a variation of the response when there are multiple cached responses for a resource. This is useful when a response depends on a set of client inputs, such as query string values or form fields. In this way, `VaryByParams` lets the output cache store and serve the appropriate representation of a resource for a given request.  
+ The <xref:System.Web.HttpCachePolicy.VaryByParams> property identifies which HTTP `GET` query string or `POST` form parameters ASP.NET uses to uniquely identify a variation of the response when there are multiple cached responses for a resource. This is useful when a response depends on a set of client inputs, such as query string values or form fields. In this way, `VaryByParams` lets the output cache store and serve the appropriate representation of a resource for a given request.  
   
 > [!IMPORTANT]
 > Output caching is a performance optimization feature. The `VaryBy` settings are designed to cache alternate representations of a resource based on request characteristics; they are not designed to isolate audiences or classes of content. Do not rely on cache variation to separate personalized, tenant-specific, authorization-dependent, or otherwise sensitive responses. Enforce any required isolation between request contexts independently of the cache configuration.


### PR DESCRIPTION
This pull request updates the XML documentation for several ASP.NET output caching-related types to clarify the intended use and limitations of the `VaryBy` settings. The main focus is to add prominent warnings that output caching and its variation mechanisms are meant for performance optimization and not for isolating personalized or sensitive content. Additional clarifications are also made to some remarks for better accuracy.

### Documentation improvements and warnings

**Security and usage warnings:**
* Added a new `[!IMPORTANT]` note to the remarks of all affected types, explaining that output caching and `VaryBy` settings are for performance optimization only, and should not be relied upon to isolate personalized, tenant-specific, authorization-dependent, or sensitive responses. Explicit isolation must be enforced independently of cache configuration. [[1]](diffhunk://#diff-185edfe0123418a837b8daa4c82201fe6977d211bbb3d4be2561a45f146f6aebL22-R25) [[2]](diffhunk://#diff-a8b5f45e901e0ee45c4cf3bae9f30b1a272ef8cf863f3080bf2c61ed7e9cbfdcR23-R26) [[3]](diffhunk://#diff-bccd6dd546d3524756fec860b53b1d1a2878fb43b49444357d06efbae79f294cR23-R26) [[4]](diffhunk://#diff-e1a1896369a265d83e2b7bbf51192b4d187dee0d1c8aa6d0afcb38c8cdcd66b9R23-R26) [[5]](diffhunk://#diff-40ff31691a327c980317f40d78ee36d95d7ce3f22bccfb2df92c848dc3b35778R30-R33) [[6]](diffhunk://#diff-16943ba985959287049047f6fbde2d3badcb9e46d647c0d8c7531bf122187e97R1348-R1351) [[7]](diffhunk://#diff-ad81d9b358587a01fcaa1ae1a42f2f007605b2daac66f9b3abc05e0b77d62445R23-R26) [[8]](diffhunk://#diff-fd61236b87d21f4c5e02f0f56d3bf2f70c9e0a3401ce401c8ce8f805a9afcd26L24-R27) [[9]](diffhunk://#diff-3e53e6fad40862559da9f440b6da9a9b03f5ac5e839fc28fbfa091ee237e439cL24-R27)

**Clarifications to remarks:**
* Improved the explanations for how `VaryByHeaders` and `VaryByParams` work, specifying that they store and serve the appropriate representation of a resource for a given request, and clarifying the types of request data used for variation. [[1]](diffhunk://#diff-fd61236b87d21f4c5e02f0f56d3bf2f70c9e0a3401ce401c8ce8f805a9afcd26L24-R27) [[2]](diffhunk://#diff-3e53e6fad40862559da9f440b6da9a9b03f5ac5e839fc28fbfa091ee237e439cL24-R27)
* Updated language in the `OutputCache.xml` remarks to use "alternate representations" instead of "different versions" for greater precision.

These changes help prevent misuse of output caching for security or isolation, and make the documentation clearer for developers.