### PR TITLE
SignedXml: drop .NET 12 InvalidOperationException documentation

### DIFF
--- a/xml/System.Security.Cryptography.Xml/SignedXml.xml
+++ b/xml/System.Security.Cryptography.Xml/SignedXml.xml
@@ -190,7 +190,7 @@ Given the risks of external references, <xref:System.Security.Cryptography.Xml.S
 
 ## Instances are single-use
 
-A <xref:System.Security.Cryptography.Xml.SignedXml> instance is not intended to be reused across multiple signing or verification operations. Starting in .NET 12, calling <xref:System.Security.Cryptography.Xml.SignedXml.ComputeSignature*> or <xref:System.Security.Cryptography.Xml.SignedXml.CheckSignature*> more than once on the same instance, or calling <xref:System.Security.Cryptography.Xml.SignedXml.LoadXml*>, <xref:System.Security.Cryptography.Xml.SignedXml.AddReference*>, or <xref:System.Security.Cryptography.Xml.SignedXml.AddObject*> after a call to <xref:System.Security.Cryptography.Xml.SignedXml.ComputeSignature*> or <xref:System.Security.Cryptography.Xml.SignedXml.CheckSignature*> has begun on the same instance, throws <xref:System.InvalidOperationException>. This applies even if the earlier call itself threw an exception. Create a new <xref:System.Security.Cryptography.Xml.SignedXml> instance for each signing or verification operation.
+A <xref:System.Security.Cryptography.Xml.SignedXml> instance is not intended to be reused across multiple signing or verification operations. Reusing an instance can produce incorrect results. Create a new <xref:System.Security.Cryptography.Xml.SignedXml> instance for each signing or verification operation.
 
  ]]></format>
     </remarks>
@@ -447,7 +447,6 @@ The following code example shows how to sign and verify a single element of an X
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Security.Cryptography.Xml.SignedXml" /> instance has already been used to compute or verify a signature.</exception>
       </Docs>
     </Member>
     <Member MemberName="AddReference">
@@ -515,7 +514,6 @@ The following code example shows how to sign and verify a single element of an X
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Security.Cryptography.Xml.SignedXml" /> instance has already been used to compute or verify a signature.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="CheckSignature">
@@ -608,7 +606,6 @@ The following code example shows how to sign and verify a single element of an X
  -or
 
  The hash algorithm could not be created.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Security.Cryptography.Xml.SignedXml" /> instance has already been used to compute or verify a signature.</exception>
       </Docs>
     </Member>
     <Member MemberName="CheckSignature">
@@ -674,7 +671,6 @@ The following code example shows how to sign and verify a single element of an X
  -or
 
  The hash algorithm could not be created.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Security.Cryptography.Xml.SignedXml" /> instance has already been used to compute or verify a signature.</exception>
       </Docs>
     </Member>
     <Member MemberName="CheckSignature">
@@ -740,7 +736,6 @@ The following code example shows how to sign and verify a single element of an X
  -or-
 
  The cryptographic transform used to check the signature could not be created.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Security.Cryptography.Xml.SignedXml" /> instance has already been used to compute or verify a signature.</exception>
       </Docs>
     </Member>
     <Member MemberName="CheckSignature">
@@ -803,7 +798,6 @@ The X.509 certificate is verified. The <xref:System.Security.Cryptography.Xml.Si
         </remarks>
         <exception cref="T:System.ArgumentNullException">The <paramref name="certificate" /> parameter is <see langword="null" />.</exception>
         <exception cref="T:System.Security.Cryptography.CryptographicException">A signature description could not be created for the <paramref name="certificate" /> parameter.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Security.Cryptography.Xml.SignedXml" /> instance has already been used to compute or verify a signature.</exception>
       </Docs>
     </Member>
     <Member MemberName="CheckSignatureReturningKey">
@@ -877,7 +871,6 @@ The X.509 certificate is verified. The <xref:System.Security.Cryptography.Xml.Si
  -or
 
  The hash algorithm could not be created.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Security.Cryptography.Xml.SignedXml" /> instance has already been used to compute or verify a signature.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="ComputeSignature">
@@ -955,7 +948,6 @@ The X.509 certificate is verified. The <xref:System.Security.Cryptography.Xml.Si
  -or-
 
  The key could not be loaded.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Security.Cryptography.Xml.SignedXml" /> instance has already been used to compute or verify a signature.</exception>
       </Docs>
     </Member>
     <Member MemberName="ComputeSignature">
@@ -1026,7 +1018,6 @@ The X.509 certificate is verified. The <xref:System.Security.Cryptography.Xml.Si
  -or-
 
  The cryptographic transform used to check the signature could not be created.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Security.Cryptography.Xml.SignedXml" /> instance has already been used to compute or verify a signature.</exception>
       </Docs>
     </Member>
     <Member MemberName="EncryptedXml">
@@ -1331,7 +1322,6 @@ The X.509 certificate is verified. The <xref:System.Security.Cryptography.Xml.Si
  -or-
 
  The <paramref name="value" /> parameter does not contain a valid <see cref="P:System.Security.Cryptography.Xml.SignedXml.SignedInfo" /> property.</exception>
-        <exception cref="T:System.InvalidOperationException">The <see cref="T:System.Security.Cryptography.Xml.SignedXml" /> instance has already been used to compute or verify a signature.</exception>
       </Docs>
     </Member>
     <Member MemberName="m_signature">
@@ -3060,4 +3050,3 @@ The X.509 certificate is verified. The <xref:System.Security.Cryptography.Xml.Si
     </Member>
   </Members>
 </Type>
-


### PR DESCRIPTION
The dotnet/runtime PR that would have thrown `InvalidOperationException` on `SignedXml` instance reuse in .NET 12 ([dotnet/runtime#132836](https://github.com/dotnet/runtime/pull/132836)) has been closed and is not going to ship.

This PR removes the .NET 12-specific documentation added in #13042:

- The 10 `<exception cref="T:System.InvalidOperationException">` entries across `ComputeSignature`, `CheckSignature`, `CheckSignatureReturningKey`, `LoadXml`, `AddReference`, and `AddObject`.
- The "Starting in .NET 12, calling ... throws `InvalidOperationException`" sentence in the `Instances are single-use` remarks section.

The general guidance that a `SignedXml` instance is not intended to be reused across multiple signing or verification operations remains correct on all supported .NET versions and stays.

Companion cleanup PR in `dotnet/docs` for the how-to callouts.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [xml/System.Security.Cryptography.Xml/SignedXml.xml](https://github.com/dotnet/dotnet-api-docs/blob/fb5f873df4e3a00ee0dceb6b74339674bba64bb6/xml/System.Security.Cryptography.Xml/SignedXml.xml) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.xml.signedxml?view=windowsdesktop-11.0&branch=pr-en-us-13054) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/500c749d-de78-3d4a-00e4-269d599bf9ec/202609030610519396-13054/BuildReport?accessString=ecbc1f4eac7c4a5b3b4fa83607e86c22463bd2f1bbf4e652ef088f34dcd02a10)