### PR TITLE
Port missing .NET 8.0 System API docs from dotnet/runtime#88563

### DIFF
--- a/xml/System/BinaryData.xml
+++ b/xml/System/BinaryData.xml
@@ -1290,9 +1290,9 @@ No special treatment is given to the contents of the data. It is merely decoded 
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="mediaType">To be added.</param>
+        <param name="mediaType">The MIME type of this data, for example, <see cref="F:System.Net.Mime.MediaTypeNames.Application.Octet" />.</param>
         <summary>
-          <para>Creates a <see cref="T:System.BinaryData" /> instance by wrapping the same data and changed <see cref="P:System.BinaryData.MediaType" /> to <see pref="mediaType" /> value.</para>
+          <para>Creates a <see cref="T:System.BinaryData" /> instance by wrapping the same data and changed <see cref="P:System.BinaryData.MediaType" /> to <paramref name="mediaType" /> value.</para>
         </summary>
         <returns>A wrapper over the same data with specified <see cref="P:System.BinaryData.MediaType" />.</returns>
         <remarks>To be added.</remarks>

--- a/xml/System/BinaryData.xml
+++ b/xml/System/BinaryData.xml
@@ -1292,7 +1292,7 @@ No special treatment is given to the contents of the data. It is merely decoded 
       <Docs>
         <param name="mediaType">The MIME type of this data, for example, <see cref="F:System.Net.Mime.MediaTypeNames.Application.Octet" />.</param>
         <summary>
-          <para>Creates a <see cref="T:System.BinaryData" /> instance by wrapping the same data and changed <see cref="P:System.BinaryData.MediaType" /> to <paramref name="mediaType" /> value.</para>
+          <para>Creates a <see cref="T:System.BinaryData" /> instance by wrapping the same data and changing the <see cref="P:System.BinaryData.MediaType" /> to <paramref name="mediaType" />.</para>
         </summary>
         <returns>A wrapper over the same data with specified <see cref="P:System.BinaryData.MediaType" />.</returns>
         <remarks>To be added.</remarks>

--- a/xml/System/Boolean.xml
+++ b/xml/System/Boolean.xml
@@ -1586,11 +1586,12 @@ This member is an explicit interface member implementation. It can be used only 
         <Parameter Name="result" Type="System.Boolean" RefType="out" />
       </Parameters>
       <Docs>
-        <param name="s">To be added.</param>
-        <param name="provider">To be added.</param>
-        <param name="result">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="s">The string to parse.</param>
+        <param name="provider">An object that provides culture-specific formatting information about <paramref name="s" />.</param>
+        <param name="result">When this method returns, contains the result of successfully parsing <paramref name="s" />, or an undefined value on failure.</param>
+        <summary>Tries to parse a string into a value.</summary>
+        <returns>
+          <see langword="true" /> if <paramref name="s" /> was successfully parsed; otherwise, <see langword="false" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -1657,11 +1658,12 @@ This member is an explicit interface member implementation. It can be used only 
         <Parameter Name="result" Type="System.Boolean" RefType="out" />
       </Parameters>
       <Docs>
-        <param name="s">To be added.</param>
-        <param name="provider">To be added.</param>
-        <param name="result">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="s">The span of characters to parse.</param>
+        <param name="provider">An object that provides culture-specific formatting information about <paramref name="s" />.</param>
+        <param name="result">When this method returns, contains the result of successfully parsing <paramref name="s" />, or an undefined value on failure.</param>
+        <summary>Tries to parse a span of characters into a value.</summary>
+        <returns>
+          <see langword="true" /> if <paramref name="s" /> was successfully parsed; otherwise, <see langword="false" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/xml/System/ConsoleKey.xml
+++ b/xml/System/ConsoleKey.xml
@@ -3005,7 +3005,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>No key was pressed.</summary>
       </Docs>
     </Member>
     <Member MemberName="NumPad0">

--- a/xml/System/ConsoleModifiers.xml
+++ b/xml/System/ConsoleModifiers.xml
@@ -159,7 +159,7 @@
       </ReturnValue>
       <MemberValue>0</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>No modifier key.</summary>
       </Docs>
     </Member>
     <Member MemberName="Shift">

