### PR TITLE
Add preview link generator workflow

### DIFF
--- a/.github/workflows/generate-preview-links.yml
+++ b/.github/workflows/generate-preview-links.yml
@@ -1,0 +1,27 @@
+name: 'Preview link generator'
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  preview_link_generator_job:
+    name: Generate preview link table
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: read
+      pull-requests: write
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+      with:
+        egress-policy: audit
+
+    - uses: dotnet/docs-tools/actions/preview-link-generator@e761d65daef04078de70423f735850919b4c8610 # main
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        docs_path: "docs"
+        url_base_path: "dotnet"

--- a/.github/workflows/generate-preview-links.yml
+++ b/.github/workflows/generate-preview-links.yml
@@ -20,8 +20,6 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: dotnet/docs-tools/actions/preview-link-generator@e761d65daef04078de70423f735850919b4c8610 # main
+    - uses: dotnet/docs-tools/actions/preview-link-generator@d5d277bdf131f7a24414491773acd1f02a1c457c # main
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        docs_path: "docs"
-        url_base_path: "dotnet"

--- a/.github/workflows/generate-preview-links.yml
+++ b/.github/workflows/generate-preview-links.yml
@@ -15,11 +15,11 @@ jobs:
       statuses: read
       pull-requests: write
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-      with:
-        egress-policy: audit
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
 
-    - uses: dotnet/docs-tools/actions/preview-link-generator@d5d277bdf131f7a24414491773acd1f02a1c457c # main
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dotnet/docs-tools/actions/preview-link-generator@d5d277bdf131f7a24414491773acd1f02a1c457c # main
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Adds preview links to PR description
- Means we don't need to enable noisy OPS build PR comments to see preview links