### PR TITLE
Update build warning workflow

### DIFF
--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -1,7 +1,7 @@
 name: 'OPS status checker'
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -20,7 +20,6 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: dotnet/docs-tools/actions/status-checker@main
+    - uses: dotnet/docs-tools/actions/status-checker@d5d277bdf131f7a24414491773acd1f02a1c457c #main
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        mode: "warning"

--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -1,7 +1,7 @@
 name: 'OPS status checker'
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -20,6 +20,6 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: dotnet/docs-tools/actions/status-checker@d5d277bdf131f7a24414491773acd1f02a1c457c #main
+    - uses: dotnet/docs-tools/actions/status-checker@455480c2e1c2fa90ecb711963250f000d66d3251c #main
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -20,6 +20,6 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: dotnet/docs-tools/actions/status-checker@455480c2e1c2fa90ecb711963250f000d66d3251c #main
+    - uses: dotnet/docs-tools/actions/status-checker@455480c2e1c2fa90ecb711963250f000d66d3251 #main
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Mode choice no longer needed. Also use SHA instead of branch name.