### PR TITLE
Revert "Remove System.Deployment.Application xrefs"

### DIFF
--- a/xml/Microsoft.VisualBasic.ApplicationServices/AssemblyInfo.xml
+++ b/xml/Microsoft.VisualBasic.ApplicationServices/AssemblyInfo.xml
@@ -816,19 +816,21 @@
 ## Remarks
  The `My.Application.Info.Version` property gets a <xref:System.Version> object containing the version number of the application. You can use the <xref:System.Version.Major*>, <xref:System.Version.Minor*>, <xref:System.Version.Build*>, and <xref:System.Version.Revision*> properties of the <xref:System.Version> object to access specific version information about the application.
 
- ClickOnce-deployed applications should use the `My.Application.Deployment.CurrentVersion` property.
+ ClickOnce-deployed applications should use the <xref:System.Deployment.Application.ApplicationDeployment.CurrentVersion> property of the <xref:Microsoft.VisualBasic.ApplicationServices.ConsoleApplicationBase.Deployment> property.
 
 ## Availability by Project Type
 
-| Project type                  | Available |
-|-------------------------------|-----------|
-| Windows Forms Application     | **Yes**   |
-| Class Library                 | **Yes**   |
-| Console Application           | **Yes**   |
-| Windows Forms Control Library | **Yes**   |
-| Web Control Library           | No        |
-| Windows Service               | **Yes**   |
-| Web Site                      | No        |
+|Project type|Available|
+|------------------|---------------|
+|Windows Forms Application|**Yes**|
+|Class Library|**Yes**|
+|Console Application|**Yes**|
+|Windows Forms Control Library|**Yes**|
+|Web Control Library|No|
+|Windows Service|**Yes**|
+|Web Site|No|
+
+
 
 ## Examples
  This example uses the `My.Application.Info.Version` property to display the version of the application.
@@ -839,6 +841,7 @@
         </remarks>
         <exception cref="T:System.Security.SecurityException">The application does not have sufficient permissions to access the assembly version.</exception>
         <altmember cref="P:Microsoft.VisualBasic.ApplicationServices.ApplicationBase.Info" />
+        <altmember cref="P:System.Deployment.Application.ApplicationDeployment.CurrentVersion" />
         <altmember cref="T:System.Version" />
         <related type="Article" href="/dotnet/visual-basic/language-reference/objects/">Objects (Visual Basic)</related>
       </Docs>

--- a/xml/Microsoft.VisualBasic.ApplicationServices/AssemblyInfo.xml
+++ b/xml/Microsoft.VisualBasic.ApplicationServices/AssemblyInfo.xml
@@ -816,7 +816,7 @@
 ## Remarks
  The `My.Application.Info.Version` property gets a <xref:System.Version> object containing the version number of the application. You can use the <xref:System.Version.Major*>, <xref:System.Version.Minor*>, <xref:System.Version.Build*>, and <xref:System.Version.Revision*> properties of the <xref:System.Version> object to access specific version information about the application.
 
- ClickOnce-deployed applications should use the <xref:System.Deployment.Application.ApplicationDeployment.CurrentVersion> property of the <xref:Microsoft.VisualBasic.ApplicationServices.ConsoleApplicationBase.Deployment> property.
+ ClickOnce-deployed applications should use the <xref:System.Deployment.Application.ApplicationDeployment.CurrentVersion> property of the `My.Application.Deployment` object.
 
 ## Availability by Project Type
 

--- a/xml/Microsoft.VisualBasic.ApplicationServices/AssemblyInfo.xml
+++ b/xml/Microsoft.VisualBasic.ApplicationServices/AssemblyInfo.xml
@@ -830,8 +830,6 @@
 |Windows Service|**Yes**|
 |Web Site|No|
 
-
-
 ## Examples
  This example uses the `My.Application.Info.Version` property to display the version of the application.
 

--- a/xml/Microsoft.VisualBasic.ApplicationServices/ConsoleApplicationBase.xml
+++ b/xml/Microsoft.VisualBasic.ApplicationServices/ConsoleApplicationBase.xml
@@ -156,8 +156,6 @@
 |Windows Service|**Yes**|
 |Web Site|No|
 
