### PR TITLE
Fix unsafe XML crypto snippets under System.Security.Cryptography.Xml

### DIFF
--- a/snippets/csharp/System.Security.Cryptography.Xml/DSAKeyValue/Overview/exampledetached.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/DSAKeyValue/Overview/exampledetached.cs
@@ -40,7 +40,7 @@ class XMLDSIGDetached
             Console.WriteLine("Verifying signature...");
 
             //Verify the XML signature in the XML file.
-            bool result = VerifyDetachedSignature(XmlFileName);
+            bool result = VerifyDetachedSignature(XmlFileName, DSAKey);
 
             // Display the results of the signature verification to 
             // the console.
@@ -99,13 +99,16 @@ class XMLDSIGDetached
     // </Snippet2>
     // <Snippet3>
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyDetachedSignature(string XmlSigFileName)
+    public static Boolean VerifyDetachedSignature(string XmlSigFileName, DSA DSAKey)
     {	
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
 
         // Load the passed XML file into the document.
-        xmlDocument.Load(XmlSigFileName);
+        using (XmlReader reader = XmlReader.Create(XmlSigFileName))
+        {
+            xmlDocument.Load(reader);
+        }
 	
         // Create a new SignedXMl object.
         SignedXml signedXml = new SignedXml();
@@ -118,7 +121,7 @@ class XMLDSIGDetached
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(DSAKey);
     }
     // </Snippet3>
 }

--- a/snippets/csharp/System.Security.Cryptography.Xml/DSAKeyValue/Overview/exampleenvelope.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/DSAKeyValue/Overview/exampleenvelope.cs
@@ -31,7 +31,7 @@ public class SignVerifyEnvelope
 
             // Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...");
-            bool result = VerifyXmlFile("SignedExample.xml");
+            bool result = VerifyXmlFile("SignedExample.xml", DSAKey);
 
             // Display the results of the signature verification to \
             // the console.
@@ -61,7 +61,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -113,7 +116,7 @@ public class SignVerifyEnvelope
     // </Snippet2>
     // <Snippet3>
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyXmlFile(String Name)
+    public static Boolean VerifyXmlFile(String Name, DSA DSAKey)
     {
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
@@ -122,7 +125,10 @@ public class SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = true;
 
         // Load the passed XML file into the document. 
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.
@@ -136,7 +142,7 @@ public class SignVerifyEnvelope
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(DSAKey);
     }
     // </Snippet3>
 