--- a/xml/System/DateTimeOffset.xml
+++ b/xml/System/DateTimeOffset.xml
@@ -5857,7 +5857,7 @@ Me.ToUtcDateTime().ToFileTime()
         <param name="utf8Destination">The span in which to write this instance's value formatted as a span of bytes.</param>
         <param name="bytesWritten">When this method returns, contains the number of bytes that were written in <paramref name="utf8Destination" />.</param>
         <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format for <paramref name="utf8Destination" />.</param>
-        <param name="formatProvider">To be added.</param>
+        <param name="formatProvider">An optional object that supplies culture-specific formatting information for <paramref name="utf8Destination" />.</param>
         <summary>Tries to format the value of the current instance as UTF-8 into the provided span of bytes.</summary>
         <returns>
           <see langword="true" /> if the formatting was successful; otherwise, <see langword="false" />.</returns>

--- a/xml/System/Enum.xml
+++ b/xml/System/Enum.xml
@@ -3493,8 +3493,8 @@ The following example demonstrates using an enumeration to represent named value
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="TEnum">To be added.</typeparam>
-        <param name="value">To be added.</param>
+        <typeparam name="TEnum">The type of the enumeration.</typeparam>
+        <param name="value">The enumeration value to format.</param>
         <param name="destination">The span into which to write the instance's value formatted as a span of characters.</param>
         <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination" />.</param>
         <param name="format">A span containing the character that represents the standard format string that defines the acceptable format of destination. This value can be empty, or "g", "d", "f", or "x".</param>

--- a/xml/System/Guid.xml
+++ b/xml/System/Guid.xml
@@ -2661,7 +2661,7 @@ The <xref:System.Guid.ParseExact*> method requires the read-only character span 
         <Parameter Name="bytesWritten" Type="System.Int32" RefType="out" />
       </Parameters>
       <Docs>
-        <param name="destination">When this method returns, the GUID as a span of bytes.</param>
+        <param name="destination">The span in which to write the GUID as a span of bytes.</param>
         <param name="bigEndian">
           <see langword="true" /> to write the bytes in big-endian byte order; <see langword="false" /> to write them in little-endian byte order.</param>
         <param name="bytesWritten">When this method returns, contains the number of bytes written into <paramref name="destination" />.</param>

--- a/xml/System/Guid.xml
+++ b/xml/System/Guid.xml
@@ -289,10 +289,13 @@
         <Parameter Name="bigEndian" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="b">To be added.</param>
-        <param name="bigEndian">To be added.</param>
-        <summary>To be added.</summary>
+        <param name="b">A 16-element read-only span containing the bytes with which to initialize the GUID.</param>
+        <param name="bigEndian">
+          <see langword="true" /> to interpret <paramref name="b" /> as big-endian; <see langword="false" /> to interpret it as little-endian.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.Guid" /> structure by using the value represented by the specified read-only span of bytes and the specified endianness.</summary>
         <remarks>To be added.</remarks>
+        <exception cref="T:System.ArgumentException">
+          <paramref name="b" /> is not 16 bytes long.</exception>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -1888,9 +1891,10 @@ The <xref:System.Guid.ParseExact*> method requires the read-only character span 
         <Parameter Name="bigEndian" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="bigEndian">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="bigEndian">
+          <see langword="true" /> to write the bytes in big-endian byte order; <see langword="false" /> to write them in little-endian byte order.</param>
+        <summary>Returns a 16-element byte array that contains the value of this instance, using the specified endianness.</summary>
+        <returns>A 16-element byte array.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -2134,11 +2138,12 @@ The <xref:System.Guid.ParseExact*> method requires the read-only character span 
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="utf8Destination">To be added.</param>
-        <param name="bytesWritten">To be added.</param>
-        <param name="format">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="utf8Destination">The span in which to write the GUID as a span of UTF-8 bytes.</param>
+        <param name="bytesWritten">When this method returns, contains the number of bytes written into <paramref name="utf8Destination" />.</param>
+        <param name="format">A read-only span containing the character representing one of the following specifiers that indicates the exact format to use when interpreting the current GUID instance: "N", "D", "B", "P", or "X".</param>
+        <summary>Tries to format the current GUID instance as UTF-8 into the provided span of bytes.</summary>
+        <returns>
+          <see langword="true" /> if the formatting operation was successful; <see langword="false" /> otherwise.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -2656,11 +2661,13 @@ The <xref:System.Guid.ParseExact*> method requires the read-only character span 
         <Parameter Name="bytesWritten" Type="System.Int32" RefType="out" />
       </Parameters>
       <Docs>