-
-
 ## Examples
  This example uses the `My.Application.CommandLineArgs` property to examine the application's command-line arguments. If an argument is found that starts with `/input=`, the rest of that argument is displayed.
 

--- a/xml/Microsoft.VisualBasic.ApplicationServices/ConsoleApplicationBase.xml
+++ b/xml/Microsoft.VisualBasic.ApplicationServices/ConsoleApplicationBase.xml
@@ -136,25 +136,27 @@
 > The `My.Application.CommandLineArgs` property returns only the command-line arguments. This is different from the behavior of the <xref:System.Environment.CommandLine> property, which returns the application name in addition to the arguments.
 
 > [!NOTE]
-> In an application that's ClickOnce-deployed, use the `My.Application.Deployment.ActivationUri` property to get the command-line arguments. For more information, see <xref:Microsoft.VisualBasic.ApplicationServices.ConsoleApplicationBase.Deployment*>.
+> In an application that is ClickOnce deployed, use the <xref:System.Deployment.Application.ApplicationDeployment.ActivationUri> property of the `My.Application.Deployment` object to get the command-line arguments. For more information, see <xref:Microsoft.VisualBasic.ApplicationServices.ConsoleApplicationBase.Deployment*>.
 
  The following table lists examples of tasks involving the `My.Application.CommandLineArgs` property.
 
-| To | See |
-| - | - |
-| Check the command-line arguments of subsequent attempts to start a single-instance application | <xref:Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.StartupNextInstance> |
+|To|See|
+|-|-|
+|Check the command-line arguments of subsequent attempts to start a single-instance application|<xref:Microsoft.VisualBasic.ApplicationServices.WindowsFormsApplicationBase.StartupNextInstance>|
 
 ## Availability by Project Type
 
-| Project type            | Available |
-|-------------------------|-----------|
-| Windows Application     | **Yes**   |
-| Class Library           | No        |
-| Console Application     | **Yes**   |
-| Windows Control Library | No        |
-| Web Control Library     | No        |
-| Windows Service         | **Yes**   |
-| Web Site                | No        |
+|Project type|Available|
+|-|-|
+|Windows Application|**Yes**|
+|Class Library|No|
+|Console Application|**Yes**|
+|Windows Control Library|No|
+|Web Control Library|No|
+|Windows Service|**Yes**|
+|Web Site|No|
+
+
 
 ## Examples
  This example uses the `My.Application.CommandLineArgs` property to examine the application's command-line arguments. If an argument is found that starts with `/input=`, the rest of that argument is displayed.


### PR DESCRIPTION
Reverts dotnet/dotnet-api-docs#13041

These APIs were inadvertently removed from Learn when a filter was put in place. The filter has now been removed in https://github.com/dotnet/msbuild-api-docs/pull/70.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [xml/Microsoft.VisualBasic.ApplicationServices/AssemblyInfo.xml](https://github.com/dotnet/dotnet-api-docs/blob/5f6d777adca2f630e46e1717f2b52510ee82a98c/xml/Microsoft.VisualBasic.ApplicationServices/AssemblyInfo.xml) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/api/microsoft.visualbasic.applicationservices.assemblyinfo?view=windowsdesktop-11.0&branch=pr-en-us-13061) |
| [xml/Microsoft.VisualBasic.ApplicationServices/ConsoleApplicationBase.xml](https://github.com/dotnet/dotnet-api-docs/blob/5f6d777adca2f630e46e1717f2b52510ee82a98c/xml/Microsoft.VisualBasic.ApplicationServices/ConsoleApplicationBase.xml) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/api/microsoft.visualbasic.applicationservices.consoleapplicationbase?view=windowsdesktop-11.0&branch=pr-en-us-13061) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/500c749d-de78-3d4a-00e4-269d599bf9ec/202609092154550907-13061/BuildReport?accessString=673c8237df787af2c02db90b33540820a11047b3d91d4a4b9f21261985cb738d)