### PR TITLE
Updating useRestrictiveXamlReader flag documentation and expectations

### DIFF
--- a/xml/System.Windows.Markup/XamlReader.xml
+++ b/xml/System.Windows.Markup/XamlReader.xml
@@ -593,9 +593,7 @@
         <param name="useRestrictiveXamlReader"><see langword="true" /> to restrict the instantiation of potentially dangerous types; otherwise, <see langword="false" />.</param>
         <summary>Reads the XAML input in the specified <see cref="T:System.IO.Stream" /> and returns the root of the corresponding object tree.</summary>
         <returns>The root of the created object tree.</returns>
-        <remarks>Restrictive mode is a defense-in-depth measure. Don't treat a restrictive parse of untrusted XAML as safe or as a replacement for isolation in a low-privilege sandbox.
-
-This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Windows.Markup.XamlReader.Load(System.IO.Stream,System.Boolean)" />.</remarks>
+<remarks>Restrictive mode is a defense-in-depth measure. Don't treat a restrictive parse of untrusted XAML as safe or as a replacement for isolation in a low-privilege sandbox. An asynchronous XAML load operation initially returns the root object while parsing continues. The <see cref="E:System.Windows.Markup.XamlReader.LoadCompleted" /> event signals completion. To load asynchronously, the root element must contain `x:SynchronousMode="Async"`; otherwise, the call is processed synchronously.</remarks>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="stream" /> is <see langword="null" />.</exception>
         <exception cref="T:System.InvalidOperationException">Multiple load operations are performed concurrently with the same <see cref="T:System.Windows.Markup.XamlReader" />.</exception>

--- a/xml/System.Windows.Markup/XamlReader.xml
+++ b/xml/System.Windows.Markup/XamlReader.xml
@@ -51,6 +51,12 @@
 
  The implications of these statements for <xref:System.Windows.Markup.XamlReader> is that your application design must make trust decisions about the XAML you decide to load. If you are loading XAML that is not trusted, consider implementing your own sandboxing technique for how you load the resulting object graph.
 
+### Restrictive XAML reader mode
+ The <xref:System.Windows.Markup.XamlReader.Load*>, <xref:System.Windows.Markup.XamlReader.LoadAsync*>, and <xref:System.Windows.Markup.XamlReader.Parse*> overloads that include a `useRestrictiveXamlReader` parameter can restrict the instantiation of potentially dangerous types. This mode runs in the caller's process and doesn't create a low-privilege security boundary.
+
+> [!IMPORTANT]
+> A restrictive or allow-list loading mode is a defense-in-depth hardening measure, not a security sandbox. It blocks a set of known-dangerous types, but it still allows many built-in types, some of which can have side effects such as loading external resources or initiating network requests. Don't treat a restrictive parse of untrusted markup as safe. Continue to isolate untrusted markup in a low-privilege boundary.
+
  <xref:System.Windows.Markup.XamlReader> can also be called by partial trust code. In this case, Internet security zone is applied for code access security. If anything in the loaded XAML is invalid under Internet security zone, a XAML parse exception is thrown. Under XBAP and other cases that are partial trust at the platform level, where <xref:System.Windows.Markup.XamlReader> is part of the execution, you get the same exception behavior as with explicit partial trust calls.
 
 ## WPF XAML, XAML Readers/Writers, and XAML Language Versioning
@@ -328,11 +334,13 @@
         <Parameter Name="useRestrictiveXamlReader" Type="System.Boolean" Index="1" FrameworkAlternate="windowsdesktop-10.0;windowsdesktop-11.0;windowsdesktop-5.0;windowsdesktop-6.0;windowsdesktop-7.0;windowsdesktop-8.0;windowsdesktop-9.0" />
       </Parameters>
       <Docs>
