### PR TITLE
Clarify ISerializable applies to formatters, not XmlSerializer

### DIFF
--- a/xml/System.Runtime.Serialization/ISerializable.xml
+++ b/xml/System.Runtime.Serialization/ISerializable.xml
@@ -48,12 +48,12 @@
   </TypeForwardingChain>
   <Interfaces />
   <Docs>
-    <summary>Allows an object to control its own serialization and deserialization through binary and XML serialization.</summary>
+    <summary>Allows an object to control its own serialization and deserialization during formatter-based (binary and SOAP) serialization.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[
 
 ## Remarks
- Any class that might be serialized using binary or XML serialization must be marked with the <xref:System.SerializableAttribute>. If a class needs to control its binary or XML serialization process, it can implement the <xref:System.Runtime.Serialization.ISerializable> interface. The <xref:System.Runtime.Serialization.Formatter> calls the <xref:System.Runtime.Serialization.ISerializable.GetObjectData*> at serialization time and populates the supplied <xref:System.Runtime.Serialization.SerializationInfo> with all the data required to represent the object. The <xref:System.Runtime.Serialization.Formatter> creates a <xref:System.Runtime.Serialization.SerializationInfo> with the type of the object in the graph. Objects that need to send proxies for themselves can use the <xref:System.Runtime.Serialization.SerializationInfo.FullTypeName*> and <xref:System.Runtime.Serialization.SerializationInfo.AssemblyName*> methods on <xref:System.Runtime.Serialization.SerializationInfo> to change the transmitted information.
+ Any class that might be serialized by a formatter, such as <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> or `SoapFormatter`, must be marked with the <xref:System.SerializableAttribute>. If a class needs to control this formatter-based serialization process, it can implement the <xref:System.Runtime.Serialization.ISerializable> interface. The <xref:System.Runtime.Serialization.Formatter> calls the <xref:System.Runtime.Serialization.ISerializable.GetObjectData*> at serialization time and populates the supplied <xref:System.Runtime.Serialization.SerializationInfo> with all the data required to represent the object. The <xref:System.Runtime.Serialization.Formatter> creates a <xref:System.Runtime.Serialization.SerializationInfo> with the type of the object in the graph. Objects that need to send proxies for themselves can use the <xref:System.Runtime.Serialization.SerializationInfo.FullTypeName*> and <xref:System.Runtime.Serialization.SerializationInfo.AssemblyName*> methods on <xref:System.Runtime.Serialization.SerializationInfo> to change the transmitted information.
 
  In the case of class inheritance, it is possible to serialize a class that derives from a base class that implements <xref:System.Runtime.Serialization.ISerializable>. In this case, the derived class should call the base class implementation of <xref:System.Runtime.Serialization.ISerializable.GetObjectData*> inside its implementation of <xref:System.Runtime.Serialization.ISerializable.GetObjectData*>. Otherwise, the data from the base class will not be serialized.
 
@@ -69,6 +69,9 @@
 
  For more information about serialization of classes that extend <xref:System.MarshalByRefObject>, see <xref:System.Runtime.Remoting.Messaging.RemotingSurrogateSelector>. For more information about implementing <xref:System.Runtime.Serialization.ISerializable>, see [Custom Serialization](/dotnet/standard/serialization/custom-serialization).
 
+> [!IMPORTANT]
+> This interface applies only to formatter-based serialization, such as with <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> and `SoapFormatter`. Here, *XML serialization* refers to the SOAP format produced by `SoapFormatter`, not to <xref:System.Xml.Serialization.XmlSerializer>. <xref:System.Xml.Serialization.XmlSerializer> ignores <xref:System.Runtime.Serialization.ISerializable>. To control how a type is serialized by <xref:System.Xml.Serialization.XmlSerializer>, implement <xref:System.Xml.Serialization.IXmlSerializable> instead.
+
 > [!NOTE]
 > This interface does not apply to JSON serialization using <xref:System.Text.Json?displayProperty=fullName>.
 
@@ -77,6 +80,7 @@
     <block subset="none" type="overrides">
       <para>Implement this interface to allow an object to take part in its own serialization and deserialization.</para>
     </block>
+    <altmember cref="T:System.Xml.Serialization.IXmlSerializable" />
     <related type="Article" href="/dotnet/standard/serialization/xml-and-soap-serialization">XML and SOAP Serialization</related>
     <related type="Article" href="/dotnet/standard/serialization/custom-serialization">Custom serialization</related>
   </Docs>


### PR DESCRIPTION
## Summary

The `ISerializable` reference described the interface as controlling serialization "through binary **and XML** serialization." Readers reasonably map "XML serialization" onto the `XmlSerializer` class and expect implementing `ISerializable` to change `XmlSerializer` output (see #9658). It doesn't: `ISerializable` is consumed only by the formatters (`BinaryFormatter`, and the XML/SOAP-producing `SoapFormatter`). `XmlSerializer` ignores it and uses `IXmlSerializable` instead.

This PR clarifies the terminology so the distinction is explicit:

- Reworded the summary and the first remarks paragraph to reference formatter-based (binary and SOAP) serialization instead of the ambiguous "XML serialization."
- Added an `[!IMPORTANT]` note stating the interface applies only to formatter-based serialization, clarifying that "XML" here means SOAP (not `XmlSerializer`), and directing readers to implement `IXmlSerializable` for `XmlSerializer` control. It sits alongside the existing JSON note.
- Added an `<altmember>` link to `IXmlSerializable` so it surfaces in "See also."

Changes are confined to `<Docs>` content; no signatures or auto-generated elements were touched. XML validated as well-formed.

Fixes #9658