### PR TITLE
Fix broken links

### DIFF
--- a/_zip/missingapi.yml
+++ b/_zip/missingapi.yml
@@ -38,139 +38,139 @@ references:
 - uid: OpenAI.Assistants.Assistant
   name: Assistant
   fullname: OpenAI.Assistants.Assistant
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Assistants.netstandard2.0.cs
 - uid: OpenAI.Assistants.AssistantClient
   name: AssistantClient
   fullname: OpenAI.Assistants.AssistantClient
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Assistants.netstandard2.0.cs
 - uid: OpenAI.Assistants.FunctionToolDefinition
   name: FunctionToolDefinition
   fullname: OpenAI.Assistants.FunctionToolDefinition
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Assistants.netstandard2.0.cs
 - uid: OpenAI.Audio.AudioClient
   name: AudioClient
   fullname: OpenAI.Audio.AudioClient
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Audio.netstandard2.0.cs
 - uid: OpenAI.Chat.ChatClient
   name: ChatClient
   fullname: OpenAI.Chat.ChatClient
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Chat.netstandard2.0.cs
 - uid: OpenAI.Chat.ChatCompletion
   name: ChatCompletion
   fullname: OpenAI.Chat.ChatCompletion
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Chat.netstandard2.0.cs
 - uid: OpenAI.Chat.ChatCompletionOptions
   name: ChatCompletionOptions
   fullname: OpenAI.Chat.ChatCompletionOptions
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Chat.netstandard2.0.cs
 - uid: OpenAI.Chat.ChatMessage
   name: ChatMessage
   fullname: OpenAI.Chat.ChatMessage
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Chat.netstandard2.0.cs
 - uid: OpenAI.Chat.ChatResponseFormat
   name: ChatResponseFormat
   fullname: OpenAI.Chat.ChatResponseFormat
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Chat.netstandard2.0.cs
 - uid: OpenAI.Chat.ChatTool
   name: ChatTool
   fullname: OpenAI.Chat.ChatTool
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Chat.netstandard2.0.cs
 - uid: OpenAI.Chat.StreamingChatCompletionUpdate
   name: StreamingChatCompletionUpdate
   fullname: OpenAI.Chat.StreamingChatCompletionUpdate
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Chat.netstandard2.0.cs
 - uid: OpenAI.Containers.ContainerClient
   name: ContainerClient
   fullname: OpenAI.Containers.ContainerClient
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Containers.netstandard2.0.cs
 - uid: OpenAI.Embeddings.EmbeddingClient
   name: EmbeddingClient
   fullname: OpenAI.Embeddings.EmbeddingClient
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Embeddings.netstandard2.0.cs
 - uid: OpenAI.Files.OpenAIFileClient
   name: OpenAIFileClient
   fullname: OpenAI.Files.OpenAIFileClient
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Files.netstandard2.0.cs
 - uid: OpenAI.Images.ImageClient
   name: ImageClient
   fullname: OpenAI.Images.ImageClient
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Images.netstandard2.0.cs
 - uid: OpenAI.OpenAIClient
   name: OpenAIClient
   fullname: OpenAI.OpenAIClient
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.netstandard2.0.cs
 - uid: OpenAI.Realtime.ConversationFunctionTool
   name: ConversationFunctionTool
   fullname: OpenAI.Realtime.ConversationFunctionTool
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Realtime.netstandard2.0.cs
 - uid: OpenAI.Realtime.RealtimeClient
   name: RealtimeClient
   fullname: OpenAI.Realtime.RealtimeClient
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Realtime.netstandard2.0.cs
 - uid: OpenAI.Realtime.RealtimeFunctionTool
   name: RealtimeFunctionTool
   fullname: OpenAI.Realtime.RealtimeFunctionTool
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Realtime.netstandard2.0.cs
 - uid: OpenAI.RealtimeConversation.ConversationFunctionTool
   name: ConversationFunctionTool
   fullname: OpenAI.RealtimeConversation.ConversationFunctionTool
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.RealtimeConversation.netstandard2.0.cs
 - uid: OpenAI.RealtimeConversation.ConversationUpdate
   name: ConversationUpdate
   fullname: OpenAI.RealtimeConversation.ConversationUpdate
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.RealtimeConversation.netstandard2.0.cs
 - uid: OpenAI.RealtimeConversation.RealtimeConversationClient
   name: RealtimeConversationClient
   fullname: OpenAI.RealtimeConversation.RealtimeConversationClient
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.RealtimeConversation.netstandard2.0.cs
 - uid: OpenAI.RealtimeConversation.RealtimeConversationSession
   name: RealtimeConversationSession
   fullname: OpenAI.RealtimeConversation.RealtimeConversationSession
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.RealtimeConversation.netstandard2.0.cs
 - uid: OpenAI.Responses.CreateResponseOptions
   name: CreateResponseOptions
   fullname: OpenAI.Responses.CreateResponseOptions
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
 - uid: OpenAI.Responses.FunctionTool
   name: FunctionTool
   fullname: OpenAI.Responses.FunctionTool
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
 - uid: OpenAI.Responses.OpenAIResponse
   name: OpenAIResponse
   fullname: OpenAI.Responses.OpenAIResponse
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
 - uid: OpenAI.Responses.OpenAIResponseClient
   name: OpenAIResponseClient
   fullname: OpenAI.Responses.OpenAIResponseClient
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
 - uid: OpenAI.Responses.ResponseCreationOptions
   name: ResponseCreationOptions
   fullname: OpenAI.Responses.ResponseCreationOptions
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
 - uid: OpenAI.Responses.ResponseItem
   name: ResponseItem
   fullname: OpenAI.Responses.ResponseItem
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
 - uid: OpenAI.Responses.ResponseResult
   name: ResponseResult
   fullname: OpenAI.Responses.ResponseResult
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
 - uid: OpenAI.Responses.ResponsesClient
   name: ResponsesClient
   fullname: OpenAI.Responses.ResponsesClient
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
 - uid: OpenAI.Responses.ResponseTextFormat
   name: ResponseTextFormat
   fullname: OpenAI.Responses.ResponseTextFormat
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
 - uid: OpenAI.Responses.ResponseTool
   name: ResponseTool
   fullname: OpenAI.Responses.ResponseTool
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
 - uid: OpenAI.Responses.StreamingResponseUpdate
   name: StreamingResponseUpdate
   fullname: OpenAI.Responses.StreamingResponseUpdate