-        <param name="stream">To be added.</param>
-        <param name="useRestrictiveXamlReader">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="stream">The stream that contains the XAML input to load.</param>
+        <param name="useRestrictiveXamlReader"><see langword="true" /> to restrict the instantiation of potentially dangerous types; otherwise, <see langword="false" />.</param>
+        <summary>Reads the XAML input in the specified <see cref="T:System.IO.Stream" /> and returns the root of the corresponding object tree.</summary>
+        <returns>The root of the created object tree.</returns>
+        <remarks>Restrictive mode is a defense-in-depth measure. Don't treat a restrictive parse of untrusted XAML as safe or as a replacement for isolation in a low-privilege sandbox.</remarks>
+        <exception cref="T:System.ArgumentNullException">
+          <paramref name="stream" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <Member MemberName="Load">
@@ -402,11 +410,13 @@
         <Parameter Name="useRestrictiveXamlReader" Type="System.Boolean" Index="1" FrameworkAlternate="windowsdesktop-10.0;windowsdesktop-11.0;windowsdesktop-5.0;windowsdesktop-6.0;windowsdesktop-7.0;windowsdesktop-8.0;windowsdesktop-9.0" />
       </Parameters>
       <Docs>
-        <param name="reader">To be added.</param>
-        <param name="useRestrictiveXamlReader">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="reader">An existing <see cref="T:System.Xml.XmlReader" /> that contains the XAML input to load.</param>
+        <param name="useRestrictiveXamlReader"><see langword="true" /> to restrict the instantiation of potentially dangerous types; otherwise, <see langword="false" />.</param>
+        <summary>Reads the XAML input in the specified <see cref="T:System.Xml.XmlReader" /> and returns the root of the corresponding object tree.</summary>
+        <returns>The root of the created object tree.</returns>
+        <remarks>Restrictive mode is a defense-in-depth measure. Don't treat a restrictive parse of untrusted XAML as safe or as a replacement for isolation in a low-privilege sandbox.</remarks>
+        <exception cref="T:System.ArgumentNullException">
+          <paramref name="reader" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <Member MemberName="Load">
@@ -436,12 +446,14 @@
         <Parameter Name="useRestrictiveXamlReader" Type="System.Boolean" Index="2" FrameworkAlternate="windowsdesktop-10.0;windowsdesktop-11.0;windowsdesktop-5.0;windowsdesktop-6.0;windowsdesktop-7.0;windowsdesktop-8.0;windowsdesktop-9.0" />
       </Parameters>
       <Docs>
-        <param name="stream">To be added.</param>
-        <param name="parserContext">To be added.</param>
-        <param name="useRestrictiveXamlReader">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="stream">The stream that contains the XAML input to load.</param>
+        <param name="parserContext">Context information used by the parser.</param>
+        <param name="useRestrictiveXamlReader"><see langword="true" /> to restrict the instantiation of potentially dangerous types; otherwise, <see langword="false" />.</param>
+        <summary>Reads the XAML input in the specified <see cref="T:System.IO.Stream" /> by using the specified <see cref="T:System.Windows.Markup.ParserContext" /> and returns the root of the corresponding object tree.</summary>
+        <returns>The root of the created object tree.</returns>
+        <remarks>Restrictive mode is a defense-in-depth measure. Don't treat a restrictive parse of untrusted XAML as safe or as a replacement for isolation in a low-privilege sandbox.</remarks>
+        <exception cref="T:System.ArgumentNullException">
+          <paramref name="stream" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="LoadAsync">
@@ -577,11 +589,16 @@
         <Parameter Name="useRestrictiveXamlReader" Type="System.Boolean" Index="1" FrameworkAlternate="windowsdesktop-10.0;windowsdesktop-11.0;windowsdesktop-5.0;windowsdesktop-6.0;windowsdesktop-7.0;windowsdesktop-8.0;windowsdesktop-9.0" />
       </Parameters>
       <Docs>
-        <param name="stream">To be added.</param>
-        <param name="useRestrictiveXamlReader">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Windows.Markup.XamlReader.Load(System.IO.Stream,System.Boolean)" />.</remarks>
+        <param name="stream">The stream that contains the XAML input to load.</param>
+        <param name="useRestrictiveXamlReader"><see langword="true" /> to restrict the instantiation of potentially dangerous types; otherwise, <see langword="false" />.</param>
+        <summary>Reads the XAML input in the specified <see cref="T:System.IO.Stream" /> and returns the root of the corresponding object tree.</summary>
+        <returns>The root of the created object tree.</returns>
+        <remarks>Restrictive mode is a defense-in-depth measure. Don't treat a restrictive parse of untrusted XAML as safe or as a replacement for isolation in a low-privilege sandbox.
+
+This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Windows.Markup.XamlReader.Load(System.IO.Stream,System.Boolean)" />.</remarks>
+        <exception cref="T:System.ArgumentNullException">
+          <paramref name="stream" /> is <see langword="null" />.</exception>
+        <exception cref="T:System.InvalidOperationException">Multiple load operations are performed concurrently with the same <see cref="T:System.Windows.Markup.XamlReader" />.</exception>
       </Docs>
     </Member>
     <Member MemberName="LoadAsync">
