### PR TITLE
Clarify behavior for suppressing warnings against inner namespaces.

### DIFF
--- a/xml/System.Diagnostics.CodeAnalysis/SuppressMessageAttribute.xml
+++ b/xml/System.Diagnostics.CodeAnalysis/SuppressMessageAttribute.xml
@@ -421,7 +421,7 @@ The <xref:System.Diagnostics.CodeAnalysis.SuppressMessageAttribute.Scope> proper
 | - | - |
 | `"member"` | Suppresses warnings against a member. |
 | `"module"` | Suppresses warnings against an assembly. It is a global suppression that applies to the entire project. |
-| `"namespace"` | This scope suppresses warnings against the namespace itself. It does not suppress warnings against types within the namespace nor inner namespaces. |
+| `"namespace"` | This scope suppresses warnings against the namespace itself. It does not suppress warnings against types within the namespace or inner namespaces. |
 | `"namespaceanddescendants"` | Suppresses warnings in a namespace and all its descendant symbols. This value is ignored by [legacy code analysis](/visualstudio/code-quality/static-code-analysis-for-managed-code-overview). |
 | `"type"` | Suppresses warnings against a type. |
 

--- a/xml/System.Diagnostics.CodeAnalysis/SuppressMessageAttribute.xml
+++ b/xml/System.Diagnostics.CodeAnalysis/SuppressMessageAttribute.xml
@@ -421,7 +421,7 @@ The <xref:System.Diagnostics.CodeAnalysis.SuppressMessageAttribute.Scope> proper
 | - | - |
 | `"member"` | Suppresses warnings against a member. |
 | `"module"` | Suppresses warnings against an assembly. It is a global suppression that applies to the entire project. |
-| `"namespace"` | This scope suppresses warnings against the namespace itself. It does not suppress warnings against types within the namespace. |
+| `"namespace"` | This scope suppresses warnings against the namespace itself. It does not suppress warnings against types within the namespace nor inner namespaces. |
 | `"namespaceanddescendants"` | Suppresses warnings in a namespace and all its descendant symbols. This value is ignored by [legacy code analysis](/visualstudio/code-quality/static-code-analysis-for-managed-code-overview). |
 | `"type"` | Suppresses warnings against a type. |
 


### PR DESCRIPTION
## Summary

Suppressing warnings against a namespace does not suppress warnings against inner namespaces, i.e. namespaces that share all namespace segments with suppressed namespace. I found this behavior to be unintuitive and wanted to update the documentation to help other people with the same confusion.

I spent a bit of time reading over the C# language specification trying to find the best term to describe namespaces that are part of another namespace. Let me know if there are any preferred terms for them.

Inspired by dotnet/roslyn#83728