-  href: https://github.com/openai/openai-dotnet/blob/main/api/OpenAI.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Responses.netstandard2.0.cs
 - uid: Polly.CircuitBreaker.CircuitBreakerStrategyOptions`1
   name: CircuitBreakerStrategyOptions`1
   fullname: Polly.CircuitBreaker.CircuitBreakerStrategyOptions`1

--- a/_zip/missingapi.yml
+++ b/_zip/missingapi.yml
@@ -114,7 +114,7 @@ references:
 - uid: OpenAI.RealtimeConversation.ConversationFunctionTool
   name: ConversationFunctionTool
   fullname: OpenAI.RealtimeConversation.ConversationFunctionTool
-  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.RealtimeConversation.netstandard2.0.cs
+  href: https://github.com/openai/openai-dotnet/blob/main/api/released/netstandard2.0/OpenAI.Realtime.netstandard2.0.cs
 - uid: OpenAI.RealtimeConversation.ConversationUpdate
   name: ConversationUpdate
   fullname: OpenAI.RealtimeConversation.ConversationUpdate

--- a/xml/System.Runtime.InteropServices.ObjectiveC/ObjectiveCMarshal+MessageSendFunction.xml
+++ b/xml/System.Runtime.InteropServices.ObjectiveC/ObjectiveCMarshal+MessageSendFunction.xml
@@ -88,7 +88,7 @@
       </ReturnValue>
       <MemberValue>2</MemberValue>
       <Docs>
-        <summary>Overrides the Objective-C runtime's <see href="https://developer.apple.com/documentation/objectivec/1456730-objc_msgsend_stret">objc_msgSend_stret()</see>.</summary>
+        <summary>Overrides the Objective-C runtime's <see href="https://developer.apple.com/documentation/objectivec/objc_msgsend_stret">objc_msgSend_stret()</see>.</summary>
       </Docs>
     </Member>
     <Member MemberName="MsgSendSuper">
@@ -134,7 +134,7 @@
       </ReturnValue>
       <MemberValue>4</MemberValue>
       <Docs>
-        <summary>Overrides the Objective-C runtime's <see href="https://developer.apple.com/documentation/objectivec/1456722-objc_msgsendsuper_stret">objc_msgSendSuper_stret()</see>.</summary>
+        <summary>Overrides the Objective-C runtime's <see href="https://developer.apple.com/documentation/objectivec/objc_msgsendsuper_stret">objc_msgSendSuper_stret()</see>.</summary>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
Contributes to dotnet/docs#53532.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [xml/System.Runtime.InteropServices.ObjectiveC/ObjectiveCMarshal+MessageSendFunction.xml](https://github.com/dotnet/dotnet-api-docs/blob/53fa1d47427486c0fa2a0eff73e7079784a91cba/xml/System.Runtime.InteropServices.ObjectiveC/ObjectiveCMarshal+MessageSendFunction.xml) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.objectivec.objectivecmarshal.messagesendfunction?view=net-11.0&branch=pr-en-us-13035) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/500c749d-de78-3d4a-00e4-269d599bf9ec/202608260357041296-13035/BuildReport?accessString=9fc7e22821960fb6f013bbb4c856bfc28af358d6f31df594657e0b1cd27ca079)