@@ -663,11 +680,16 @@
         <Parameter Name="useRestrictiveXamlReader" Type="System.Boolean" Index="1" FrameworkAlternate="windowsdesktop-10.0;windowsdesktop-11.0;windowsdesktop-5.0;windowsdesktop-6.0;windowsdesktop-7.0;windowsdesktop-8.0;windowsdesktop-9.0" />
       </Parameters>
       <Docs>
-        <param name="reader">To be added.</param>
-        <param name="useRestrictiveXamlReader">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Windows.Markup.XamlReader.Load(System.Xml.XmlReader,System.Boolean)" />.</remarks>
+        <param name="reader">An existing <see cref="T:System.Xml.XmlReader" /> that contains the XAML input to load.</param>
+        <param name="useRestrictiveXamlReader"><see langword="true" /> to restrict the instantiation of potentially dangerous types; otherwise, <see langword="false" />.</param>
+        <summary>Reads the XAML input in the specified <see cref="T:System.Xml.XmlReader" /> and returns the root of the corresponding object tree.</summary>
+        <returns>The root of the created object tree.</returns>
+        <remarks>Restrictive mode is a defense-in-depth measure. Don't treat a restrictive parse of untrusted XAML as safe or as a replacement for isolation in a low-privilege sandbox.
+
+This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Windows.Markup.XamlReader.Load(System.Xml.XmlReader,System.Boolean)" />.</remarks>
+        <exception cref="T:System.ArgumentNullException">
+          <paramref name="reader" /> is <see langword="null" />.</exception>
+        <exception cref="T:System.InvalidOperationException">Multiple load operations are performed concurrently with the same <see cref="T:System.Windows.Markup.XamlReader" />.</exception>
       </Docs>
     </Member>
     <Member MemberName="LoadAsync">
@@ -697,12 +719,17 @@
         <Parameter Name="useRestrictiveXamlReader" Type="System.Boolean" Index="2" FrameworkAlternate="windowsdesktop-10.0;windowsdesktop-11.0;windowsdesktop-5.0;windowsdesktop-6.0;windowsdesktop-7.0;windowsdesktop-8.0;windowsdesktop-9.0" />
       </Parameters>
       <Docs>
-        <param name="stream">To be added.</param>
-        <param name="parserContext">To be added.</param>
-        <param name="useRestrictiveXamlReader">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Windows.Markup.XamlReader.Load(System.IO.Stream,System.Windows.Markup.ParserContext,System.Boolean)" />.</remarks>
+        <param name="stream">The stream that contains the XAML input to load.</param>
+        <param name="parserContext">Context information used by the parser.</param>
+        <param name="useRestrictiveXamlReader"><see langword="true" /> to restrict the instantiation of potentially dangerous types; otherwise, <see langword="false" />.</param>
+        <summary>Reads the XAML input in the specified <see cref="T:System.IO.Stream" /> by using the specified <see cref="T:System.Windows.Markup.ParserContext" /> and returns the root of the corresponding object tree.</summary>
+        <returns>The root of the created object tree.</returns>
+        <remarks>Restrictive mode is a defense-in-depth measure. Don't treat a restrictive parse of untrusted XAML as safe or as a replacement for isolation in a low-privilege sandbox.
+
+This method stores in the task it returns all non-usage exceptions that the method's synchronous counterpart can throw. If an exception is stored into the returned task, that exception will be thrown when the task is awaited. Usage exceptions, such as <see cref="T:System.ArgumentException" />, are still thrown synchronously. For the stored exceptions, see the exceptions thrown by <see cref="M:System.Windows.Markup.XamlReader.Load(System.IO.Stream,System.Windows.Markup.ParserContext,System.Boolean)" />.</remarks>
+        <exception cref="T:System.ArgumentNullException">
+          <paramref name="stream" /> is <see langword="null" />.</exception>
+        <exception cref="T:System.InvalidOperationException">Multiple load operations are performed concurrently with the same <see cref="T:System.Windows.Markup.XamlReader" />.</exception>
       </Docs>
     </Member>
     <Member MemberName="LoadCompleted">