-        <param name="destination">To be added.</param>
-        <param name="bigEndian">To be added.</param>
-        <param name="bytesWritten">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="destination">When this method returns, the GUID as a span of bytes.</param>
+        <param name="bigEndian">
+          <see langword="true" /> to write the bytes in big-endian byte order; <see langword="false" /> to write them in little-endian byte order.</param>
+        <param name="bytesWritten">When this method returns, contains the number of bytes written into <paramref name="destination" />.</param>
+        <summary>Tries to write the current GUID instance into a span of bytes, using the specified endianness.</summary>
+        <returns>
+          <see langword="true" /> if the GUID is successfully written to the specified span; <see langword="false" /> otherwise.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/xml/System/MemoryExtensions.xml
+++ b/xml/System/MemoryExtensions.xml
@@ -799,7 +799,7 @@ Returns `default` when `text` is `null`.
         <param name="text">The target string.</param>
         <param name="startIndex">The index at which to begin this slice.</param>
         <summary>Creates a new <see cref="T:System.ReadOnlySpan`1" /> over a portion of the target string from a specified position to the end of the string.</summary>
-        <returns>To be added.</returns>
+        <returns>The read-only span representation of the string.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">
           <paramref name="startIndex" /> is less than 0 or greater than <paramref name="text" />.Length.</exception>
@@ -885,7 +885,7 @@ Returns `default` when `text` is `null`.
         <param name="text">The target string.</param>
         <param name="range">The range that has start and end indexes to use for slicing the string.</param>
         <summary>Creates a new <see cref="T:System.ReadOnlySpan`1" /> over a portion of a target string using the range start and end indexes.</summary>
-        <returns>To be added.</returns>
+        <returns>The read-only span representation of the string.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="text" /> is <see langword="null" />.</exception>
@@ -2532,7 +2532,7 @@ Returns `default` when `array` is `null`.
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="values">The set of values to search for.</param>
         <summary>Searches for an occurrence of any of the specified <paramref name="values" />.</summary>
@@ -2588,7 +2588,7 @@ Returns `default` when `array` is `null`.
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="values">The set of values to search for.</param>
         <summary>Searches for an occurrence of any of the specified <paramref name="values" />.</summary>
@@ -2650,11 +2650,12 @@ Returns `default` when `array` is `null`.
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="values">The set of values to search for.</param>
         <summary>Searches for an occurrence of any of the specified <paramref name="values" /> and returns <see langword="true" /> if found. If not found, returns <see langword="false" />.</summary>
-        <returns>To be added.</returns>
+        <returns>
+          <see langword="true" /> if found. If not found, returns <see langword="false" />.</returns>
         <remarks>To be added.</remarks>
         <inheritdoc cref="M:System.MemoryExtensions.ContainsAny``1(System.ReadOnlySpan{``0},System.Buffers.SearchValues{``0})" />
       </Docs>
@@ -2712,11 +2713,12 @@ Returns `default` when `array` is `null`.
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="values">The set of values to search for.</param>
         <summary>Searches for an occurrence of any of the specified <paramref name="values" /> and returns <see langword="true" /> if found. If not found, returns <see langword="false" />.</summary>
-        <returns>To be added.</returns>
+        <returns>
+          <see langword="true" /> if found. If not found, returns <see langword="false" />.</returns>
         <remarks>To be added.</remarks>
         <inheritdoc cref="M:System.MemoryExtensions.ContainsAny``1(System.ReadOnlySpan{``0},System.ReadOnlySpan{``0})" />
       </Docs>
@@ -2825,7 +2827,7 @@ Returns `default` when `array` is `null`.
         <Parameter Name="value1" Type="T" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="value0">The first value to search for.</param>
         <param name="value1">The second value to search for.</param>
@@ -2888,12 +2890,13 @@ Returns `default` when `array` is `null`.
         <Parameter Name="value1" Type="T" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="value0">The first value to search for.</param>
         <param name="value1">The second value to search for.</param>
         <summary>Searches for an occurrence of <paramref name="value0" /> or <paramref name="value1" />, and returns <see langword="true" /> if found. If not found, returns <see langword="false" />.</summary>
