### PR TITLE
Link the platform compatibility analyzer article from OS platform API reference pages

### DIFF
--- a/xml/System.Runtime.Versioning/OSPlatformAttribute.xml
+++ b/xml/System.Runtime.Versioning/OSPlatformAttribute.xml
@@ -28,6 +28,7 @@
   <Docs>
     <summary>Base type for all platform-specific API attributes.</summary>
     <remarks>To be added.</remarks>
+    <related type="Article" href="/dotnet/standard/analyzers/platform-compat-analyzer">Platform compatibility analyzer</related>
   </Docs>
   <Members>
     <Member MemberName="PlatformName">

--- a/xml/System.Runtime.Versioning/ObsoletedOSPlatformAttribute.xml
+++ b/xml/System.Runtime.Versioning/ObsoletedOSPlatformAttribute.xml
@@ -30,6 +30,7 @@
   <Docs>
     <summary>Marks APIs that were obsoleted in a given operating system version.</summary>
     <remarks>Primarily used by OS bindings to indicate APIs that should not be used anymore.</remarks>
+    <related type="Article" href="/dotnet/standard/analyzers/platform-compat-analyzer">Platform compatibility analyzer</related>
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">

--- a/xml/System.Runtime.Versioning/SupportedOSPlatformAttribute.xml
+++ b/xml/System.Runtime.Versioning/SupportedOSPlatformAttribute.xml
@@ -37,6 +37,7 @@ Callers can apply a <xref:System.Runtime.Versioning.SupportedOSPlatformAttribute
 
           ]]></format>
     </remarks>
+    <related type="Article" href="/dotnet/standard/analyzers/platform-compat-analyzer">Platform compatibility analyzer</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Runtime.Versioning/SupportedOSPlatformGuardAttribute.xml
+++ b/xml/System.Runtime.Versioning/SupportedOSPlatformGuardAttribute.xml
@@ -39,6 +39,7 @@ Callers can apply a <xref:System.Runtime.Versioning.SupportedOSPlatformGuardAttr
 
       ]]></format>
     </remarks>
+    <related type="Article" href="/dotnet/standard/analyzers/platform-compat-analyzer">Platform compatibility analyzer</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Runtime.Versioning/TargetPlatformAttribute.xml
+++ b/xml/System.Runtime.Versioning/TargetPlatformAttribute.xml
@@ -28,6 +28,7 @@
   <Docs>
     <summary>Specifies the operating system that a project targets, for example, Windows or iOS.</summary>
     <remarks>To be added.</remarks>
+    <related type="Article" href="/dotnet/standard/analyzers/platform-compat-analyzer">Platform compatibility analyzer</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Runtime.Versioning/UnsupportedOSPlatformAttribute.xml
+++ b/xml/System.Runtime.Versioning/UnsupportedOSPlatformAttribute.xml
@@ -40,6 +40,7 @@ The versionless attribute is primarily used to indicate the API is unsupported f
 
           ]]></format>
     </remarks>
+    <related type="Article" href="/dotnet/standard/analyzers/platform-compat-analyzer">Platform compatibility analyzer</related>
   </Docs>
   <Members>
     <MemberGroup MemberName=".ctor">

--- a/xml/System.Runtime.Versioning/UnsupportedOSPlatformGuardAttribute.xml
+++ b/xml/System.Runtime.Versioning/UnsupportedOSPlatformGuardAttribute.xml
@@ -39,6 +39,7 @@ Callers can apply a <xref:System.Runtime.Versioning.UnsupportedOSPlatformGuardAt
 
       ]]></format>
     </remarks>
+    <related type="Article" href="/dotnet/standard/analyzers/platform-compat-analyzer">Platform compatibility analyzer</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System/OperatingSystem.xml
+++ b/xml/System/OperatingSystem.xml
@@ -83,6 +83,7 @@
 
  ]]></format>
     </remarks>
+    <related type="Article" href="/dotnet/standard/analyzers/platform-compat-analyzer">Platform compatibility analyzer</related>
   </Docs>
   <Members>
     <Member MemberName=".ctor">


### PR DESCRIPTION
## Summary

Adds a **See also** link to the [Platform compatibility analyzer](/dotnet/standard/analyzers/platform-compat-analyzer) conceptual article on the API reference pages for the OS platform attributes and `System.OperatingSystem`.