@@ -810,11 +837,13 @@
         <Parameter Name="useRestrictiveXamlReader" Type="System.Boolean" Index="1" FrameworkAlternate="windowsdesktop-10.0;windowsdesktop-11.0;windowsdesktop-5.0;windowsdesktop-6.0;windowsdesktop-7.0;windowsdesktop-8.0;windowsdesktop-9.0" />
       </Parameters>
       <Docs>
-        <param name="xamlText">To be added.</param>
-        <param name="useRestrictiveXamlReader">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="xamlText">The XAML input, as a single text string.</param>
+        <param name="useRestrictiveXamlReader"><see langword="true" /> to restrict the instantiation of potentially dangerous types; otherwise, <see langword="false" />.</param>
+        <summary>Reads the XAML input in the specified text string and returns the root of the corresponding object tree.</summary>
+        <returns>The root of the created object tree.</returns>
+        <remarks>Restrictive mode is a defense-in-depth measure. Don't treat a restrictive parse of untrusted XAML as safe or as a replacement for isolation in a low-privilege sandbox.</remarks>
+        <exception cref="T:System.ArgumentNullException">
+          <paramref name="xamlText" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <Member MemberName="Parse">
@@ -885,12 +914,14 @@
         <Parameter Name="useRestrictiveXamlReader" Type="System.Boolean" Index="2" FrameworkAlternate="windowsdesktop-10.0;windowsdesktop-11.0;windowsdesktop-5.0;windowsdesktop-6.0;windowsdesktop-7.0;windowsdesktop-8.0;windowsdesktop-9.0" />
       </Parameters>
       <Docs>
-        <param name="xamlText">To be added.</param>
-        <param name="parserContext">To be added.</param>
-        <param name="useRestrictiveXamlReader">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="xamlText">The XAML input, as a single text string.</param>
+        <param name="parserContext">Context information used by the parser.</param>
+        <param name="useRestrictiveXamlReader"><see langword="true" /> to restrict the instantiation of potentially dangerous types; otherwise, <see langword="false" />.</param>
+        <summary>Reads the XAML input in the specified text string by using the specified <see cref="T:System.Windows.Markup.ParserContext" /> and returns the root of the corresponding object tree.</summary>
+        <returns>The root of the created object tree.</returns>
+        <remarks>Restrictive mode is a defense-in-depth measure. Don't treat a restrictive parse of untrusted XAML as safe or as a replacement for isolation in a low-privilege sandbox.</remarks>
+        <exception cref="T:System.ArgumentNullException">
+          <paramref name="xamlText" /> is <see langword="null" />.</exception>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
## Summary

In this PR, I have updated the XamlReader document, especifically useRestrictiveXamlReader flags usage, capabilities and constraints. This is in alignment with the change here: https://github.com/dotnet/docs-desktop/pull/2278

- Updated XamlReader's Load, LoadAsync and Parse method overload using useRestrictiveXamlReader flag.
- Added security remarks regarding the capabilities of the restrictive XAML reader mode in WPF.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [xml/System.Windows.Markup/XamlReader.xml](https://github.com/dotnet/dotnet-api-docs/blob/e99685703e8f963e950f18e64cc344844b32300c/xml/System.Windows.Markup/XamlReader.xml) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/api/system.windows.markup.xamlreader?view=windowsdesktop-11.0&branch=pr-en-us-13018) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/500c749d-de78-3d4a-00e4-269d599bf9ec/202608270859073406-13018/BuildReport?accessString=7882ad4340eb2f4bb259526b7d518f5e90bb6a88f47060e2ed0e0d502fe685d3)