### PR TITLE
Process.Kill isn't immediate

### DIFF
--- a/xml/System.Diagnostics/Process.xml
+++ b/xml/System.Diagnostics/Process.xml
@@ -1986,7 +1986,7 @@ You cannot cause processes on remote computers to exit. You can only view inform
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Immediately stops the associated process.</summary>
+        <summary>Stops the associated process.</summary>
         <remarks>To be added.</remarks>
         <exception cref="T:System.ComponentModel.Win32Exception">The associated process could not be terminated.</exception>
         <exception cref="T:System.NotSupportedException">You are attempting to call <see cref="M:System.Diagnostics.Process.Kill" /> for a process that is running on a remote computer. The method is available only for processes running on the local computer.</exception>
@@ -2037,7 +2037,7 @@ You cannot cause processes on remote computers to exit. You can only view inform
       <Docs>
         <param name="entireProcessTree">
           <see langword="true" /> to kill the associated process and its descendants; <see langword="false" /> to kill only the associated process.</param>
-        <summary>Immediately stops the associated process, and optionally its child/descendent processes.</summary>
+        <summary>Stops the associated process, and optionally its child/descendent processes.</summary>
         <remarks>When <paramref name="entireProcessTree" /> is set to <see langword="true" />, processes where the call lacks permissions to view details are silently skipped by the descendant termination process because the termination process is unable to determine whether those processes are descendants.</remarks>
         <exception cref="T:System.ComponentModel.Win32Exception">The associated process could not be terminated.
 


### PR DESCRIPTION
## Summary

Process.Kill isn't immediate as it's asynchronous like it's specified in the [note in the remarks section](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill?view=net-10.0#remarks) and as confirmed by the [Windows implementation that uses the asynchronous TerminateProcess function](https://github.com/dotnet/dotnet/blob/v11.0.100/src/runtime/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs#L100).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [xml/System.Diagnostics/Process.xml](https://github.com/dotnet/dotnet-api-docs/blob/67fe6827dca22e356ddac4e7277569396b2a6099/xml/System.Diagnostics/Process.xml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process?view=net-11.0&branch=pr-en-us-13020) |

<!-- PREVIEW-TABLE-END -->