That article is the conceptual documentation for these APIs — it covers the platform name and version string formats, how CA1416 interprets the attributes, and which patterns count as platform guards — but none of the reference pages linked out to it.

Files touched (one `<related>` line each, in the type-level `<Docs>`):

- `System.Runtime.Versioning.OSPlatformAttribute`
- `System.Runtime.Versioning.TargetPlatformAttribute`
- `System.Runtime.Versioning.SupportedOSPlatformAttribute`
- `System.Runtime.Versioning.UnsupportedOSPlatformAttribute`
- `System.Runtime.Versioning.ObsoletedOSPlatformAttribute`
- `System.Runtime.Versioning.SupportedOSPlatformGuardAttribute`
- `System.Runtime.Versioning.UnsupportedOSPlatformGuardAttribute`
- `System.OperatingSystem`

`System.Runtime.InteropServices.OSPlatform` is intentionally excluded: the article doesn't mention it, and `RuntimeInformation.IsOSPlatform` isn't recognized by CA1416 as a platform guard, so the link would misdirect readers.

Follows up on a comment in dotnet/runtime#125181. These types set `UseCompilerGeneratedDocXmlFile=false`, so dotnet-api-docs is the source of truth for their docs and this is the correct repo for the change.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [xml/System.Runtime.Versioning/ObsoletedOSPlatformAttribute.xml](https://github.com/dotnet/dotnet-api-docs/blob/3a93ccfccab9256b26e9dbdb9aaa1271be5f9a11/xml/System.Runtime.Versioning/ObsoletedOSPlatformAttribute.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.obsoletedosplatformattribute?view=net-11.0&branch=pr-en-us-12993) |
| [xml/System.Runtime.Versioning/OSPlatformAttribute.xml](https://github.com/dotnet/dotnet-api-docs/blob/3a93ccfccab9256b26e9dbdb9aaa1271be5f9a11/xml/System.Runtime.Versioning/OSPlatformAttribute.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.osplatformattribute?view=net-11.0&branch=pr-en-us-12993) |
| [xml/System.Runtime.Versioning/SupportedOSPlatformAttribute.xml](https://github.com/dotnet/dotnet-api-docs/blob/3a93ccfccab9256b26e9dbdb9aaa1271be5f9a11/xml/System.Runtime.Versioning/SupportedOSPlatformAttribute.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.supportedosplatformattribute?view=net-11.0&branch=pr-en-us-12993) |
| [xml/System.Runtime.Versioning/SupportedOSPlatformGuardAttribute.xml](https://github.com/dotnet/dotnet-api-docs/blob/3a93ccfccab9256b26e9dbdb9aaa1271be5f9a11/xml/System.Runtime.Versioning/SupportedOSPlatformGuardAttribute.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.supportedosplatformguardattribute?view=net-11.0&branch=pr-en-us-12993) |
| [xml/System.Runtime.Versioning/TargetPlatformAttribute.xml](https://github.com/dotnet/dotnet-api-docs/blob/3a93ccfccab9256b26e9dbdb9aaa1271be5f9a11/xml/System.Runtime.Versioning/TargetPlatformAttribute.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.targetplatformattribute?view=net-11.0&branch=pr-en-us-12993) |
| [xml/System.Runtime.Versioning/UnsupportedOSPlatformAttribute.xml](https://github.com/dotnet/dotnet-api-docs/blob/3a93ccfccab9256b26e9dbdb9aaa1271be5f9a11/xml/System.Runtime.Versioning/UnsupportedOSPlatformAttribute.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.unsupportedosplatformattribute?view=net-11.0&branch=pr-en-us-12993) |
| [xml/System.Runtime.Versioning/UnsupportedOSPlatformGuardAttribute.xml](https://github.com/dotnet/dotnet-api-docs/blob/3a93ccfccab9256b26e9dbdb9aaa1271be5f9a11/xml/System.Runtime.Versioning/UnsupportedOSPlatformGuardAttribute.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.unsupportedosplatformguardattribute?view=net-11.0&branch=pr-en-us-12993) |
| [xml/System/OperatingSystem.xml](https://github.com/dotnet/dotnet-api-docs/blob/3a93ccfccab9256b26e9dbdb9aaa1271be5f9a11/xml/System/OperatingSystem.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.operatingsystem?view=net-11.0&branch=pr-en-us-12993) |

<!-- PREVIEW-TABLE-END -->