### PR TITLE
Fix and Update the summary for AggregateException.Flatten()

### DIFF
--- a/xml/System/AggregateException.xml
+++ b/xml/System/AggregateException.xml
@@ -529,7 +529,7 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Flattens an <see cref="T:System.AggregateException" /> instances into a single, new instance.</summary>
+        <summary>Flattens a tree of <see cref="T:System.AggregateException" /> instances into a single, new instance.</summary>
         <returns>A new, flattened <see cref="T:System.AggregateException" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[


### PR DESCRIPTION
## Summary

The current summary of AggregateException.Flatten() is grammatically incorrect and difficult to understand.

This updated version is grammatically correct and also makes it clearer what the Flatten method does.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [xml/System/AggregateException.xml](https://github.com/dotnet/dotnet-api-docs/blob/4b6910ab622c27ac573291b1ff9c7ba35c5e0116/xml/System/AggregateException.xml) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/api/system.aggregateexception?view=net-11.0&branch=pr-en-us-13049) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/500c749d-de78-3d4a-00e4-269d599bf9ec/202609011348589411-13049/BuildReport?accessString=3947f7456504f8730229013cb40b336c2665fbe22c42e99c22008e23203b3230)