### PR TITLE
Add reference to Zip/Tar best practices to ExractToDirectory

### DIFF
--- a/includes/tar-zip-extracttodirectory.md
+++ b/includes/tar-zip-extracttodirectory.md
@@ -1,2 +1,2 @@
 > [!WARNING]
-> This method must be used only on trusted archives as it doesn't enforce any size limits, entry count limits, or other policies needed for safe extraction of untrusted archives. Refer to [Best practices for using zip and tar archives](/dotnet/standard/io/zip-tar-best-practices) for more information on safely extracting archives from untrusted sources.
+> This method must be used only on trusted archives as it doesn't enforce any size limits, entry count limits, or other policies needed for safe extraction of untrusted archives. For more information on safely extracting archives from untrusted sources, see [Best practices for using zip and tar archives](/dotnet/standard/io/zip-tar-best-practices).

--- a/includes/tar-zip-extracttodirectory.md
+++ b/includes/tar-zip-extracttodirectory.md
@@ -1,0 +1,2 @@
+> [!WARNING]
+> This method must be used only on trusted archives as it doesn't enforce any size limits, entry count limits, or other policies needed for safe extraction of untrusted archives. Refer to [Best practices for using zip and tar archives](dotnet/standard/io/zip-tar-best-practices) for more information on safely extracting archives from untrusted sources.

--- a/includes/tar-zip-extracttodirectory.md
+++ b/includes/tar-zip-extracttodirectory.md
@@ -1,2 +1,2 @@
 > [!WARNING]
-> This method must be used only on trusted archives as it doesn't enforce any size limits, entry count limits, or other policies needed for safe extraction of untrusted archives. Refer to [Best practices for using zip and tar archives](dotnet/standard/io/zip-tar-best-practices) for more information on safely extracting archives from untrusted sources.
+> This method must be used only on trusted archives as it doesn't enforce any size limits, entry count limits, or other policies needed for safe extraction of untrusted archives. Refer to [Best practices for using zip and tar archives](/dotnet/standard/io/zip-tar-best-practices) for more information on safely extracting archives from untrusted sources.

--- a/xml/System.Formats.Tar/TarFile.xml
+++ b/xml/System.Formats.Tar/TarFile.xml
@@ -492,6 +492,11 @@
           <para>Files of type <see cref="F:System.Formats.Tar.TarEntryType.BlockDevice" />, <see cref="F:System.Formats.Tar.TarEntryType.CharacterDevice" />, or <see cref="F:System.Formats.Tar.TarEntryType.Fifo" /> can only be extracted in Unix platforms.</para>
           <para>Elevation is required to extract a <see cref="F:System.Formats.Tar.TarEntryType.BlockDevice" /> or <see cref="F:System.Formats.Tar.TarEntryType.CharacterDevice" /> to disk.</para>
           <para>This method doesn't limit the total extracted size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <see cref="T:System.Formats.Tar.TarReader" />, and validate that the size and the number of entries are within acceptable limits for your scenario.</para>