-        <returns>To be added.</returns>
+        <returns>
+          <see langword="true" /> if found. If not found, returns <see langword="false" />.</returns>
         <remarks>To be added.</remarks>
         <inheritdoc cref="M:System.MemoryExtensions.ContainsAny``1(System.ReadOnlySpan{``0},``0,``0)" />
       </Docs>
@@ -3006,7 +3009,7 @@ Returns `default` when `array` is `null`.
         <Parameter Name="value2" Type="T" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="value0">The first value to search for.</param>
         <param name="value1">The second value to search for.</param>
@@ -3071,7 +3074,7 @@ Returns `default` when `array` is `null`.
         <Parameter Name="value2" Type="T" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="value0">The first value to search for.</param>
         <param name="value1">The second value to search for.</param>
@@ -3197,7 +3200,7 @@ Returns `default` when `array` is `null`.
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="values">The set of values to exclude from the search.</param>
         <summary>Searches the specified span for any value other than the specified <paramref name="values" />.</summary>
@@ -3253,7 +3256,7 @@ Returns `default` when `array` is `null`.
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="values">The set of values to exclude from the search.</param>
         <summary>Searches the specified span for any value other than the specified <paramref name="values" />.</summary>
@@ -3309,7 +3312,7 @@ Returns `default` when `array` is `null`.
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="value">The value to exclude from the search.</param>
         <summary>Searches the specified span for any value other than the specified <paramref name="value" />.</summary>
@@ -3371,7 +3374,7 @@ Returns `default` when `array` is `null`.
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="values">The set of values to exclude from the search.</param>
         <summary>Searches the specified span for any value other than the specified <paramref name="values" />.</summary>
@@ -3434,7 +3437,7 @@ Returns `default` when `array` is `null`.
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="values">The set of values to exclude from the search.</param>
         <summary>Searches the specified span for any value other than the specified <paramref name="values" />.</summary>
@@ -3497,7 +3500,7 @@ Returns `default` when `array` is `null`.
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="value">The value to exclude from the search.</param>
         <summary>Searches the specified span for any value other than the specified <paramref name="value" />.</summary>
@@ -3672,7 +3675,7 @@ Returns `default` when `array` is `null`.
         <Parameter Name="value1" Type="T" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="value0">The first value to exclude from the search.</param>
         <param name="value1">The second value to exclude from the search.</param>
@@ -3735,7 +3738,7 @@ Returns `default` when `array` is `null`.
         <Parameter Name="value1" Type="T" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="value0">The first value to exclude from the search.</param>
         <param name="value1">The second value to exclude from the search.</param>
@@ -3855,7 +3858,7 @@ Returns `default` when `array` is `null`.
         <Parameter Name="value2" Type="T" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="value0">The first value to exclude from the search.</param>
         <param name="value1">The second value to exclude from the search.</param>
@@ -3920,7 +3923,7 @@ Returns `default` when `array` is `null`.
         <Parameter Name="value2" Type="T" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="value0">The first value to exclude from the search.</param>
         <param name="value1">The second value to exclude from the search.</param>
@@ -4047,7 +4050,7 @@ Returns `default` when `array` is `null`.
         <Parameter Name="highInclusive" Type="T" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="lowInclusive">The lower bound, inclusive, of the excluded range.</param>
         <param name="highInclusive">The upper bound, inclusive, of the excluded range.</param>
@@ -4110,7 +4113,7 @@ Returns `default` when `array` is `null`.
         <Parameter Name="highInclusive" Type="T" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="lowInclusive">The lower bound, inclusive, of the excluded range.</param>
         <param name="highInclusive">The upper bound, inclusive, of the excluded range.</param>
@@ -4174,7 +4177,7 @@ Returns `default` when `array` is `null`.
         <Parameter Name="highInclusive" Type="T" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="lowInclusive">The lower bound, inclusive, of the range for which to search.</param>
         <param name="highInclusive">The upper bound, inclusive, of the range for which to search.</param>
