### PR TITLE
Fix XmlReader.GetAttribute return documentation

### DIFF
--- a/xml/System.Xml/XmlReader.xml
+++ b/xml/System.Xml/XmlReader.xml
@@ -1933,7 +1933,7 @@ This means that the <xref:System.Xml.XmlReader> can access any locations that do
       <Docs>
         <param name="name">The qualified name of the attribute.</param>
         <summary>When overridden in a derived class, gets the value of the attribute with the specified <see cref="P:System.Xml.XmlReader.Name" />.</summary>
-        <returns>The value of the specified attribute. If the attribute is not found, <see langword="null" /> is returned.</returns>
+        <returns>The value of the specified attribute. If the attribute is not found, <see langword="null" /> is returned. If the attribute is present but has an empty value, <see cref="F:System.String.Empty" /> is returned.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 

--- a/xml/System.Xml/XmlReader.xml
+++ b/xml/System.Xml/XmlReader.xml
@@ -1933,7 +1933,7 @@ This means that the <xref:System.Xml.XmlReader> can access any locations that do
       <Docs>
         <param name="name">The qualified name of the attribute.</param>
         <summary>When overridden in a derived class, gets the value of the attribute with the specified <see cref="P:System.Xml.XmlReader.Name" />.</summary>
-        <returns>The value of the specified attribute. If the attribute is not found or the value is <see langword="String.Empty" />, <see langword="null" /> is returned.</returns>
+        <returns>The value of the specified attribute. If the attribute is not found, <see langword="null" /> is returned.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 
@@ -2002,7 +2002,7 @@ This means that the <xref:System.Xml.XmlReader> can access any locations that do
         <param name="name">The local name of the attribute.</param>
         <param name="namespaceURI">The namespace URI of the attribute.</param>
         <summary>When overridden in a derived class, gets the value of the attribute with the specified <see cref="P:System.Xml.XmlReader.LocalName" /> and <see cref="P:System.Xml.XmlReader.NamespaceURI" />.</summary>
-        <returns>The value of the specified attribute. If the attribute is not found or the value is <see langword="String.Empty" />, <see langword="null" /> is returned. This method does not move the reader.</returns>
+        <returns>The value of the specified attribute. If the attribute is not found, <see langword="null" /> is returned. This method does not move the reader.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[
 


### PR DESCRIPTION
## Summary

Clarify that the named `XmlReader.GetAttribute` overloads return `null` only when the requested attribute isn't found. A present attribute with an empty value returns `String.Empty`.

Preserve the existing guidance that these methods don't move the reader. The index-based overload is unchanged.

Fixes dotnet/runtime#123749

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [xml/Microsoft.Extensions.DependencyInjection/ValidationLocalizationServiceCollectionExtensions.xml](https://github.com/dotnet/dotnet-api-docs/blob/dcd4a90356606eac57b0e01be573d7ce3b40a6a0/xml/Microsoft.Extensions.DependencyInjection/ValidationLocalizationServiceCollectionExtensions.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.validationlocalizationservicecollectionextensions?view=net-11.0-pp&branch=pr-en-us-12986) |
| [xml/Microsoft.Extensions.Validation.Localization/ValidationLocalizationOptions.xml](https://github.com/dotnet/dotnet-api-docs/blob/dcd4a90356606eac57b0e01be573d7ce3b40a6a0/xml/Microsoft.Extensions.Validation.Localization/ValidationLocalizationOptions.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.validation.localization.validationlocalizationoptions?view=net-11.0-pp&branch=pr-en-us-12986) |
| [xml/System.Xml/XmlReader.xml](https://github.com/dotnet/dotnet-api-docs/blob/dcd4a90356606eac57b0e01be573d7ce3b40a6a0/xml/System.Xml/XmlReader.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.xml.xmlreader?view=net-11.0&branch=pr-en-us-12986) |


<!-- PREVIEW-TABLE-END -->