### PR TITLE
Clarify ObjectInstance remarks when no owning object is available

### DIFF
--- a/xml/System.ComponentModel.DataAnnotations/ValidationContext.xml
+++ b/xml/System.ComponentModel.DataAnnotations/ValidationContext.xml
@@ -518,7 +518,8 @@ This property represents an entity member name, not the name of a corresponding 
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- During validation, especially during property-level validation, the object instance could be in an indeterminate state. When validation is performed without an owning object (for example, validating standalone values), it may be a placeholder and should not be treated as the owner of the value.
+ During validation, especially during property-level validation, the object instance could be in an indeterminate state.
+ When validation is performed without an owning object (for example, validating standalone values), it might be a placeholder, so don't treat it as the owner of the value.
 
  ]]></format>
         </remarks>

--- a/xml/System.ComponentModel.DataAnnotations/ValidationContext.xml
+++ b/xml/System.ComponentModel.DataAnnotations/ValidationContext.xml
@@ -518,7 +518,7 @@ This property represents an entity member name, not the name of a corresponding 
           <format type="text/markdown"><![CDATA[
 
 ## Remarks
- During validation, especially during property-level validation, the object instance could be in an indeterminate state.
+ During validation, especially during property-level validation, the object instance could be in an indeterminate state. When validation is performed without an owning object (for example, validating standalone values), it may be a placeholder and should not be treated as the owner of the value.
 
  ]]></format>
         </remarks>


### PR DESCRIPTION
Updates the ObjectInstance remarks to note that the property has no meaningful value when validation runs outside the context of an owning object (for example, standalone values), helping attribute authors avoid incorrect assumptions.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [xml/System.ComponentModel.DataAnnotations/ValidationContext.xml](https://github.com/dotnet/dotnet-api-docs/blob/f021d9e0c20f1d4246ff49d0414ef4bbbafc58d6/xml/System.ComponentModel.DataAnnotations/ValidationContext.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.validationcontext?view=net-11.0&branch=pr-en-us-12939) |

<!-- PREVIEW-TABLE-END -->