@@ -4237,12 +4240,13 @@ Returns `default` when `array` is `null`.
         <Parameter Name="highInclusive" Type="T" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="lowInclusive">The lower bound, inclusive, of the range for which to search.</param>
         <param name="highInclusive">The upper bound, inclusive, of the range for which to search.</param>
         <summary>Searches for any value in the range between <paramref name="lowInclusive" /> and <paramref name="highInclusive" />, inclusive, and returns <see langword="true" /> if found. If not found, returns <see langword="false" />.</summary>
-        <returns>To be added.</returns>
+        <returns>
+          <see langword="true" /> if found. If not found, returns <see langword="false" />.</returns>
         <remarks>To be added.</remarks>
         <inheritdoc cref="M:System.MemoryExtensions.ContainsAnyInRange``1(System.ReadOnlySpan{``0},``0,``0)" />
       </Docs>
@@ -6005,7 +6009,7 @@ Invalid sequences will be represented in the enumeration by <xref:System.Text.Ru
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="values">The set of values to search for.</param>
         <summary>Searches for the first index of any of the specified values.</summary>
@@ -6122,7 +6126,7 @@ Invalid sequences will be represented in the enumeration by <xref:System.Text.Ru
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="values">The set of values to search for.</param>
         <summary>Searches for the first index of any of the specified values.</summary>
@@ -8239,7 +8243,7 @@ Invalid sequences will be represented in the enumeration by <xref:System.Text.Ru
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="values">The set of values to search for.</param>
         <summary>Searches for the last index of any of the specified values.</summary>
@@ -8356,7 +8360,7 @@ Invalid sequences will be represented in the enumeration by <xref:System.Text.Ru
         </Parameter>
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="T">The type of the elements in the span.</typeparam>
         <param name="span">The span to search.</param>
         <param name="values">The set of values to search for.</param>
         <summary>Searches for the last index of any of the specified values.</summary>

--- a/xml/System/OperatingSystem.xml
+++ b/xml/System/OperatingSystem.xml
@@ -858,7 +858,8 @@
       <Parameters />
       <Docs>
         <summary>Indicates whether the current application is running as WASI.</summary>
-        <returns>To be added.</returns>
+        <returns>
+          <see langword="true" /> if the current application is running as WASI; <see langword="false" /> otherwise.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/xml/System/String.xml
+++ b/xml/System/String.xml
@@ -14498,11 +14498,12 @@ This member is an explicit interface member implementation. It can be used only 
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="s">To be added.</param>
-        <param name="provider">To be added.</param>
-        <param name="result">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="s">The string to parse.</param>
+        <param name="provider">An object that provides culture-specific formatting information about <paramref name="s" />.</param>
+        <param name="result">When this method returns, contains the result of successfully parsing <paramref name="s" />, or an undefined value on failure.</param>
+        <summary>Tries to parse a string into a value.</summary>
+        <returns>
+          <see langword="true" /> if <paramref name="s" /> was successfully parsed; otherwise, <see langword="false" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -14576,11 +14577,12 @@ This member is an explicit interface member implementation. It can be used only 
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="s">To be added.</param>
-        <param name="provider">To be added.</param>
-        <param name="result">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="s">The span of characters to parse.</param>
+        <param name="provider">An object that provides culture-specific formatting information about <paramref name="s" />.</param>
+        <param name="result">When this method returns, contains the result of successfully parsing <paramref name="s" />, or an undefined value on failure.</param>
+        <summary>Tries to parse a span of characters into a value.</summary>
+        <returns>
+          <see langword="true" /> if <paramref name="s" /> was successfully parsed; otherwise, <see langword="false" />.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/xml/System/TimeProvider.xml
+++ b/xml/System/TimeProvider.xml
@@ -277,7 +277,7 @@
             Gets a <see cref="T:System.DateTimeOffset" /> value that is set to the current date and time according to this <see cref="T:System.TimeProvider" />'s
             notion of time based on <see cref="M:System.TimeProvider.GetUtcNow" />, with the offset set to the <see cref="P:System.TimeProvider.LocalTimeZone" />'s offset from Coordinated Universal Time (UTC).
             </summary>
-        <returns>To be added.</returns>
+        <returns>A <see cref="T:System.DateTimeOffset" /> value that is set to the current date and time in the local time zone, according to this provider's notion of time.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -357,7 +357,7 @@
             Coordinated Universal Time (UTC) date and time and whose offset is Zero,
             all according to this <see cref="T:System.TimeProvider" />'s notion of time.
             </summary>
