### PR TITLE
Simplify job name in ops-build-reporter.yml

### DIFF
--- a/.github/workflows/ops-build-reporter.yml
+++ b/.github/workflows/ops-build-reporter.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   ops_build_reporter_job:
-    name: Add preview links to PR body and annotate files with build warnings
+    name: Add preview links and annotate files
     runs-on: ubuntu-latest
     permissions:
       statuses: read


### PR DESCRIPTION
This text appears in the status checks list, so shorten it.