+          <format type="text/markdown"><![CDATA[
+
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
+
+          ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="source" /> or <paramref name="destinationDirectoryName" /> is <see langword="null" />.</exception>
@@ -536,7 +541,13 @@ Extracting one of the tar entries would have resulted in a file outside the spec
         <param name="destinationDirectoryName">To be added.</param>
         <param name="options">To be added.</param>
         <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[
+
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
+
+          ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="ExtractToDirectory">
@@ -574,6 +585,11 @@ Extracting one of the tar entries would have resulted in a file outside the spec
           <para>Files of type <see cref="F:System.Formats.Tar.TarEntryType.BlockDevice" />, <see cref="F:System.Formats.Tar.TarEntryType.CharacterDevice" />, or <see cref="F:System.Formats.Tar.TarEntryType.Fifo" /> can only be extracted in Unix platforms.</para>
           <para>Elevation is required to extract a <see cref="F:System.Formats.Tar.TarEntryType.BlockDevice" /> or <see cref="F:System.Formats.Tar.TarEntryType.CharacterDevice" /> to disk.</para>
           <para>This method doesn't limit the total extracted size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <see cref="T:System.Formats.Tar.TarReader" />, and validate that the size and the number of entries are within acceptable limits for your scenario.</para>
+          <format type="text/markdown"><![CDATA[
+
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
+
+          ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="sourceFileName" /> or <paramref name="destinationDirectoryName" /> is <see langword="null" />.</exception>
@@ -615,7 +631,13 @@ Extracting one of the tar entries would have resulted in a file outside the spec
         <param name="destinationDirectoryName">To be added.</param>
         <param name="options">To be added.</param>
         <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[
+
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
+
+          ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <MemberGroup MemberName="ExtractToDirectoryAsync">

--- a/xml/System.Formats.Tar/TarFile.xml
+++ b/xml/System.Formats.Tar/TarFile.xml
@@ -487,12 +487,17 @@
           <see langword="true" /> to overwrite files and directories in <paramref name="destinationDirectoryName" />; <see langword="false" /> to avoid overwriting, and throw if any files or directories are found with existing names.</param>
         <summary>Extracts the contents of a stream that represents a tar archive into the specified directory.</summary>
         <remarks>
-          <para>If a symbolic link or junction in the tar archive results in a file being extracted outside the specified <paramref name="destinationDirectoryName" />, an <see cref="T:System.IO.IOException" /> is thrown to ensure extraction remains within the same directory.</para>
-          <para>If <paramref name="destinationDirectoryName" /> or any of its parent directories is a pre-existing junction or symbolic link, the link is followed and the extraction writes to the final target folder.</para>
-          <para>Files of type <see cref="F:System.Formats.Tar.TarEntryType.BlockDevice" />, <see cref="F:System.Formats.Tar.TarEntryType.CharacterDevice" />, or <see cref="F:System.Formats.Tar.TarEntryType.Fifo" /> can only be extracted in Unix platforms.</para>
-          <para>Elevation is required to extract a <see cref="F:System.Formats.Tar.TarEntryType.BlockDevice" /> or <see cref="F:System.Formats.Tar.TarEntryType.CharacterDevice" /> to disk.</para>
-          <para>This method doesn't limit the total extracted size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <see cref="T:System.Formats.Tar.TarReader" />, and validate that the size and the number of entries are within acceptable limits for your scenario.</para>
           <format type="text/markdown"><![CDATA[
+
+If a symbolic link or junction in the tar archive results in a file being extracted outside the specified `destinationDirectoryName`, an <xref:System.IO.IOException> is thrown to ensure extraction remains within the same directory.
+
+If `destinationDirectoryName` or any of its parent directories is a pre-existing junction or symbolic link, the link is followed and the extraction writes to the final target folder.
+
+Files of type <xref:System.Formats.Tar.TarEntryType.BlockDevice>, <xref:System.Formats.Tar.TarEntryType.CharacterDevice>, or <xref:System.Formats.Tar.TarEntryType.Fifo> can only be extracted in Unix platforms.
+
+Elevation is required to extract a <xref:System.Formats.Tar.TarEntryType.BlockDevice> or <xref:System.Formats.Tar.TarEntryType.CharacterDevice> to disk.
+
+This method doesn't limit the total extracted size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.Formats.Tar.TarReader>, and validate that the size and the number of entries are within acceptable limits for your scenario.
 
 [!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
@@ -580,12 +585,17 @@ Extracting one of the tar entries would have resulted in a file outside the spec
           <see langword="true" /> to overwrite files and directories in <paramref name="destinationDirectoryName" />; <see langword="false" /> to avoid overwriting, and throw if any files or directories are found with existing names.</param>
         <summary>Extracts the contents of a tar file into the specified directory.</summary>
         <remarks>
-          <para>If a symbolic link or junction in the tar archive results in a file being extracted outside the specified <paramref name="destinationDirectoryName" />, an <see cref="T:System.IO.IOException" /> is thrown to ensure extraction remains within the same directory.</para>
-          <para>If <paramref name="destinationDirectoryName" /> or any of its parent directories is a pre-existing junction or symbolic link, the link is followed and the extraction writes to the final target folder.</para>
-          <para>Files of type <see cref="F:System.Formats.Tar.TarEntryType.BlockDevice" />, <see cref="F:System.Formats.Tar.TarEntryType.CharacterDevice" />, or <see cref="F:System.Formats.Tar.TarEntryType.Fifo" /> can only be extracted in Unix platforms.</para>
-          <para>Elevation is required to extract a <see cref="F:System.Formats.Tar.TarEntryType.BlockDevice" /> or <see cref="F:System.Formats.Tar.TarEntryType.CharacterDevice" /> to disk.</para>
-          <para>This method doesn't limit the total extracted size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <see cref="T:System.Formats.Tar.TarReader" />, and validate that the size and the number of entries are within acceptable limits for your scenario.</para>
           <format type="text/markdown"><![CDATA[
+
+If a symbolic link or junction in the tar archive results in a file being extracted outside the specified `destinationDirectoryName`, an <xref:System.IO.IOException> is thrown to ensure extraction remains within the same directory.
+
+If `destinationDirectoryName` or any of its parent directories is a pre-existing junction or symbolic link, the link is followed and the extraction writes to the final target folder.
+
+Files of type <xref:System.Formats.Tar.TarEntryType.BlockDevice>, <xref:System.Formats.Tar.TarEntryType.CharacterDevice>, or <xref:System.Formats.Tar.TarEntryType.Fifo> can only be extracted in Unix platforms.
+
+Elevation is required to extract a <xref:System.Formats.Tar.TarEntryType.BlockDevice> or <xref:System.Formats.Tar.TarEntryType.CharacterDevice> to disk.
+
+This method doesn't limit the total extracted size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.Formats.Tar.TarReader>, and validate that the size and the number of entries are within acceptable limits for your scenario.
 
 [!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 

--- a/xml/System.IO.Compression/ZipFile.xml
+++ b/xml/System.IO.Compression/ZipFile.xml
@@ -1156,8 +1156,7 @@ An I/O error occurred while opening a file to be archived.</exception>
 
  If a file to be archived has an invalid last modified time, the first date and time representable in the zip timestamp format (midnight on January 1, 1980) will be used.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>
@@ -1235,8 +1234,7 @@ An archive entry was compressed by using a compression method that isn't support
  If an entry in the zip archive is a symbolic link, it's extracted as a regular folder since symbolic link information isn't preserved in the ZIP format.
  If `destinationDirectoryName` or any of its parent directories is a pre-existing junction or symbolic link, the link is followed and the extraction writes to the final target folder.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
 ## Examples
  This example shows how to create and extract a zip archive by using the <xref:System.IO.Compression.ZipFile> class. It compresses the contents of a folder into a zip archive and extracts that content to a new folder. To use the <xref:System.IO.Compression.ZipFile> class, you must reference the `System.IO.Compression.FileSystem` assembly in your project.
@@ -1321,8 +1319,7 @@ An archive entry was compressed by using a compression method that isn't support
 
  If a file to be archived has an invalid last modified time, the first date and time representable in the zip timestamp format (midnight on January 1, 1980) will be used.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>
@@ -1433,8 +1430,7 @@ An archive entry was compressed by using a compression method that isn't support
 
  If a file to be archived has an invalid last modified time, the first date and time representable in the zip timestamp format (midnight on January 1, 1980) will be used.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>
@@ -1520,8 +1516,7 @@ If `destinationDirectoryName` or any of its parent directories is a pre-existing
 
 If a file to be archived has an invalid last modified time, the first date and time representable in the zip timestamp format (midnight on January 1, 1980) will be used.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
           ]]></format>
         </remarks>
@@ -1662,9 +1657,8 @@ If `entryNameEncoding` is set to `null`, entry names and comments are decoded ac
 
 - For entries where the language encoding flag (in the general-purpose bit flag of the local file header) is not set, entry names and comments are decoded by using the current system default code page.
 - For entries where the language encoding flag is set, the entry names and comments are decoded by using UTF-8.
-
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+  
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>
@@ -1755,8 +1749,7 @@ If `entryNameEncoding` is set to `null`, entry names and comments are decoded ac
 
  If a file to be archived has an invalid last modified time, the first date and time representable in the zip timestamp format (midnight on January 1, 1980) will be used.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>
@@ -1851,8 +1844,7 @@ An archive entry was compressed by using a compression method that isn't support
 
  If a file to be archived has an invalid last modified time, the first date and time representable in the zip timestamp format (midnight on January 1, 1980) will be used.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
 ]]></format>
         </remarks>
@@ -1944,8 +1936,7 @@ An archive entry has been compressed using a compression method that isn't suppo
 
  If a file to be archived has an invalid last modified time, the first date and time representable in the zip timestamp format (midnight on January 1, 1980) will be used.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>
@@ -2017,8 +2008,7 @@ An archive entry has been compressed using a compression method that isn't suppo
 
  If a file to be archived has an invalid last modified time, the first date and time representable in the zip timestamp format (midnight on January 1, 1980) will be used.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>
@@ -2098,8 +2088,7 @@ An archive entry has been compressed using a compression method that isn't suppo
 
  If a file to be archived has an invalid last modified time, the first date and time representable in the zip timestamp format (midnight on January 1, 1980) will be used.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>
@@ -2210,8 +2199,7 @@ An archive entry has been compressed using a compression method that isn't suppo
 
  If a file to be archived has an invalid last modified time, the first date and time representable in the zip timestamp format (midnight on January 1, 1980) will be used.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>
@@ -2291,8 +2279,7 @@ An archive entry has been compressed using a compression method that isn't suppo
 
  If a file to be archived has an invalid last modified time, the first date and time representable in the zip timestamp format (midnight on January 1, 1980) will be used.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>
@@ -2429,8 +2416,7 @@ An archive entry has been compressed using a compression method that isn't suppo
 
  Unicode encodings other than UTF-8 can't be used for `entryNameEncoding`, otherwise an <xref:System.ArgumentException> is thrown.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>
@@ -2519,8 +2505,7 @@ An archive entry has been compressed using a compression method that isn't suppo
 
  If a file to be archived has an invalid last modified time, the first date and time representable in the zip timestamp format (midnight on January 1, 1980) will be used.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>
@@ -2618,8 +2603,7 @@ An archive entry has been compressed using a compression method that isn't suppo
 
  Unicode encodings other than UTF-8 can't be used for `entryNameEncoding`, otherwise an <xref:System.ArgumentException> is thrown.
 
-> [!WARNING]
-> This method doesn't limit the total uncompressed size or the number of entries extracted from the archive. When processing archives from untrusted sources, iterate over the entries manually using <xref:System.IO.Compression.ZipArchive>, and validate that the total uncompressed size and the number of entries are within acceptable limits for your scenario.
+[!INCLUDE[tar-zip-extracttodirectory](~/includes/tar-zip-extracttodirectory.md)]
 
  ]]></format>
         </remarks>


### PR DESCRIPTION
## Summary

Add warnings to the Tar extraction method to inform users about the risks of using it on untrusted archives. Include a reference to the best practices document for safely extracting archives.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [includes/tar-zip-extracttodirectory.md](https://github.com/dotnet/dotnet-api-docs/blob/17b66e8ea51612186963bf48387ce08a61a573d3/includes/tar-zip-extracttodirectory.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/api/system.formats.tar.tarfile?view=net-11.0&branch=pr-en-us-12995) |
| [xml/System.Formats.Tar/TarFile.xml](https://github.com/dotnet/dotnet-api-docs/blob/17b66e8ea51612186963bf48387ce08a61a573d3/xml/System.Formats.Tar/TarFile.xml) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/api/system.formats.tar.tarfile?view=net-11.0&branch=pr-en-us-12995) |
| [xml/System.IO.Compression/ZipFile.xml](https://github.com/dotnet/dotnet-api-docs/blob/17b66e8ea51612186963bf48387ce08a61a573d3/xml/System.IO.Compression/ZipFile.xml) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/api/system.io.compression.zipfile?view=net-11.0&branch=pr-en-us-12995) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/500c749d-de78-3d4a-00e4-269d599bf9ec/202608260900141321-12995/BuildReport?accessString=49d4487735f27808b63ea5b06e7bd8f0e8efe3a02721cef11bbb19facb8af5ed)