-        <returns>To be added.</returns>
+        <returns>A <see cref="T:System.DateTimeOffset" /> value that is set to the current Coordinated Universal Time (UTC) date and time, according to this provider's notion of time.</returns>
         <remarks>
             The default implementation returns <see cref="P:System.DateTimeOffset.UtcNow" />.
             </remarks>

--- a/xml/System/TimeSpan.xml
+++ b/xml/System/TimeSpan.xml
@@ -5579,7 +5579,7 @@ The <xref:System.TimeSpan.TotalNanoseconds> property represents whole and fracti
         <param name="utf8Destination">The span in which to write this instance's value formatted as a span of bytes.</param>
         <param name="bytesWritten">When this method returns, contains the number of bytes that were written in <paramref name="utf8Destination" />.</param>
         <param name="format">A span containing the characters that represent a standard or custom format string that defines the acceptable format for <paramref name="utf8Destination" />.</param>
-        <param name="formatProvider">To be added.</param>
+        <param name="formatProvider">An optional object that supplies culture-specific formatting information for <paramref name="utf8Destination" />.</param>
         <summary>Tries to format the value of the current instance as UTF-8 into the provided span of bytes.</summary>
         <returns>
           <see langword="true" /> if the formatting was successful; otherwise, <see langword="false" />.</returns>

--- a/xml/System/TimeZoneInfo.xml
+++ b/xml/System/TimeZoneInfo.xml
@@ -2132,7 +2132,7 @@ The following example uses the <xref:System.TimeZoneInfo.FindSystemTimeZoneById*
         <param name="skipSorting">If <see langword="true" />, The collection returned may not necessarily be sorted.</param>
         <summary>Returns a <see cref="T:System.Collections.ObjectModel.ReadOnlyCollection`1" /> containing all valid TimeZone's from the local machine.
             This method does *not* throw TimeZoneNotFoundException or InvalidTimeZoneException.</summary>
-        <returns>To be added.</returns>
+        <returns>A read-only collection of <see cref="T:System.TimeZoneInfo" /> objects.</returns>
         <remarks>By setting the skipSorting parameter to <see langword="true" />, the method will attempt to avoid sorting the returned collection.
             This option can be beneficial when the caller does not require a sorted list and aims to enhance the performance.</remarks>
       </Docs>


### PR DESCRIPTION
Fills in the remaining `To be added.` documentation placeholders for the .NET 8.0 System APIs tracked by dotnet/runtime#88563. Wording matches already-documented sibling members in each file.

46 members documented across 13 files:

| File | Members |
|------|---------|
| `System/MemoryExtensions.xml` | 28 — `typeparam T` on the generic `ContainsAny`/`ContainsAnyExcept`/`*InRange`/`IndexOfAny`/`LastIndexOfAny` overloads; `returns` on the `Span<T>` overloads (copied from their `ReadOnlySpan<T>` siblings) and both `AsSpan(string, Index/Range)` |
| `System/Guid.xml` | 4 — `.ctor(ReadOnlySpan<byte>, bool)`, `ToByteArray(bool)`, UTF-8 `TryFormat`, `TryWriteBytes(Span<byte>, bool, out int)` |
| `System/Boolean.xml`, `System/String.xml` | 4 — `IParsable`/`ISpanParsable` `TryParse` explicit interface implementations |
| `System/DateTimeOffset.xml`, `System/TimeSpan.xml` | 2 — `formatProvider` on the UTF-8 `TryFormat` overloads |
| `System/BinaryData.xml` | `WithMediaType` param (also fixes a `<see pref=` typo in its summary) |
| `System/Enum.xml` | `TryFormat<TEnum>` — `value` param + `TEnum` typeparam |
| `System/TimeProvider.xml` | `GetLocalNow`, `GetUtcNow` returns |
| `System/ConsoleKey.xml`, `System/ConsoleModifiers.xml` | `None` field summaries |
| `System/OperatingSystem.xml` | `IsWasi` returns |
| `System/TimeZoneInfo.xml` | `GetSystemTimeZones(bool)` returns |

Contributes to dotnet/runtime#88563.

> [!NOTE]
> This pull request was authored by GitHub Copilot.