--- a/snippets/csharp/System.Security.Cryptography.Xml/DataObject/Overview/source1.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/DataObject/Overview/source1.cs
@@ -12,18 +12,21 @@ public class Verify {
 
         Console.WriteLine("Verifying " + args[0] + "...");
 
-    	// Create a SignedXml.
-        SignedXml signedXml = new SignedXml();
+        RSA trustedKey = RSA.Create();
+        // ... load trustedKey from an out-of-band source ...
 
-        // Load the XML.
         XmlDocument xmlDocument = new XmlDocument();
         xmlDocument.PreserveWhitespace = true;
-        xmlDocument.Load(new XmlTextReader(args[0]));
+        using (XmlReader reader = XmlReader.Create(args[0]))
+        {
+            xmlDocument.Load(reader);
+        }
 
+        SignedXml signedXml = new SignedXml(xmlDocument);
         XmlNodeList nodeList = xmlDocument.GetElementsByTagName("Signature");
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
-        if (signedXml.CheckSignature()) {
+        if (signedXml.CheckSignature(trustedKey)) {
             Console.WriteLine("Signature check OK");
         } else {
             Console.WriteLine("Signature check FAILED");

--- a/snippets/csharp/System.Security.Cryptography.Xml/DataReference/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/DataReference/Overview/sample.cs
@@ -15,7 +15,10 @@ class Program
         try
         {
             xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
+            using (XmlReader reader = XmlReader.Create("test.xml"))
+            {
+                xmlDoc.Load(reader);
+            }
         }
         catch (Exception e)
         {

--- a/snippets/csharp/System.Security.Cryptography.Xml/EncryptedData/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/EncryptedData/Overview/sample.cs
@@ -16,7 +16,10 @@ class Program
 		try
 		{
 			xmlDoc.PreserveWhitespace = true;
-			xmlDoc.Load("test.xml");
+			using (XmlReader reader = XmlReader.Create("test.xml"))
+			{
+				xmlDoc.Load(reader);
+			}
 		}
 		catch (Exception e)
 		{

--- a/snippets/csharp/System.Security.Cryptography.Xml/EncryptedKey/Overview/example.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/EncryptedKey/Overview/example.cs
@@ -16,7 +16,10 @@ class Program
 		try
 		{
 			xmlDoc.PreserveWhitespace = true;
-			xmlDoc.Load("test.xml");
+			using (XmlReader reader = XmlReader.Create("test.xml"))
+			{
+				xmlDoc.Load(reader);
+			}
 		}
 		catch (Exception e)
 		{

--- a/snippets/csharp/System.Security.Cryptography.Xml/EncryptedType/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/EncryptedType/Overview/sample.cs
@@ -16,7 +16,10 @@ class Program
         try
         {
             xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
+            using (XmlReader reader = XmlReader.Create("test.xml"))
+            {
+                xmlDoc.Load(reader);
+            }
         }
         catch (Exception e)
         {

--- a/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/AddKeyNameMapping/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/AddKeyNameMapping/sample.cs
@@ -16,7 +16,10 @@ class Program
         try
         {
             xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
+            using (XmlReader reader = XmlReader.Create("test.xml"))
+            {
+                xmlDoc.Load(reader);
+            }
         }
         catch (Exception e)
         {

--- a/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/Project.csproj
+++ b/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/Project.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="sample.vb" />
+    <Compile Include="sample.cs" />
   </ItemGroup>
 
 </Project>

--- a/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample.cs
@@ -16,7 +16,10 @@ using System.Security.Cryptography.Xml;
 			try
 			{
 				xmlDoc.PreserveWhitespace = true;
-				xmlDoc.Load("test.xml");
+				using (XmlReader reader = XmlReader.Create("test.xml"))
+				{
+					xmlDoc.Load(reader);
+				}
 			}
 			catch (Exception e)
 			{

--- a/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample1.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample1.cs
@@ -16,7 +16,10 @@ class Program
         try
         {
             xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
+            using (XmlReader reader = XmlReader.Create("test.xml"))
+            {
+                xmlDoc.Load(reader);
+            }
         }
         catch (Exception e)
         {

--- a/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample2.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample2.cs
@@ -16,7 +16,10 @@ class Program
         try
         {
             xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
+            using (XmlReader reader = XmlReader.Create("test.xml"))
+            {
+                xmlDoc.Load(reader);
+            }
         }
         catch (Exception e)
         {

--- a/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample3.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample3.cs
@@ -17,7 +17,10 @@ class Program
         try
         {
             xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
+            using (XmlReader reader = XmlReader.Create("test.xml"))
+            {
+                xmlDoc.Load(reader);
+            }
         }
         catch (Exception e)
         {

--- a/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample4.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample4.cs
@@ -16,7 +16,10 @@ class Program
         try
         {
             xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
+            using (XmlReader reader = XmlReader.Create("test.xml"))
+            {
+                xmlDoc.Load(reader);
+            }
         }
         catch (Exception e)
         {

--- a/snippets/csharp/System.Security.Cryptography.Xml/EncryptionProperty/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/EncryptionProperty/Overview/sample.cs
@@ -16,7 +16,10 @@ class Program
         try
         {
             xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
+            using (XmlReader reader = XmlReader.Create("test.xml"))
+            {
+                xmlDoc.Load(reader);
+            }
         }
         catch (Exception e)
         {

--- a/snippets/csharp/System.Security.Cryptography.Xml/IRelDecryptor/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/IRelDecryptor/Overview/sample.cs
@@ -12,7 +12,7 @@ namespace XMLDSIGExample
         {
         }
         //<SNIPPET2>
-        public static void CheckSignatureWithEncryptedGrant(string fileName, IRelDecryptor decryptor)
+        public static void CheckSignatureWithEncryptedGrant(string fileName, IRelDecryptor decryptor, AsymmetricAlgorithm trustedKey)
         {
             // Create a new XML document.
             XmlDocument xmlDocument = new XmlDocument();
@@ -22,7 +22,10 @@ namespace XMLDSIGExample
             xmlDocument.PreserveWhitespace = true;
 
             // Load the passed XML file into the document.
-            xmlDocument.Load(fileName);
+            using (XmlReader reader = XmlReader.Create(fileName))
+            {
+                xmlDocument.Load(reader);
+            }
             nsManager.AddNamespace("dsig", SignedXml.XmlDsigNamespaceUrl);
 
             // Find the "Signature" node and create a new XmlNodeList object.
@@ -51,7 +54,7 @@ namespace XMLDSIGExample
                 }
 
                 // Check the signature and display the result.
-                bool result = signedXml.CheckSignature();
+                bool result = signedXml.CheckSignature(trustedKey);
 
                 if (result)
                     Console.WriteLine("SUCCESS: CheckSignatureWithEncryptedGrant - issuer index #" +

--- a/snippets/csharp/System.Security.Cryptography.Xml/KeyInfo/Overview/xmldsigdetach.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/KeyInfo/Overview/xmldsigdetach.cs
@@ -40,7 +40,7 @@ class XMLDSIGDetached
             Console.WriteLine("Verifying signature...");
 
             //Verify the XML signature in the XML file.
-            bool result = VerifyDetachedSignature(XmlFileName);
+            bool result = VerifyDetachedSignature(XmlFileName, Key);
 
             // Display the results of the signature verification to 
             // the console.
@@ -99,13 +99,16 @@ class XMLDSIGDetached
 // </Snippet2>
 // <Snippet3>
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyDetachedSignature(string XmlSigFileName)
+    public static Boolean VerifyDetachedSignature(string XmlSigFileName, RSA Key)
     {	
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
 
         // Load the passed XML file into the document.
-        xmlDocument.Load(XmlSigFileName);
+        using (XmlReader reader = XmlReader.Create(XmlSigFileName))
+        {
+            xmlDocument.Load(reader);
+        }
 	
         // Create a new SignedXMl object.
         SignedXml signedXml = new SignedXml();
@@ -118,7 +121,7 @@ class XMLDSIGDetached
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(Key);
     }
 // </Snippet3>
 }

--- a/snippets/csharp/System.Security.Cryptography.Xml/KeyInfo/Overview/xmldsigenv.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/KeyInfo/Overview/xmldsigenv.cs
@@ -32,7 +32,7 @@ public class SignVerifyEnvelope
 
             // Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...");
-            bool result = VerifyXmlFile("SignedExample.xml");
+            bool result = VerifyXmlFile("SignedExample.xml", Key);
 
             // Display the results of the signature verification to \
             // the console.
@@ -62,7 +62,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -110,7 +113,7 @@ public class SignVerifyEnvelope
 // </Snippet2>
 // <Snippet3>
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyXmlFile(String Name)
+    public static Boolean VerifyXmlFile(String Name, RSA Key)
     {
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
@@ -119,7 +122,10 @@ public class SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = true;
 
         // Load the passed XML file into the document. 
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.
@@ -133,7 +139,7 @@ public class SignVerifyEnvelope
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(Key);
     }
 // </Snippet3>
 

--- a/snippets/csharp/System.Security.Cryptography.Xml/KeyInfoX509Data/.ctor/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/KeyInfoX509Data/.ctor/sample.cs
@@ -74,7 +74,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -147,7 +150,10 @@ public class SignVerifyEnvelope
         XmlDocument xmlDocument = new XmlDocument();
 
         // Load the passed XML file into the document. 
-        xmlDocument.Load(FileName);
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.

--- a/snippets/csharp/System.Security.Cryptography.Xml/KeyInfoX509Data/Overview/examplecreateenvelope.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/KeyInfoX509Data/Overview/examplecreateenvelope.cs
@@ -50,7 +50,11 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        // Load the passed XML file into the document.
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);

--- a/snippets/csharp/System.Security.Cryptography.Xml/KeyReference/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/KeyReference/Overview/sample.cs
@@ -15,7 +15,10 @@ class Program
         try
         {
             xmlDoc.PreserveWhitespace = true;
-            xmlDoc.Load("test.xml");
+            using (XmlReader reader = XmlReader.Create("test.xml"))
+            {
+                xmlDoc.Load(reader);
+            }
         }
         catch (Exception e)
         {

--- a/snippets/csharp/System.Security.Cryptography.Xml/Reference/.ctor/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/Reference/.ctor/sample.cs
@@ -29,7 +29,7 @@ public class SignVerifyEnvelope
            // Verify the signature of the signed XML.
            Console.WriteLine("Verifying signature...");
 
-           bool result = VerifyXmlFile("SignedExample.xml");
+           bool result = VerifyXmlFile("SignedExample.xml", Key);
 
            // Display the results of the signature verification to
            // the console.
@@ -72,7 +72,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -124,11 +127,13 @@ public class SignVerifyEnvelope
         xmltw.Close();
     }
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyXmlFile(String Name)
+    public static Boolean VerifyXmlFile(String Name, RSA Key)
     {
         // Check the arguments.
         if (Name == null)
             throw new ArgumentNullException("Name");
+        if (Key == null)
+            throw new ArgumentNullException("Key");
 
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
@@ -137,7 +142,10 @@ public class SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = true;
 
         // Load the passed XML file into the document.
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.
@@ -151,7 +159,7 @@ public class SignVerifyEnvelope
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(Key);
     }
 }
 //</SNIPPET1>

--- a/snippets/csharp/System.Security.Cryptography.Xml/Signature/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/Signature/Overview/sample.cs
@@ -29,7 +29,7 @@ public class SignVerifyEnvelope
            // Verify the signature of the signed XML.
            Console.WriteLine("Verifying signature...");
 
-           bool result = VerifyXmlFile("SignedExample.xml");
+           bool result = VerifyXmlFile("SignedExample.xml", Key);
 
            // Display the results of the signature verification to \
            // the console.
@@ -105,11 +105,13 @@ public class SignVerifyEnvelope
     }
 
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyXmlFile(String Name)
+    public static Boolean VerifyXmlFile(String Name, RSA Key)
     {
         // Check the arguments.
         if (Name == null)
             throw new ArgumentNullException("Name");
+        if (Key == null)
+            throw new ArgumentNullException("Key");
 
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
@@ -118,7 +120,10 @@ public class SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = true;
 
         // Load the passed XML file into the document.
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.
@@ -132,7 +137,7 @@ public class SignVerifyEnvelope
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(Key);
     }
 }
 //</SNIPPET1>

--- a/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/Project.csproj
+++ b/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/Project.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="sample.vb" />
+    <Compile Include="sample.cs" />
   </ItemGroup>
 
 </Project>

--- a/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/exampledetached.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/exampledetached.cs
@@ -101,7 +101,10 @@ class XMLDSIGDetached
         XmlDocument xmlDocument = new XmlDocument();
 
         // Load the passedXML file into the document.
-        xmlDocument.Load(XmlSigFileName);
+        using (XmlReader reader = XmlReader.Create(XmlSigFileName))
+        {
+            xmlDocument.Load(reader);
+        }
 	
         // Create a new SignedXml object.
         SignedXml signedXml = new SignedXml();

--- a/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/sample.cs
@@ -74,7 +74,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -145,7 +148,10 @@ public class SignVerifyEnvelope
         XmlDocument xmlDocument = new XmlDocument();
 
         // Load the passed XML file into the document.
-        xmlDocument.Load(FileName);
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.

--- a/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/xmldsigdetachedkeyedhashalg.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/xmldsigdetachedkeyedhashalg.cs
@@ -94,7 +94,10 @@ class XMLDSIGDetached
         XmlDocument xmlDocument = new XmlDocument();
 
         // Load the passedXML file into the document.
-        xmlDocument.Load(XmlSigFileName);
+        using (XmlReader reader = XmlReader.Create(XmlSigFileName))
+        {
+            xmlDocument.Load(reader);
+        }
 	
         // Create a new SignedXml object and pass it
         // the XML document class.

--- a/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/xmldsigenvkeyedhashalg.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/xmldsigenvkeyedhashalg.cs
@@ -62,7 +62,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -110,7 +113,10 @@ public class SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = true;
 
         // Load the passed XML file into the document. 
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXMl object and pass it
         // the XMl document class.

--- a/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignatureReturningKey/exampleenvelope.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignatureReturningKey/exampleenvelope.cs
@@ -140,20 +140,27 @@ public class SignVerifyEnvelope
 
         // Verify the signature and retrieve the key that produced it.
         AsymmetricAlgorithm signingKey;
-        if (!signedXml.CheckSignatureReturningKey(out signingKey))
-            return false;
+        bool verified = signedXml.CheckSignatureReturningKey(out signingKey);
 
-        // A valid signature only proves possession of some key.
-        // The caller must confirm the returned key matches a key it trusts.
-        if (signingKey is RSA rsa)
+        // The returned key is owned by the caller and can hold native
+        // handles, so dispose it once the comparison is complete.
+        using (signingKey)
         {
-            RSAParameters expected = TrustedKey.ExportParameters(false);
-            RSAParameters actual = rsa.ExportParameters(false);
-            return expected.Modulus.SequenceEqual(actual.Modulus)
-                && expected.Exponent.SequenceEqual(actual.Exponent);
-        }
+            if (!verified)
+                return false;
 
-        return false;
+            // A valid signature only proves possession of some key.
+            // The caller must confirm the returned key matches a key it trusts.
+            if (signingKey is RSA rsa)
+            {
+                RSAParameters expected = TrustedKey.ExportParameters(false);
+                RSAParameters actual = rsa.ExportParameters(false);
+                return expected.Modulus.SequenceEqual(actual.Modulus)
+                    && expected.Exponent.SequenceEqual(actual.Exponent);
+            }
+
+            return false;
+        }
     }
     // </Snippet3>
 

--- a/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignatureReturningKey/exampleenvelope.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignatureReturningKey/exampleenvelope.cs
@@ -5,6 +5,7 @@
 // signed XML.
 //
 using System;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Xml;
 using System.Text;
@@ -31,7 +32,7 @@ public class SignVerifyEnvelope
 
             // Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...");
-            bool result = VerifyXmlFile("SignedExample.xml");
+            bool result = VerifyXmlFile("SignedExample.xml", RSAKey);
 
             // Display the results of the signature verification to \
             // the console.
@@ -61,7 +62,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -109,7 +113,7 @@ public class SignVerifyEnvelope
     // </Snippet2>
     // <Snippet3>
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyXmlFile(String Name)
+    public static Boolean VerifyXmlFile(String Name, RSA TrustedKey)
     {
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
@@ -118,7 +122,10 @@ public class SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = true;
 
         // Load the passed XML file into the document. 
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.
@@ -131,8 +138,22 @@ public class SignVerifyEnvelope
         // Load the signature node.
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
-        // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        // Verify the signature and retrieve the key that produced it.
+        AsymmetricAlgorithm signingKey;
+        if (!signedXml.CheckSignatureReturningKey(out signingKey))
+            return false;
+
+        // A valid signature only proves possession of some key.
+        // The caller must confirm the returned key matches a key it trusts.
+        if (signingKey is RSA rsa)
+        {
+            RSAParameters expected = TrustedKey.ExportParameters(false);
+            RSAParameters actual = rsa.ExportParameters(false);
+            return expected.Modulus.SequenceEqual(actual.Modulus)
+                && expected.Exponent.SequenceEqual(actual.Exponent);
+        }
+
+        return false;
     }
     // </Snippet3>
 

--- a/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/Overview/Project.csproj
+++ b/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/Overview/Project.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="sample.vb" />
+    <Compile Include="sample.cs" />
   </ItemGroup>
 
 </Project>

--- a/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/Overview/exampleenvelope.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/Overview/exampleenvelope.cs
@@ -60,7 +60,10 @@ public class SignVerifyEnvelope
         XmlDocument doc = new XmlDocument();
 
         // Load the passed XML file using its name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -109,7 +112,10 @@ public class SignVerifyEnvelope
         XmlDocument xmlDocument = new XmlDocument();
 
         // Load the passed XML file into the document. 
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.

--- a/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/Overview/sample.cs
@@ -31,7 +31,7 @@ public class SignVerifyEnvelope
            // Verify the signature of the signed XML.
            Console.WriteLine("Verifying signature...");
 
-           bool result = VerifyXmlFile("SignedExample.xml");
+           bool result = VerifyXmlFile("SignedExample.xml", Key);
 
            // Display the results of the signature verification to
            // the console.
@@ -76,7 +76,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -127,11 +130,13 @@ public class SignVerifyEnvelope
         xmltw.Close();
     }
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyXmlFile(String Name)
+    public static Boolean VerifyXmlFile(String Name, RSA Key)
     {
         // Check the arguments.
         if (Name == null)
             throw new ArgumentNullException("Name");
+        if (Key == null)
+            throw new ArgumentNullException("Key");
 
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
@@ -140,7 +145,10 @@ public class SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = true;
 
         // Load the passed XML file into the document.
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.
@@ -154,7 +162,7 @@ public class SignVerifyEnvelope
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(Key);
     }
 }
 //</SNIPPET1>

--- a/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NTransformUrl/example.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NTransformUrl/example.cs
@@ -32,7 +32,7 @@ public class SignVerifyEnvelope
 
             // Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...");
-            bool result = VerifyXmlFile("SignedExample.xml");
+            bool result = VerifyXmlFile("SignedExample.xml", Key);
 
             // Display the results of the signature verification to \
             // the console.
@@ -61,7 +61,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -114,7 +117,7 @@ public class SignVerifyEnvelope
         xmltw.Close();
     }
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyXmlFile(String Name)
+    public static Boolean VerifyXmlFile(String Name, RSA Key)
     {
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
@@ -123,7 +126,10 @@ public class SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = true;
 
         // Load the passed XML file into the document.
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.
@@ -137,7 +143,7 @@ public class SignVerifyEnvelope
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(Key);
     }
 
     // Create example data to sign.

--- a/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NWithCommentsTransformUrl/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NWithCommentsTransformUrl/sample.cs
@@ -32,7 +32,7 @@ public class SignVerifyEnvelope
 
             // Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...");
-            bool result = VerifyXmlFile("SignedExample.xml");
+            bool result = VerifyXmlFile("SignedExample.xml", Key);
 
             // Display the results of the signature verification to
             // the console.
@@ -61,7 +61,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -114,7 +117,7 @@ public class SignVerifyEnvelope
         xmltw.Close();
     }
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyXmlFile(String Name)
+    public static Boolean VerifyXmlFile(String Name, RSA Key)
     {
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
@@ -123,7 +126,10 @@ public class SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = true;
 
         // Load the passed XML file into the document.
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.
@@ -137,7 +143,7 @@ public class SignVerifyEnvelope
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(Key);
     }
 
     // Create example data to sign.

--- a/snippets/csharp/System.Security.Cryptography.Xml/X509IssuerSerial/Overview/Project.csproj
+++ b/snippets/csharp/System.Security.Cryptography.Xml/X509IssuerSerial/Overview/Project.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/csharp/System.Security.Cryptography.Xml/X509IssuerSerial/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/X509IssuerSerial/Overview/sample.cs
@@ -74,7 +74,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -157,7 +160,10 @@ public class SignVerifyEnvelope
         XmlDocument xmlDocument = new XmlDocument();
 
         // Load the passed XML file into the document. 
-        xmlDocument.Load(FileName);
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.

--- a/snippets/csharp/System.Security.Cryptography.Xml/X509IssuerSerial/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/X509IssuerSerial/Overview/sample.cs
@@ -106,7 +106,7 @@ public class SignVerifyEnvelope
         
         KeyInfoX509Data kdata = new KeyInfoX509Data(cert);
 
-        X509IssuerSerial xserial;
+        X509IssuerSerial xserial = default;
 
         xserial.IssuerName = cert.IssuerName.ToString();
         xserial.SerialNumber = cert.SerialNumber;

--- a/snippets/csharp/System.Security.Cryptography.Xml/XmlDsigC14NWithCommentsTransform/Overview/sampledetached.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/XmlDsigC14NWithCommentsTransform/Overview/sampledetached.cs
@@ -40,7 +40,7 @@ class XMLDSIGDetached
             Console.WriteLine("Verifying signature...");
 
             //Verify the XML signature in the XML file.
-            bool result = VerifyDetachedSignature(XmlFileName);
+            bool result = VerifyDetachedSignature(XmlFileName, Key);
 
             // Display the results of the signature verification to 
             // the console.
@@ -99,13 +99,16 @@ class XMLDSIGDetached
     // </Snippet2>
     // <Snippet3>
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyDetachedSignature(string XmlSigFileName)
+    public static Boolean VerifyDetachedSignature(string XmlSigFileName, RSA Key)
     {	
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
 
         // Load the passed XML file into the document.
-        xmlDocument.Load(XmlSigFileName);
+        using (XmlReader reader = XmlReader.Create(XmlSigFileName))
+        {
+            xmlDocument.Load(reader);
+        }
 	
         // Create a new SignedXMl object.
         SignedXml signedXml = new SignedXml();
@@ -118,7 +121,7 @@ class XMLDSIGDetached
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(Key);
     }
     // </Snippet3>
 }

--- a/snippets/csharp/System.Security.Cryptography.Xml/XmlDsigC14NWithCommentsTransform/Overview/sampleenvelope.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/XmlDsigC14NWithCommentsTransform/Overview/sampleenvelope.cs
@@ -30,7 +30,7 @@ public class SignVerifyEnvelope
 
             // Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...");
-            bool result = VerifyXmlFile("SignedExample.xml");
+            bool result = VerifyXmlFile("SignedExample.xml", Key);
 
             // Display the results of the signature verification to \
             // the console.
@@ -60,7 +60,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -108,7 +111,7 @@ public class SignVerifyEnvelope
     // </Snippet2>
     // <Snippet3>
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyXmlFile(String Name)
+    public static Boolean VerifyXmlFile(String Name, RSA Key)
     {
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
@@ -117,7 +120,10 @@ public class SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = true;
 
         // Load the passed XML file into the document. 
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.
@@ -131,7 +137,7 @@ public class SignVerifyEnvelope
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(Key);
     }
     // </Snippet3>
 

--- a/snippets/csharp/System.Security.Cryptography.Xml/XmlDsigXPathTransform/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/XmlDsigXPathTransform/Overview/sample.cs
@@ -32,7 +32,7 @@ public class SignVerifyEnvelope
 
             // Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...");
-            bool result = VerifyXmlFile("SignedExample.xml");
+            bool result = VerifyXmlFile("SignedExample.xml", Key);
 
             // Display the results of the signature verification to \
             // the console.
@@ -65,7 +65,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -111,7 +114,7 @@ public class SignVerifyEnvelope
         xmltw.Close();
     }
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyXmlFile(String Name)
+    public static Boolean VerifyXmlFile(String Name, RSA Key)
     {
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
@@ -120,7 +123,10 @@ public class SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = true;
 
         // Load the passed XML file into the document.
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.
@@ -134,7 +140,7 @@ public class SignVerifyEnvelope
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(Key);
     }
 
     // Create the XML that represents the transform.

--- a/snippets/csharp/System.Security.Cryptography.Xml/XmlDsigXsltTransform/Overview/sample.cs
+++ b/snippets/csharp/System.Security.Cryptography.Xml/XmlDsigXsltTransform/Overview/sample.cs
@@ -42,7 +42,7 @@ public class SignVerifyEnvelope
 
             // Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...");
-            bool result = VerifyXmlFile("SignedExample.xml");
+            bool result = VerifyXmlFile("SignedExample.xml", Key);
 
             // Display the results of the signature verification to \
             // the console.
@@ -75,7 +75,10 @@ public class SignVerifyEnvelope
         doc.PreserveWhitespace = false;
 
         // Load the passed XML file using it's name.
-        doc.Load(new XmlTextReader(FileName));
+        using (XmlReader reader = XmlReader.Create(FileName))
+        {
+            doc.Load(reader);
+        }
 
         // Create a SignedXml object.
         SignedXml signedXml = new SignedXml(doc);
@@ -125,7 +128,7 @@ public class SignVerifyEnvelope
         xmltw.Close();
     }
     // Verify the signature of an XML file and return the result.
-    public static Boolean VerifyXmlFile(String Name)
+    public static Boolean VerifyXmlFile(String Name, RSA Key)
     {
         // Create a new XML document.
         XmlDocument xmlDocument = new XmlDocument();
@@ -134,7 +137,10 @@ public class SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = true;
 
         // Load the passed XML file into the document.
-        xmlDocument.Load(Name);
+        using (XmlReader reader = XmlReader.Create(Name))
+        {
+            xmlDocument.Load(reader);
+        }
 
         // Create a new SignedXml object and pass it
         // the XML document class.
@@ -148,7 +154,7 @@ public class SignVerifyEnvelope
         signedXml.LoadXml((XmlElement)nodeList[0]);
 
         // Check the signature and return the result.
-        return signedXml.CheckSignature();
+        return signedXml.CheckSignature(Key);
     }
 
     // Create the XML that represents the transform.

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/DSAKeyValue/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/DSAKeyValue/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/DSAKeyValue/Overview/exampledetached.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/DSAKeyValue/Overview/exampledetached.vb
@@ -37,7 +37,7 @@ Class XMLDSIGDetached
          Console.WriteLine("Verifying signature...")
          
          'Verify the XML signature in the XML file.
-         Dim result As Boolean = VerifyDetachedSignature(XmlFileName)
+         Dim result As Boolean = VerifyDetachedSignature(XmlFileName, DSAKey)
          
          ' Display the results of the signature verification to 
          ' the console.
@@ -94,12 +94,14 @@ Class XMLDSIGDetached
 
    ' <Snippet3>
    ' Verify the signature of an XML file and return the result.
-   Public Shared Function VerifyDetachedSignature(XmlSigFileName As String) As [Boolean]
+   Public Shared Function VerifyDetachedSignature(XmlSigFileName As String, DSAKey As DSA) As [Boolean]
       ' Create a new XML document.
       Dim xmlDocument As New XmlDocument()
       
       ' Load the passed XML file into the document.
-      xmlDocument.Load(XmlSigFileName)
+      Using reader As XmlReader = XmlReader.Create(XmlSigFileName)
+         xmlDocument.Load(reader)
+      End Using
       
       ' Create a new SignedXMl object.
       Dim signedXml As New SignedXml()
@@ -112,7 +114,7 @@ Class XMLDSIGDetached
       signedXml.LoadXml(CType(nodeList(0), XmlElement))
       
       ' Check the signature and return the result.
-      Return signedXml.CheckSignature()
+      Return signedXml.CheckSignature(DSAKey)
    End Function 
 ' </Snippet3>
 

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/DSAKeyValue/Overview/exampleenvelope.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/DSAKeyValue/Overview/exampleenvelope.vb
@@ -30,7 +30,7 @@ Public Class SignVerifyEnvelope
          
          ' Verify the signature of the signed XML.
          Console.WriteLine("Verifying signature...")
-         Dim result As Boolean = VerifyXmlFile("SignedExample.xml")
+         Dim result As Boolean = VerifyXmlFile("SignedExample.xml", DSAKey)
          
          ' Display the results of the signature verification to \
          ' the console.
@@ -55,7 +55,9 @@ Public Class SignVerifyEnvelope
       doc.PreserveWhitespace = False
       
       ' Load the passed XML file using it's name.
-      doc.Load(New XmlTextReader(FileName))
+      Using reader As XmlReader = XmlReader.Create(FileName)
+         doc.Load(reader)
+      End Using
       
       ' Create a SignedXml object.
       Dim signedXml As New SignedXml(doc)
@@ -109,7 +111,7 @@ Public Class SignVerifyEnvelope
    ' </Snippet2>
    ' <Snippet3>
    ' Verify the signature of an XML file and return the result.
-   Public Shared Function VerifyXmlFile(Name As [String]) As [Boolean]
+   Public Shared Function VerifyXmlFile(Name As [String], DSAKey As DSA) As [Boolean]
       ' Create a new XML document.
       Dim xmlDocument As New XmlDocument()
       
@@ -117,7 +119,9 @@ Public Class SignVerifyEnvelope
       xmlDocument.PreserveWhitespace = True
       
       ' Load the passed XML file into the document. 
-      xmlDocument.Load(Name)
+      Using reader As XmlReader = XmlReader.Create(Name)
+         xmlDocument.Load(reader)
+      End Using
       
       ' Create a new SignedXml object and pass it
       ' the XML document class.
@@ -131,7 +135,7 @@ Public Class SignVerifyEnvelope
       signedXml.LoadXml(CType(nodeList(0), XmlElement))
       
       ' Check the signature and return the result.
-      Return signedXml.CheckSignature()
+      Return signedXml.CheckSignature(DSAKey)
    End Function 
    
    ' </Snippet3>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/DataObject/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/DataObject/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/DataObject/Overview/source1.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/DataObject/Overview/source1.vb
@@ -1,33 +1,31 @@
 ﻿'<Snippet1>
+Imports System
 Imports System.Security.Cryptography
 Imports System.Security.Cryptography.Xml
-Imports System.IO
 Imports System.Xml
 
- _
-
 Public Class Verify
-   
-   Public Shared Sub Main(args() As [String])
-      
-      Console.WriteLine(("Verifying " + args(0) + "..."))
-      
-      ' Create a SignedXml.
-      Dim signedXml As New SignedXml()
-      
-      ' Load the XML.
-      Dim xmlDocument As New XmlDocument()
-      xmlDocument.PreserveWhitespace = True
-      xmlDocument.Load(New XmlTextReader(args(0)))
-      
-      Dim nodeList As XmlNodeList = xmlDocument.GetElementsByTagName("Signature")
-      signedXml.LoadXml(CType(nodeList(0), XmlElement))
-      
-      If signedXml.CheckSignature() Then
-         Console.WriteLine("Signature check OK")
-      Else
-         Console.WriteLine("Signature check FAILED")
-      End If
-   End Sub
+    Public Shared Sub Main(ByVal args As String())
+        Console.WriteLine("Verifying " & args(0) & "...")
+
+        Dim trustedKey As RSA = RSA.Create()
+        ' ... load trustedKey from an out-of-band source ...
+
+        Dim xmlDocument As New XmlDocument()
+        xmlDocument.PreserveWhitespace = True
+        Using reader As XmlReader = XmlReader.Create(args(0))
+            xmlDocument.Load(reader)
+        End Using
+
+        Dim signedXml As New SignedXml(xmlDocument)
+        Dim nodeList As XmlNodeList = xmlDocument.GetElementsByTagName("Signature")
+        signedXml.LoadXml(CType(nodeList(0), XmlElement))
+
+        If signedXml.CheckSignature(trustedKey) Then
+            Console.WriteLine("Signature check OK")
+        Else
+            Console.WriteLine("Signature check FAILED")
+        End If
+    End Sub
 End Class
 '</Snippet1>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/DataReference/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/DataReference/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/DataReference/Overview/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/DataReference/Overview/sample.vb
@@ -14,7 +14,9 @@ Module Program
         ' Load an XML file into the XmlDocument object.
         Try
             xmlDoc.PreserveWhitespace = True
-            xmlDoc.Load("test.xml")
+            Using reader As XmlReader = XmlReader.Create("test.xml")
+               xmlDoc.Load(reader)
+            End Using
         Catch e As Exception
             Console.WriteLine(e.Message)
         End Try

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedData/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedData/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedData/Overview/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedData/Overview/sample.vb
@@ -15,7 +15,9 @@ Module Program
         ' Load an XML file into the XmlDocument object.
         Try
             xmlDoc.PreserveWhitespace = True
-            xmlDoc.Load("test.xml")
+            Using reader As XmlReader = XmlReader.Create("test.xml")
+               xmlDoc.Load(reader)
+            End Using
         Catch e As Exception
             Console.WriteLine(e.Message)
         End Try

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedKey/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedKey/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedKey/Overview/example.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedKey/Overview/example.vb
@@ -15,7 +15,9 @@ Module Program
         ' Load an XML file into the XmlDocument object.
         Try
             xmlDoc.PreserveWhitespace = True
-            xmlDoc.Load("test.xml")
+            Using reader As XmlReader = XmlReader.Create("test.xml")
+               xmlDoc.Load(reader)
+            End Using
         Catch e As Exception
             Console.WriteLine(e.Message)
         End Try

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedType/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedType/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedType/Overview/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedType/Overview/sample.vb
@@ -15,7 +15,9 @@ Module Program
         ' Load an XML file into the XmlDocument object.
         Try
             xmlDoc.PreserveWhitespace = True
-            xmlDoc.Load("test.xml")
+            Using reader As XmlReader = XmlReader.Create("test.xml")
+               xmlDoc.Load(reader)
+            End Using
         Catch e As Exception
             Console.WriteLine(e.Message)
         End Try

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/AddKeyNameMapping/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/AddKeyNameMapping/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/AddKeyNameMapping/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/AddKeyNameMapping/sample.vb
@@ -15,7 +15,9 @@ Module Program
         ' Load an XML file into the XmlDocument object.
         Try
             xmlDoc.PreserveWhitespace = True
-            xmlDoc.Load("test.xml")
+            Using reader As XmlReader = XmlReader.Create("test.xml")
+               xmlDoc.Load(reader)
+            End Using
         Catch e As Exception
             Console.WriteLine(e.Message)
         End Try

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample.vb
@@ -14,7 +14,9 @@ Module Program
 
         ' Load an XML file into the XmlDocument object.
         xmlDoc.PreserveWhitespace = True
-        xmlDoc.Load("test.xml")
+        Using reader As XmlReader = XmlReader.Create("test.xml")
+           xmlDoc.Load(reader)
+        End Using
 
 
         ' Create a new TripleDES key. 

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample1.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample1.vb
@@ -15,7 +15,9 @@ Module Program
         ' Load an XML file into the XmlDocument object.
         Try
             xmlDoc.PreserveWhitespace = True
-            xmlDoc.Load("test.xml")
+            Using reader As XmlReader = XmlReader.Create("test.xml")
+               xmlDoc.Load(reader)
+            End Using
         Catch e As Exception
             Console.WriteLine(e.Message)
             Return

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample2.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample2.vb
@@ -15,7 +15,9 @@ Module Program
         ' Load an XML file into the XmlDocument object.
         Try
             xmlDoc.PreserveWhitespace = True
-            xmlDoc.Load("test.xml")
+            Using reader As XmlReader = XmlReader.Create("test.xml")
+               xmlDoc.Load(reader)
+            End Using
         Catch e As Exception
             Console.WriteLine(e.Message)
             Return

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample3.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample3.vb
@@ -16,7 +16,9 @@ Module Program
         ' Load an XML file into the XmlDocument object.
         Try
             xmlDoc.PreserveWhitespace = True
-            xmlDoc.Load("test.xml")
+            Using reader As XmlReader = XmlReader.Create("test.xml")
+               xmlDoc.Load(reader)
+            End Using
         Catch e As Exception
             Console.WriteLine(e.Message)
             Return

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample4.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample4.vb
@@ -15,7 +15,9 @@ Module Program
         ' Load an XML file into the XmlDocument object.
         Try
             xmlDoc.PreserveWhitespace = True
-            xmlDoc.Load("test.xml")
+            Using reader As XmlReader = XmlReader.Create("test.xml")
+               xmlDoc.Load(reader)
+            End Using
         Catch e As Exception
             Console.WriteLine(e.Message)
             Return

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptionProperty/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptionProperty/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptionProperty/Overview/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/EncryptionProperty/Overview/sample.vb
@@ -15,7 +15,9 @@ Module Program
         ' Load an XML file into the XmlDocument object.
         Try
             xmlDoc.PreserveWhitespace = True
-            xmlDoc.Load("test.xml")
+            Using reader As XmlReader = XmlReader.Create("test.xml")
+               xmlDoc.Load(reader)
+            End Using
         Catch e As Exception
             Console.WriteLine(e.Message)
         End Try

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/IRelDecryptor/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/IRelDecryptor/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/IRelDecryptor/Overview/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/IRelDecryptor/Overview/sample.vb
@@ -13,7 +13,7 @@ Class XmlLicenseTransformExample
 
 
     '<SNIPPET2>
-    Public Shared Sub CheckSignatureWithEncryptedGrant(ByVal fileName As String, ByVal decryptor As IRelDecryptor)
+    Public Shared Sub CheckSignatureWithEncryptedGrant(ByVal fileName As String, ByVal decryptor As IRelDecryptor, ByVal trustedKey As AsymmetricAlgorithm)
         ' Create a new XML document.
         Dim xmlDocument As New XmlDocument()
         Dim nsManager As New XmlNamespaceManager(xmlDocument.NameTable)
@@ -22,7 +22,9 @@ Class XmlLicenseTransformExample
         xmlDocument.PreserveWhitespace = True
 
         ' Load the passed XML file into the document. 
-        xmlDocument.Load(fileName)
+        Using reader As XmlReader = XmlReader.Create(fileName)
+           xmlDocument.Load(reader)
+        End Using
         nsManager.AddNamespace("dsig", SignedXml.XmlDsigNamespaceUrl)
 
         ' Find the "Signature" node and create a new XmlNodeList object.
@@ -54,7 +56,7 @@ Class XmlLicenseTransformExample
             End If
 
             ' Check the signature and display the result.
-            Dim result As Boolean = signedXml.CheckSignature()
+            Dim result As Boolean = signedXml.CheckSignature(trustedKey)
 
             If result Then
                 Console.WriteLine("SUCCESS: CheckSignatureWithEncryptedGrant - issuer index #" + i.ToString())

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfo/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfo/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfo/Overview/xmldsigdetach.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfo/Overview/xmldsigdetach.vb
@@ -37,7 +37,7 @@ Class XMLDSIGDetached
          Console.WriteLine("Verifying signature...")
          
          'Verify the XML signature in the XML file.
-         Dim result As Boolean = VerifyDetachedSignature(XmlFileName)
+         Dim result As Boolean = VerifyDetachedSignature(XmlFileName, Key)
          
          ' Display the results of the signature verification to 
          ' the console.
@@ -92,12 +92,14 @@ Class XMLDSIGDetached
  
 ' <Snippet3> 
    ' Verify the signature of an XML file and return the result.
-   Public Shared Function VerifyDetachedSignature(XmlSigFileName As String) As [Boolean]
+   Public Shared Function VerifyDetachedSignature(XmlSigFileName As String, Key As RSA) As [Boolean]
       ' Create a new XML document.
       Dim xmlDocument As New XmlDocument()
       
       ' Load the passed XML file into the document.
-      xmlDocument.Load(XmlSigFileName)
+      Using reader As XmlReader = XmlReader.Create(XmlSigFileName)
+         xmlDocument.Load(reader)
+      End Using
       
       ' Create a new SignedXMl object.
       Dim signedXml As New SignedXml()
@@ -110,7 +112,7 @@ Class XMLDSIGDetached
       signedXml.LoadXml(CType(nodeList(0), XmlElement))
       
       ' Check the signature and return the result.
-      Return signedXml.CheckSignature()
+      Return signedXml.CheckSignature(Key)
    End Function
 ' </Snippet3>  
 End Class 

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfo/Overview/xmldsigenv.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfo/Overview/xmldsigenv.vb
@@ -30,7 +30,7 @@ Public Class SignVerifyEnvelope
          
          ' Verify the signature of the signed XML.
          Console.WriteLine("Verifying signature...")
-         Dim result As Boolean = VerifyXmlFile("SignedExample.xml")
+         Dim result As Boolean = VerifyXmlFile("SignedExample.xml", Key)
          
          ' Display the results of the signature verification to \
          ' the console.
@@ -55,7 +55,9 @@ Public Class SignVerifyEnvelope
       doc.PreserveWhitespace = False
       
       ' Load the passed XML file using it's name.
-      doc.Load(New XmlTextReader(FileName))
+      Using reader As XmlReader = XmlReader.Create(FileName)
+         doc.Load(reader)
+      End Using
       
       ' Create a SignedXml object.
       Dim signedXml As New SignedXml(doc)
@@ -104,7 +106,7 @@ Public Class SignVerifyEnvelope
 ' </Snippet2>   
 ' <Snippet3> 
    ' Verify the signature of an XML file and return the result.
-   Public Shared Function VerifyXmlFile(Name As [String]) As [Boolean]
+   Public Shared Function VerifyXmlFile(Name As [String], Key As RSA) As [Boolean]
       ' Create a new XML document.
       Dim xmlDocument As New XmlDocument()
       
@@ -112,7 +114,9 @@ Public Class SignVerifyEnvelope
       xmlDocument.PreserveWhitespace = True
       
       ' Load the passed XML file into the document. 
-      xmlDocument.Load(Name)
+      Using reader As XmlReader = XmlReader.Create(Name)
+         xmlDocument.Load(reader)
+      End Using
       
       ' Create a new SignedXml object and pass it
       ' the XML document class.
@@ -126,7 +130,7 @@ Public Class SignVerifyEnvelope
       signedXml.LoadXml(CType(nodeList(0), XmlElement))
       
       ' Check the signature and return the result.
-      Return signedXml.CheckSignature()
+      Return signedXml.CheckSignature(Key)
    End Function 
 ' </Snippet3>  
    

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfoX509Data/.ctor/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfoX509Data/.ctor/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfoX509Data/.ctor/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfoX509Data/.ctor/sample.vb
@@ -70,7 +70,9 @@ Module SignVerifyEnvelope
         doc.PreserveWhitespace = False
 
         ' Load the passed XML file using it's name.
-        doc.Load(New XmlTextReader(FileName))
+        Using reader As XmlReader = XmlReader.Create(FileName)
+           doc.Load(reader)
+        End Using
 
         ' Create a SignedXml object.
         Dim signedXml As New SignedXml(doc)
@@ -146,7 +148,9 @@ Module SignVerifyEnvelope
         Dim xmlDocument As New XmlDocument()
 
         ' Load the passed XML file into the document. 
-        xmlDocument.Load(FileName)
+        Using reader As XmlReader = XmlReader.Create(FileName)
+           xmlDocument.Load(reader)
+        End Using
 
         ' Create a new SignedXml object and pass it
         ' the XML document class.

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfoX509Data/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfoX509Data/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfoX509Data/Overview/examplecreateenvelope.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/KeyInfoX509Data/Overview/examplecreateenvelope.vb
@@ -47,7 +47,9 @@ Public Class SignVerifyEnvelope
       doc.PreserveWhitespace = False
       
       ' Load the passed XML file using it's name.
-      doc.Load(New XmlTextReader(FileName))
+      Using reader As XmlReader = XmlReader.Create(FileName)
+         doc.Load(reader)
+      End Using
       
       ' Create a SignedXml object.
       Dim signedXml As New SignedXml(doc)

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/KeyReference/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/KeyReference/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/KeyReference/Overview/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/KeyReference/Overview/sample.vb
@@ -14,7 +14,9 @@ Module Program
         ' Load an XML file into the XmlDocument object.
         Try
             xmlDoc.PreserveWhitespace = True
-            xmlDoc.Load("test.xml")
+            Using reader As XmlReader = XmlReader.Create("test.xml")
+               xmlDoc.Load(reader)
+            End Using
         Catch e As Exception
             Console.WriteLine(e.Message)
         End Try

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/Reference/.ctor/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/Reference/.ctor/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/Reference/.ctor/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/Reference/.ctor/sample.vb
@@ -27,7 +27,7 @@ Module SignVerifyEnvelope
             ' Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...")
 
-            Dim result As Boolean = VerifyXmlFile("SignedExample.xml")
+            Dim result As Boolean = VerifyXmlFile("SignedExample.xml", Key)
 
             ' Display the results of the signature verification to 
             ' the console.
@@ -67,7 +67,9 @@ Module SignVerifyEnvelope
         doc.PreserveWhitespace = False
 
         ' Load the passed XML file using it's name.
-        doc.Load(New XmlTextReader(FileName))
+        Using reader As XmlReader = XmlReader.Create(FileName)
+           doc.Load(reader)
+        End Using
 
         ' Create a SignedXml object.
         Dim signedXml As New SignedXml(doc)
@@ -121,10 +123,13 @@ Module SignVerifyEnvelope
     End Sub
 
     ' Verify the signature of an XML file and return the result.
-    Function VerifyXmlFile(ByVal Name As String) As [Boolean]
+    Function VerifyXmlFile(ByVal Name As String, Key As RSA) As [Boolean]
         ' Check the arguments.  
         If Name Is Nothing Then
             Throw New ArgumentNullException("Name")
+        End If
+        If Key Is Nothing Then
+            Throw New ArgumentNullException("Key")
         End If
         ' Create a new XML document.
         Dim xmlDocument As New XmlDocument()
@@ -133,7 +138,9 @@ Module SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = True
 
         ' Load the passed XML file into the document. 
-        xmlDocument.Load(Name)
+        Using reader As XmlReader = XmlReader.Create(Name)
+           xmlDocument.Load(reader)
+        End Using
 
         ' Create a new SignedXml object and pass it
         ' the XML document class.
@@ -147,7 +154,7 @@ Module SignVerifyEnvelope
         signedXml.LoadXml(CType(nodeList(0), XmlElement))
 
         ' Check the signature and return the result.
-        Return signedXml.CheckSignature()
+        Return signedXml.CheckSignature(Key)
 
     End Function
 End Module

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/Signature/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/Signature/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/Signature/Overview/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/Signature/Overview/sample.vb
@@ -27,7 +27,7 @@ Module SignVerifyEnvelope
             ' Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...")
 
-            Dim result As Boolean = VerifyXmlFile("SignedExample.xml")
+            Dim result As Boolean = VerifyXmlFile("SignedExample.xml", Key)
 
             ' Display the results of the signature verification to \
             ' the console.
@@ -102,10 +102,13 @@ Module SignVerifyEnvelope
 
 
     ' Verify the signature of an XML file and return the result.
-    Function VerifyXmlFile(ByVal Name As String) As [Boolean]
+    Function VerifyXmlFile(ByVal Name As String, Key As RSA) As [Boolean]
         ' Check the arguments.  
         If Name Is Nothing Then
             Throw New ArgumentNullException("Name")
+        End If
+        If Key Is Nothing Then
+            Throw New ArgumentNullException("Key")
         End If
         ' Create a new XML document.
         Dim xmlDocument As New XmlDocument()
@@ -114,7 +117,9 @@ Module SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = True
 
         ' Load the passed XML file into the document. 
-        xmlDocument.Load(Name)
+        Using reader As XmlReader = XmlReader.Create(Name)
+           xmlDocument.Load(reader)
+        End Using
 
         ' Create a new SignedXml object and pass it
         ' the XML document class.
@@ -128,7 +133,7 @@ Module SignVerifyEnvelope
         signedXml.LoadXml(CType(nodeList(0), XmlElement))
 
         ' Check the signature and return the result.
-        Return signedXml.CheckSignature()
+        Return signedXml.CheckSignature(Key)
 
     End Function
 End Module

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignature/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignature/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignature/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignature/Project.vbproj
@@ -4,6 +4,11 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net10.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="sample.vb" />
+  </ItemGroup>
 
 </Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignature/exampledetached.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignature/exampledetached.vb
@@ -96,7 +96,9 @@ Class XMLDSIGDetached
       Dim xmlDocument As New XmlDocument()
       
       ' Load the passedXML file into the document.
-      xmlDocument.Load(XmlSigFileName)
+      Using reader As XmlReader = XmlReader.Create(XmlSigFileName)
+         xmlDocument.Load(reader)
+      End Using
       
       ' Create a new SignedXml object.
       Dim signedXml As New SignedXml()

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignature/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignature/sample.vb
@@ -70,7 +70,9 @@ Module SignVerifyEnvelope
         doc.PreserveWhitespace = False
 
         ' Load the passed XML file using it's name.
-        doc.Load(New XmlTextReader(FileName))
+        Using reader As XmlReader = XmlReader.Create(FileName)
+           doc.Load(reader)
+        End Using
 
         ' Create a SignedXml object.
         Dim signedXml As New SignedXml(doc)
@@ -144,7 +146,9 @@ Module SignVerifyEnvelope
         Dim xmlDocument As New XmlDocument()
 
         ' Load the passed XML file into the document. 
-        xmlDocument.Load(FileName)
+        Using reader As XmlReader = XmlReader.Create(FileName)
+           xmlDocument.Load(reader)
+        End Using
 
         ' Create a new SignedXml object and pass it
         ' the XML document class.

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignature/xmldsigdetachedkeyedhashalg.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignature/xmldsigdetachedkeyedhashalg.vb
@@ -87,7 +87,9 @@ Class XMLDSIGDetached
       Dim xmlDocument As New XmlDocument()
       
       ' Load the passedXML file into the document.
-      xmlDocument.Load(XmlSigFileName)
+      Using reader As XmlReader = XmlReader.Create(XmlSigFileName)
+         xmlDocument.Load(reader)
+      End Using
       
       ' Create a new SignedXml object and pass it
       ' the XML document class.

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignature/xmldsigenvkeyedhashalg.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignature/xmldsigenvkeyedhashalg.vb
@@ -57,7 +57,9 @@ Public Class SignVerifyEnvelope
       doc.PreserveWhitespace = False
       
       ' Load the passed XML file using it's name.
-      doc.Load(New XmlTextReader(FileName))
+      Using reader As XmlReader = XmlReader.Create(FileName)
+         doc.Load(reader)
+      End Using
       
       ' Create a SignedXml object.
       Dim signedXml As New SignedXml(doc)
@@ -105,7 +107,9 @@ Public Class SignVerifyEnvelope
       xmlDocument.PreserveWhitespace = True
       
       ' Load the passed XML file into the document. 
-      xmlDocument.Load(Name)
+      Using reader As XmlReader = XmlReader.Create(Name)
+         xmlDocument.Load(reader)
+      End Using
       
       ' Create a new SignedXMl object and pass it
       ' the XMl document class.

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignatureReturningKey/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignatureReturningKey/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignatureReturningKey/exampleenvelope.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/CheckSignatureReturningKey/exampleenvelope.vb
@@ -4,6 +4,7 @@
 ' envelope signature. It then verifies the 
 ' signed XML.
 '
+Imports System.Linq
 Imports System.Security.Cryptography
 Imports System.Security.Cryptography.Xml
 Imports System.Text
@@ -30,7 +31,7 @@ Public Class SignVerifyEnvelope
          
          ' Verify the signature of the signed XML.
          Console.WriteLine("Verifying signature...")
-         Dim result As Boolean = VerifyXmlFile("SignedExample.xml")
+         Dim result As Boolean = VerifyXmlFile("SignedExample.xml", RSAKey)
          
          ' Display the results of the signature verification to \
          ' the console.
@@ -55,7 +56,9 @@ Public Class SignVerifyEnvelope
       doc.PreserveWhitespace = False
       
       ' Load the passed XML file using it's name.
-      doc.Load(New XmlTextReader(FileName))
+      Using reader As XmlReader = XmlReader.Create(FileName)
+         doc.Load(reader)
+      End Using
       
       ' Create a SignedXml object.
       Dim signedXml As New SignedXml(doc)
@@ -105,7 +108,7 @@ Public Class SignVerifyEnvelope
    ' </Snippet2>
    ' <Snippet3>
    ' Verify the signature of an XML file and return the result.
-   Public Shared Function VerifyXmlFile(Name As [String]) As [Boolean]
+   Public Shared Function VerifyXmlFile(Name As [String], TrustedKey As RSA) As [Boolean]
       ' Create a new XML document.
       Dim xmlDocument As New XmlDocument()
       
@@ -113,7 +116,9 @@ Public Class SignVerifyEnvelope
       xmlDocument.PreserveWhitespace = True
       
       ' Load the passed XML file into the document. 
-      xmlDocument.Load(Name)
+      Using reader As XmlReader = XmlReader.Create(Name)
+         xmlDocument.Load(reader)
+      End Using
       
       ' Create a new SignedXml object and pass it
       ' the XML document class.
@@ -126,8 +131,28 @@ Public Class SignVerifyEnvelope
       ' Load the signature node.
       signedXml.LoadXml(CType(nodeList(0), XmlElement))
       
-      ' Check the signature and return the result.
-      Return signedXml.CheckSignature()
+      ' Verify the signature and retrieve the key that produced it.
+      Dim signingKey As AsymmetricAlgorithm = Nothing
+      Dim verified As Boolean = signedXml.CheckSignatureReturningKey(signingKey)
+
+      ' The returned key is owned by the caller and can hold native
+      ' handles, so dispose it once the comparison is complete.
+      Using signingKey
+         If Not verified Then
+            Return False
+         End If
+
+         ' A valid signature only proves possession of some key.
+         ' The caller must confirm the returned key matches a key it trusts.
+         If TypeOf signingKey Is RSA Then
+            Dim rsa As RSA = CType(signingKey, RSA)
+            Dim expected As RSAParameters = TrustedKey.ExportParameters(False)
+            Dim actual As RSAParameters = rsa.ExportParameters(False)
+            Return expected.Modulus.SequenceEqual(actual.Modulus) AndAlso expected.Exponent.SequenceEqual(actual.Exponent)
+         End If
+
+         Return False
+      End Using
    End Function 
    
    ' </Snippet3>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/Overview/Project.vbproj
@@ -4,6 +4,11 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net10.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="sample.vb" />
+  </ItemGroup>
 
 </Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/Overview/exampleenvelope.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/Overview/exampleenvelope.vb
@@ -54,7 +54,9 @@ Public Class SignVerifyEnvelope
       Dim doc As New XmlDocument()
       
       ' Load the passed XML file using its name.
-      doc.Load(New XmlTextReader(FileName))
+      Using reader As XmlReader = XmlReader.Create(FileName)
+         doc.Load(reader)
+      End Using
       
       ' Create a SignedXml object.
       Dim signedXml As New SignedXml(doc)
@@ -102,7 +104,9 @@ Public Class SignVerifyEnvelope
       Dim xmlDocument As New XmlDocument()
       
       ' Load the passed XML file into the document. 
-      xmlDocument.Load(Name)
+      Using reader As XmlReader = XmlReader.Create(Name)
+         xmlDocument.Load(reader)
+      End Using
       
       ' Create a new SignedXml object and pass it
       ' the XML document class.

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/Overview/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/Overview/sample.vb
@@ -30,7 +30,7 @@ Module SignVerifyEnvelope
             ' Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...")
 
-            Dim result As Boolean = VerifyXmlFile("SignedExample.xml")
+            Dim result As Boolean = VerifyXmlFile("SignedExample.xml", Key)
 
             ' Display the results of the signature verification to \
             ' the console.
@@ -72,7 +72,9 @@ Module SignVerifyEnvelope
         doc.PreserveWhitespace = False
 
         ' Load the passed XML file using it's name.
-        doc.Load(New XmlTextReader(FileName))
+        Using reader As XmlReader = XmlReader.Create(FileName)
+           doc.Load(reader)
+        End Using
 
         ' Create a SignedXml object.
         Dim signedXml As New SignedXml(doc)
@@ -125,10 +127,13 @@ Module SignVerifyEnvelope
     End Sub
 
     ' Verify the signature of an XML file and return the result.
-    Function VerifyXmlFile(ByVal Name As String) As [Boolean]
+    Function VerifyXmlFile(ByVal Name As String, Key As RSA) As [Boolean]
         ' Check the arguments.  
         If Name Is Nothing Then
             Throw New ArgumentNullException("Name")
+        End If
+        If Key Is Nothing Then
+            Throw New ArgumentNullException("Key")
         End If
         ' Create a new XML document.
         Dim xmlDocument As New XmlDocument()
@@ -137,7 +142,9 @@ Module SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = True
 
         ' Load the passed XML file into the document. 
-        xmlDocument.Load(Name)
+        Using reader As XmlReader = XmlReader.Create(Name)
+           xmlDocument.Load(reader)
+        End Using
 
         ' Create a new SignedXml object and pass it
         ' the XML document class.
@@ -151,7 +158,7 @@ Module SignVerifyEnvelope
         signedXml.LoadXml(CType(nodeList(0), XmlElement))
 
         ' Check the signature and return the result.
-        Return signedXml.CheckSignature()
+        Return signedXml.CheckSignature(Key)
 
     End Function
 End Module

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NTransformUrl/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NTransformUrl/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NTransformUrl/example.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NTransformUrl/example.vb
@@ -31,7 +31,7 @@ Module SignVerifyEnvelope
 
             ' Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...")
-            Dim result As Boolean = VerifyXmlFile("SignedExample.xml")
+            Dim result As Boolean = VerifyXmlFile("SignedExample.xml", Key)
 
             ' Display the results of the signature verification to 
             ' the console.
@@ -57,7 +57,9 @@ Module SignVerifyEnvelope
         doc.PreserveWhitespace = False
 
         ' Load the passed XML file using it's name.
-        doc.Load(New XmlTextReader(FileName))
+        Using reader As XmlReader = XmlReader.Create(FileName)
+           doc.Load(reader)
+        End Using
 
         ' Create a SignedXml object.
         Dim signedXml As New SignedXml(doc)
@@ -113,7 +115,7 @@ Module SignVerifyEnvelope
     End Sub
 
     ' Verify the signature of an XML file and return the result.
-    Function VerifyXmlFile(ByVal Name As String) As [Boolean]
+    Function VerifyXmlFile(ByVal Name As String, Key As RSA) As [Boolean]
         ' Create a new XML document.
         Dim xmlDocument As New XmlDocument()
 
@@ -121,7 +123,9 @@ Module SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = True
 
         ' Load the passed XML file into the document. 
-        xmlDocument.Load(Name)
+        Using reader As XmlReader = XmlReader.Create(Name)
+           xmlDocument.Load(reader)
+        End Using
 
         ' Create a new SignedXml object and pass it
         ' the XML document class.
@@ -135,7 +139,7 @@ Module SignVerifyEnvelope
         signedXml.LoadXml(CType(nodeList(0), XmlElement))
 
         ' Check the signature and return the result.
-        Return signedXml.CheckSignature()
+        Return signedXml.CheckSignature(Key)
 
     End Function
 

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NWithCommentsTransformUrl/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NWithCommentsTransformUrl/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NWithCommentsTransformUrl/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NWithCommentsTransformUrl/sample.vb
@@ -31,7 +31,7 @@ Module SignVerifyEnvelope
 
             ' Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...")
-            Dim result As Boolean = VerifyXmlFile("SignedExample.xml")
+            Dim result As Boolean = VerifyXmlFile("SignedExample.xml", Key)
 
             ' Display the results of the signature verification to 
             ' the console.
@@ -56,7 +56,9 @@ Module SignVerifyEnvelope
         doc.PreserveWhitespace = False
 
         ' Load the passed XML file using it's name.
-        doc.Load(New XmlTextReader(FileName))
+        Using reader As XmlReader = XmlReader.Create(FileName)
+           doc.Load(reader)
+        End Using
 
         ' Create a SignedXml object.
         Dim signedXml As New SignedXml(doc)
@@ -112,7 +114,7 @@ Module SignVerifyEnvelope
     End Sub
 
     ' Verify the signature of an XML file and return the result.
-    Function VerifyXmlFile(ByVal Name As String) As [Boolean]
+    Function VerifyXmlFile(ByVal Name As String, Key As RSA) As [Boolean]
         ' Create a new XML document.
         Dim xmlDocument As New XmlDocument()
 
@@ -120,7 +122,9 @@ Module SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = True
 
         ' Load the passed XML file into the document. 
-        xmlDocument.Load(Name)
+        Using reader As XmlReader = XmlReader.Create(Name)
+           xmlDocument.Load(reader)
+        End Using
 
         ' Create a new SignedXml object and pass it
         ' the XML document class.
@@ -134,7 +138,7 @@ Module SignVerifyEnvelope
         signedXml.LoadXml(CType(nodeList(0), XmlElement))
 
         ' Check the signature and return the result.
-        Return signedXml.CheckSignature()
+        Return signedXml.CheckSignature(Key)
 
     End Function
 

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/X509IssuerSerial/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/X509IssuerSerial/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/X509IssuerSerial/Overview/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/X509IssuerSerial/Overview/sample.vb
@@ -70,7 +70,9 @@ Module SignVerifyEnvelope
         doc.PreserveWhitespace = False
 
         ' Load the passed XML file using it's name.
-        doc.Load(New XmlTextReader(FileName))
+        Using reader As XmlReader = XmlReader.Create(FileName)
+           doc.Load(reader)
+        End Using
 
         ' Create a SignedXml object.
         Dim signedXml As New SignedXml(doc)
@@ -156,7 +158,9 @@ Module SignVerifyEnvelope
         Dim xmlDocument As New XmlDocument()
 
         ' Load the passed XML file into the document. 
-        xmlDocument.Load(FileName)
+        Using reader As XmlReader = XmlReader.Create(FileName)
+           xmlDocument.Load(reader)
+        End Using
 
         ' Create a new SignedXml object and pass it
         ' the XML document class.

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigC14NWithCommentsTransform/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigC14NWithCommentsTransform/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigC14NWithCommentsTransform/Overview/sampledetached.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigC14NWithCommentsTransform/Overview/sampledetached.vb
@@ -35,7 +35,7 @@ Class XMLDSIGDetached
          Console.WriteLine("Verifying signature...")
          
          'Verify the XML signature in the XML file.
-         Dim result As Boolean = VerifyDetachedSignature(XmlFileName)
+         Dim result As Boolean = VerifyDetachedSignature(XmlFileName, Key)
          
          ' Display the results of the signature verification to 
          ' the console.
@@ -89,12 +89,14 @@ Class XMLDSIGDetached
    ' </Snippet2>
    ' <Snippet3>
    ' Verify the signature of an XML file and return the result.
-   Public Shared Function VerifyDetachedSignature(XmlSigFileName As String) As [Boolean]
+   Public Shared Function VerifyDetachedSignature(XmlSigFileName As String, Key As RSA) As [Boolean]
       ' Create a new XML document.
       Dim xmlDocument As New XmlDocument()
       
       ' Load the passed XML file into the document.
-      xmlDocument.Load(XmlSigFileName)
+      Using reader As XmlReader = XmlReader.Create(XmlSigFileName)
+         xmlDocument.Load(reader)
+      End Using
       
       ' Create a new SignedXMl object.
       Dim signedXml As New SignedXml()
@@ -107,7 +109,7 @@ Class XMLDSIGDetached
       signedXml.LoadXml(CType(nodeList(0), XmlElement))
       
       ' Check the signature and return the result.
-      Return signedXml.CheckSignature()
+      Return signedXml.CheckSignature(Key)
    End Function
    ' </snippet3>
 End Class

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigC14NWithCommentsTransform/Overview/sampleenvelope.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigC14NWithCommentsTransform/Overview/sampleenvelope.vb
@@ -26,7 +26,7 @@ Public Class SignVerifyEnvelope
          
          ' Verify the signature of the signed XML.
          Console.WriteLine("Verifying signature...")
-         Dim result As Boolean = VerifyXmlFile("SignedExample.xml")
+         Dim result As Boolean = VerifyXmlFile("SignedExample.xml", Key)
          
          ' Display the results of the signature verification to \
          ' the console.
@@ -51,7 +51,9 @@ Public Class SignVerifyEnvelope
       doc.PreserveWhitespace = False
       
       ' Load the passed XML file using it's name.
-      doc.Load(New XmlTextReader(FileName))
+      Using reader As XmlReader = XmlReader.Create(FileName)
+         doc.Load(reader)
+      End Using
       
       ' Create a SignedXml object.
       Dim signedXml As New SignedXml(doc)
@@ -101,7 +103,7 @@ Public Class SignVerifyEnvelope
    ' </Snippet2>
    ' <Snippet3>
    ' Verify the signature of an XML file and return the result.
-   Public Shared Function VerifyXmlFile(Name As [String]) As [Boolean]
+   Public Shared Function VerifyXmlFile(Name As [String], Key As RSA) As [Boolean]
       ' Create a new XML document.
       Dim xmlDocument As New XmlDocument()
       
@@ -109,7 +111,9 @@ Public Class SignVerifyEnvelope
       xmlDocument.PreserveWhitespace = True
       
       ' Load the passed XML file into the document. 
-      xmlDocument.Load(Name)
+      Using reader As XmlReader = XmlReader.Create(Name)
+         xmlDocument.Load(reader)
+      End Using
       
       ' Create a new SignedXml object and pass it
       ' the XML document class.
@@ -123,7 +127,7 @@ Public Class SignVerifyEnvelope
       signedXml.LoadXml(CType(nodeList(0), XmlElement))
       
       ' Check the signature and return the result.
-      Return signedXml.CheckSignature()
+      Return signedXml.CheckSignature(Key)
    End Function 
    
    ' </Snippet3>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigXPathTransform/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigXPathTransform/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigXPathTransform/Overview/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigXPathTransform/Overview/sample.vb
@@ -31,7 +31,7 @@ Module SignVerifyEnvelope
 
             ' Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...")
-            Dim result As Boolean = VerifyXmlFile("SignedExample.xml")
+            Dim result As Boolean = VerifyXmlFile("SignedExample.xml", Key)
 
             ' Display the results of the signature verification to \
             ' the console.
@@ -58,7 +58,9 @@ Module SignVerifyEnvelope
         doc.PreserveWhitespace = False
 
         ' Load the passed XML file using it's name.
-        doc.Load(New XmlTextReader(FileName))
+        Using reader As XmlReader = XmlReader.Create(FileName)
+           doc.Load(reader)
+        End Using
 
         ' Create a SignedXml object.
         Dim signedXml As New SignedXml(doc)
@@ -105,7 +107,7 @@ Module SignVerifyEnvelope
     End Sub
 
     ' Verify the signature of an XML file and return the result.
-    Function VerifyXmlFile(ByVal Name As String) As [Boolean]
+    Function VerifyXmlFile(ByVal Name As String, Key As RSA) As [Boolean]
         ' Create a new XML document.
         Dim xmlDocument As New XmlDocument()
 
@@ -113,7 +115,9 @@ Module SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = True
 
         ' Load the passed XML file into the document. 
-        xmlDocument.Load(Name)
+        Using reader As XmlReader = XmlReader.Create(Name)
+           xmlDocument.Load(reader)
+        End Using
 
         ' Create a new SignedXml object and pass it
         ' the XML document class.
@@ -127,7 +131,7 @@ Module SignVerifyEnvelope
         signedXml.LoadXml(CType(nodeList(0), XmlElement))
 
         ' Check the signature and return the result.
-        Return signedXml.CheckSignature()
+        Return signedXml.CheckSignature(Key)
 
     End Function
 

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigXsltTransform/Overview/Project.vbproj
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigXsltTransform/Overview/Project.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+</Project>

--- a/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigXsltTransform/Overview/sample.vb
+++ b/snippets/visualbasic/System.Security.Cryptography.Xml/XmlDsigXsltTransform/Overview/sample.vb
@@ -33,7 +33,7 @@ Module SignVerifyEnvelope
 
             ' Verify the signature of the signed XML.
             Console.WriteLine("Verifying signature...")
-            Dim result As Boolean = VerifyXmlFile("SignedExample.xml")
+            Dim result As Boolean = VerifyXmlFile("SignedExample.xml", Key)
 
             ' Display the results of the signature verification to \
             ' the console.
@@ -60,7 +60,9 @@ Module SignVerifyEnvelope
         doc.PreserveWhitespace = False
 
         ' Load the passed XML file using it's name.
-        doc.Load(New XmlTextReader(FileName))
+        Using reader As XmlReader = XmlReader.Create(FileName)
+           doc.Load(reader)
+        End Using
 
         ' Create a SignedXml object.
         Dim signedXml As New SignedXml(doc)
@@ -111,7 +113,7 @@ Module SignVerifyEnvelope
     End Sub
 
     ' Verify the signature of an XML file and return the result.
-    Function VerifyXmlFile(ByVal Name As String) As [Boolean]
+    Function VerifyXmlFile(ByVal Name As String, Key As RSA) As [Boolean]
         ' Create a new XML document.
         Dim xmlDocument As New XmlDocument()
 
@@ -119,7 +121,9 @@ Module SignVerifyEnvelope
         xmlDocument.PreserveWhitespace = True
 
         ' Load the passed XML file into the document. 
-        xmlDocument.Load(Name)
+        Using reader As XmlReader = XmlReader.Create(Name)
+           xmlDocument.Load(reader)
+        End Using
 
         ' Create a new SignedXml object and pass it
         ' the XML document class.
@@ -133,7 +137,7 @@ Module SignVerifyEnvelope
         signedXml.LoadXml(CType(nodeList(0), XmlElement))
 
         ' Check the signature and return the result.
-        Return signedXml.CheckSignature()
+        Return signedXml.CheckSignature(Key)
 
     End Function
 


### PR DESCRIPTION
Apply safe-by-default patterns to signing/verification and encryption samples:

- Wrap XmlDocument.Load in XmlReader.Create so DTD processing is prohibited and no XmlResolver is used.
- Replace parameterless SignedXml.CheckSignature() with the overload that takes a caller-provided trusted key.
- For the CheckSignatureReturningKey sample, compare the returned key against a trusted key before accepting the signature.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| File | Preview link |
|:--|:--|
| [snippets/csharp/System.Security.Cryptography.Xml/DataObject/Overview/source1.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/DataObject/Overview/source1.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.dataobject?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/DataReference/Overview/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/DataReference/Overview/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.datareference?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/DSAKeyValue/Overview/exampledetached.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/DSAKeyValue/Overview/exampledetached.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.dsakeyvalue?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/DSAKeyValue/Overview/exampleenvelope.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/DSAKeyValue/Overview/exampleenvelope.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.dsakeyvalue?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/EncryptedData/Overview/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/EncryptedData/Overview/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.encrypteddata?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/EncryptedKey/Overview/example.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/EncryptedKey/Overview/example.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.encryptedkey?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/EncryptedType/Overview/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/EncryptedType/Overview/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.encryptedtype?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/AddKeyNameMapping/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/AddKeyNameMapping/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.encryptedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.encryptedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample1.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample1.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.encryptedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample2.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample2.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.encryptedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample3.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample3.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.encryptedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample4.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/EncryptedXml/Overview/sample4.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.encryptedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/EncryptionProperty/Overview/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/EncryptionProperty/Overview/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.encryptionproperty?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/IRelDecryptor/Overview/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/IRelDecryptor/Overview/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.ireldecryptor?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/KeyInfo/Overview/xmldsigdetach.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/KeyInfo/Overview/xmldsigdetach.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.keyinfo?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/KeyInfo/Overview/xmldsigenv.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/KeyInfo/Overview/xmldsigenv.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.keyinfo?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/KeyInfoX509Data/.ctor/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/KeyInfoX509Data/.ctor/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.keyinfox509data?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/KeyInfoX509Data/Overview/examplecreateenvelope.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/KeyInfoX509Data/Overview/examplecreateenvelope.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.keyinfox509data?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/KeyReference/Overview/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/KeyReference/Overview/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.keyreference?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/Reference/.ctor/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/Reference/.ctor/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.reference?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/Signature/Overview/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/Signature/Overview/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.signature?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/exampledetached.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/exampledetached.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.signedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.signedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/xmldsigdetachedkeyedhashalg.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/xmldsigdetachedkeyedhashalg.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.signedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/xmldsigenvkeyedhashalg.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignature/xmldsigenvkeyedhashalg.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.signedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignatureReturningKey/exampleenvelope.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/CheckSignatureReturningKey/exampleenvelope.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.signedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/SignedXml/Overview/exampleenvelope.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/Overview/exampleenvelope.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.signedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/SignedXml/Overview/sample.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/Overview/sample.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.signedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |
| [snippets/csharp/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NTransformUrl/example.cs](https://github.com/dotnet/dotnet-api-docs/blob/75b453e9341872d77d4cf919a70991d2f10e0fd8/snippets/csharp/System.Security.Cryptography.Xml/SignedXml/XmlDsigExcC14NTransformUrl/example.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.signedxml?view=windowsdesktop-11.0&branch=pr-en-us-13013) |

</details>

> [!NOTE]
> This table shows the first 30 preview links (sorted alphabetically by file path) found in the OPS build report. For the full list, select <strong>OpenPublishing.Build Details</strong> within [checks](https://github.com/dotnet/dotnet-api-docs/pull/13013/checks).


<!-- PREVIEW-TABLE-END -->