### PR TITLE
Document LINQ to XML thread safety

### DIFF
--- a/xml/System.Xml.Linq/XDocument.xml
+++ b/xml/System.Xml.Linq/XDocument.xml
@@ -55,6 +55,10 @@
 ## Remarks
  For details about the valid content of an <xref:System.Xml.Linq.XDocument>, see [Valid Content of XElement and XDocument Objects](/dotnet/standard/linq/valid-content-xelement-xdocument-objects).
 
+## Thread safety
+
+ An <xref:System.Xml.Linq.XDocument> instance is safe for concurrent read operations as long as no thread modifies it. If the instance is modified, you must synchronize all access to it.
+
 
 
 ## Examples

--- a/xml/System.Xml.Linq/XElement.xml
+++ b/xml/System.Xml.Linq/XElement.xml
@@ -85,6 +85,10 @@
 
  Some <xref:System.Xml.Linq.XElement> methods can be used from XAML. For more information, see [LINQ to XML Dynamic Properties](/dotnet/desktop/wpf/data/linq-to-xml-dynamic-properties).
 
+## Thread safety
+
+ An <xref:System.Xml.Linq.XElement> instance is safe for concurrent read operations as long as no thread modifies it. If the instance is modified, you must synchronize all access to it.
+
 
 
 ## Examples

--- a/xml/System.Xml.Linq/XObject.xml
+++ b/xml/System.Xml.Linq/XObject.xml
@@ -61,6 +61,10 @@
 
  Note that annotations are not part of the XML infoset; they are not serialized or deserialized.
 
+## Thread safety
+
+ An <xref:System.Xml.Linq.XObject> instance, including an instance of a derived type, is safe for concurrent read operations as long as no thread modifies it. If the instance is modified, you must synchronize all access to it.
+
  ]]></format>
     </remarks>
     <related type="Article" href="/dotnet/standard/linq/linq-xml-overview">LINQ to XML overview</related>


### PR DESCRIPTION
## Summary

- document the shared concurrent-read guarantee on `XObject` and derived types
- surface the same guidance on the `XDocument` and `XElement` API pages
- clarify that all access must be synchronized when an instance is modified

Fixes dotnet/runtime#123068

## Validation

- parsed all three edited ECMAXML files with `XML::Parser`
- `git diff --check`

This documentation update was prepared with Codex assistance.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [xml/System.Xml.Linq/XDocument.xml](https://github.com/dotnet/dotnet-api-docs/blob/768479ba7b26ecbba637e556cc396ea5e372eb65/xml/System.Xml.Linq/XDocument.xml) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/api/system.xml.linq.xdocument?view=net-11.0&branch=pr-en-us-13050) |
| [xml/System.Xml.Linq/XElement.xml](https://github.com/dotnet/dotnet-api-docs/blob/768479ba7b26ecbba637e556cc396ea5e372eb65/xml/System.Xml.Linq/XElement.xml) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/api/system.xml.linq.xelement?view=net-11.0&branch=pr-en-us-13050) |
| [xml/System.Xml.Linq/XObject.xml](https://github.com/dotnet/dotnet-api-docs/blob/768479ba7b26ecbba637e556cc396ea5e372eb65/xml/System.Xml.Linq/XObject.xml) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/api/system.xml.linq.xobject?view=net-11.0&branch=pr-en-us-13050) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/500c749d-de78-3d4a-00e4-269d599bf9ec/202609021213560141-13050/BuildReport?accessString=cc85f7c1c1994e8821bab0ffd62fc6614685a740635e5093f5335a61c5e42700)